### PR TITLE
Expose render_page_pdfium in public API behind pdfium feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub use engine::{
 };
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};
 pub use observe::{CollectingObserver, EngineEvent, EngineObserver, MemoryTracker};
+#[cfg(feature = "pdfium")]
+pub use pdf::render_page_pdfium;
 pub use pdf::{PdfError, PdfInfo, PdfPageInfo, extract_page_image, pdf_info};
 pub use pixel::PixelFormat;
 pub use planner::{


### PR DESCRIPTION
Add conditional re-export of render_page_pdfium from the pdf module so downstream crates can use pdfium-based page rendering when the "pdfium" feature is enabled. This keeps the default build unaffected while making the function accessible without reaching into internal module paths.