### PR TITLE
Add pdfium-static feature and budgeted rendering API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
 [features]
 default = []
 pdfium = ["dep:pdfium-render"]
+pdfium-static = ["pdfium", "pdfium-render/static"]
 
 [dependencies]
 flate2 = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@ pub use engine::{
 };
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};
 pub use observe::{CollectingObserver, EngineEvent, EngineObserver, MemoryTracker};
-pub use pdf::{PdfError, PdfInfo, PdfPageInfo, extract_page_image, pdf_info};
 #[cfg(feature = "pdfium")]
-pub use pdf::{render_page_pdfium, render_page_pdfium_budgeted, BudgetRenderResult};
+pub use pdf::{BudgetRenderResult, render_page_pdfium, render_page_pdfium_budgeted};
+pub use pdf::{PdfError, PdfInfo, PdfPageInfo, extract_page_image, pdf_info};
 pub use pixel::PixelFormat;
 pub use planner::{
     Layout, LevelPlan, PlannerError, PyramidPlan, PyramidPlanner, TileCoord, TileRect,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@ pub use engine::{
 };
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};
 pub use observe::{CollectingObserver, EngineEvent, EngineObserver, MemoryTracker};
-#[cfg(feature = "pdfium")]
-pub use pdf::render_page_pdfium;
 pub use pdf::{PdfError, PdfInfo, PdfPageInfo, extract_page_image, pdf_info};
+#[cfg(feature = "pdfium")]
+pub use pdf::{render_page_pdfium, render_page_pdfium_budgeted, BudgetRenderResult};
 pub use pixel::PixelFormat;
 pub use planner::{
     Layout, LevelPlan, PlannerError, PyramidPlan, PyramidPlanner, TileCoord, TileRect,

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -480,36 +480,30 @@ fn obj_to_f64(obj: &lopdf::Object) -> Option<f64> {
 // Pdfium-based rendering (feature-gated)
 // ---------------------------------------------------------------------------
 
-/// Render a PDF page to a raster using PDFium.
-///
-/// This handles vector content (AutoCAD exports, text, paths) that cannot be
-/// extracted as embedded images. Requires the `pdfium` feature and a PDFium
-/// library available at runtime.
+/// Open a pdfium instance with the appropriate bindings.
 #[cfg(feature = "pdfium")]
-pub fn render_page_pdfium(path: &Path, page: usize, dpi: u32) -> Result<Raster, PdfError> {
+fn init_pdfium() -> Result<pdfium_render::prelude::Pdfium, PdfError> {
     use pdfium_render::prelude::*;
 
-    let pdfium = Pdfium::default();
-    let document = pdfium
-        .load_pdf_from_file(path, None)
+    #[cfg(feature = "pdfium-static")]
+    let bindings = Pdfium::bind_to_statically_linked_library()
+        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
+    #[cfg(not(feature = "pdfium-static"))]
+    let bindings = Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
+        .or_else(|_| Pdfium::bind_to_system_library())
         .map_err(|e| PdfError::Pdfium(e.to_string()))?;
 
-    let pages = document.pages();
-    let total = pages.len();
-    if page == 0 || page > total as usize {
-        return Err(PdfError::PageOutOfRange {
-            page,
-            total: total as usize,
-        });
-    }
+    Ok(Pdfium::new(bindings))
+}
 
-    let pdf_page = pages
-        .get(page as u16 - 1)
-        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
-
-    let scale = dpi as f32 / 72.0;
-    let width = (pdf_page.width().value * scale) as u32;
-    let height = (pdf_page.height().value * scale) as u32;
+/// Render a page at the given pixel dimensions and return a Raster.
+#[cfg(feature = "pdfium")]
+fn render_at_size(
+    pdf_page: &pdfium_render::prelude::PdfPage<'_>,
+    width: u32,
+    height: u32,
+) -> Result<Raster, PdfError> {
+    use pdfium_render::prelude::*;
 
     let config = PdfRenderConfig::new()
         .set_target_width(width as i32)
@@ -525,6 +519,110 @@ pub fn render_page_pdfium(path: &Path, page: usize, dpi: u32) -> Result<Raster, 
     let data = rgba.into_raw();
 
     Raster::new(w, h, PixelFormat::Rgba8, data).map_err(PdfError::from)
+}
+
+/// Render a PDF page to a raster using PDFium.
+///
+/// This handles vector content (AutoCAD exports, text, paths) that cannot be
+/// extracted as embedded images. Requires the `pdfium` feature and a PDFium
+/// library available at runtime.
+#[cfg(feature = "pdfium")]
+pub fn render_page_pdfium(path: &Path, page: usize, dpi: u32) -> Result<Raster, PdfError> {
+    let pdfium = init_pdfium()?;
+    let document = pdfium
+        .load_pdf_from_file(path, None)
+        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
+
+    let pages = document.pages();
+    let total = pages.len();
+    if page == 0 || page > total as usize {
+        return Err(PdfError::PageOutOfRange {
+            page,
+            total: total as usize,
+        });
+    }
+    let pdf_page = pages
+        .get(page as u16 - 1)
+        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
+
+    let scale = dpi as f32 / 72.0;
+    let width = (pdf_page.width().value * scale) as u32;
+    let height = (pdf_page.height().value * scale) as u32;
+
+    render_at_size(&pdf_page, width, height)
+}
+
+/// Result of a budget-constrained render, including the DPI that was used.
+#[cfg(feature = "pdfium")]
+#[derive(Debug)]
+pub struct BudgetRenderResult {
+    pub raster: Raster,
+    pub dpi_used: u32,
+    pub capped: bool,
+}
+
+/// Render a PDF page to a raster, capping the output size to a maximum pixel
+/// budget to prevent excessive memory use on large documents.
+///
+/// - `max_dpi`: the preferred DPI (e.g. 300). Used when the result fits within
+///   the budget.
+/// - `max_pixels`: maximum total pixel count (width * height). If rendering at
+///   `max_dpi` would exceed this, the DPI is automatically reduced so the
+///   output fits.
+///
+/// Returns the raster along with the actual DPI used and whether it was capped.
+#[cfg(feature = "pdfium")]
+pub fn render_page_pdfium_budgeted(
+    path: &Path,
+    page: usize,
+    max_dpi: u32,
+    max_pixels: u64,
+) -> Result<BudgetRenderResult, PdfError> {
+    let pdfium = init_pdfium()?;
+    let document = pdfium
+        .load_pdf_from_file(path, None)
+        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
+
+    let pages = document.pages();
+    let total = pages.len();
+    if page == 0 || page > total as usize {
+        return Err(PdfError::PageOutOfRange {
+            page,
+            total: total as usize,
+        });
+    }
+    let pdf_page = pages
+        .get(page as u16 - 1)
+        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
+
+    let width_pts = pdf_page.width().value as f64;
+    let height_pts = pdf_page.height().value as f64;
+
+    // Compute the DPI that fits within the pixel budget
+    let scale_at_max = max_dpi as f64 / 72.0;
+    let pixels_at_max =
+        (width_pts * scale_at_max) as u64 * (height_pts * scale_at_max) as u64;
+
+    let (dpi_used, capped) = if pixels_at_max <= max_pixels {
+        (max_dpi, false)
+    } else {
+        // scale = sqrt(max_pixels / (w_pts * h_pts)), then dpi = scale * 72
+        let scale = (max_pixels as f64 / (width_pts * height_pts)).sqrt();
+        let dpi = (scale * 72.0).floor() as u32;
+        (dpi.max(1), true)
+    };
+
+    let scale = dpi_used as f32 / 72.0;
+    let width = (width_pts as f32 * scale) as u32;
+    let height = (height_pts as f32 * scale) as u32;
+
+    let raster = render_at_size(&pdf_page, width, height)?;
+
+    Ok(BudgetRenderResult {
+        raster,
+        dpi_used,
+        capped,
+    })
 }
 
 #[cfg(test)]

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -486,8 +486,8 @@ fn init_pdfium() -> Result<pdfium_render::prelude::Pdfium, PdfError> {
     use pdfium_render::prelude::*;
 
     #[cfg(feature = "pdfium-static")]
-    let bindings = Pdfium::bind_to_statically_linked_library()
-        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
+    let bindings =
+        Pdfium::bind_to_statically_linked_library().map_err(|e| PdfError::Pdfium(e.to_string()))?;
     #[cfg(not(feature = "pdfium-static"))]
     let bindings = Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
         .or_else(|_| Pdfium::bind_to_system_library())
@@ -600,8 +600,7 @@ pub fn render_page_pdfium_budgeted(
 
     // Compute the DPI that fits within the pixel budget
     let scale_at_max = max_dpi as f64 / 72.0;
-    let pixels_at_max =
-        (width_pts * scale_at_max) as u64 * (height_pts * scale_at_max) as u64;
+    let pixels_at_max = (width_pts * scale_at_max) as u64 * (height_pts * scale_at_max) as u64;
 
     let (dpi_used, capped) = if pixels_at_max <= max_pixels {
         (max_dpi, false)


### PR DESCRIPTION
## Summary

This PR adds two features to libviprs: static PDFium linking support and a memory-safe budgeted rendering API. It also refactors the pdfium internals to reduce duplication.

## Changes

### Added: `pdfium-static` feature flag (`Cargo.toml`)
Enables static linking of PDFium via pdfium-render's `static` feature. This allows building a single binary with no runtime dependency on `libpdfium.so`, which simplifies deployment in containerized environments where installing shared libraries adds image size and complexity.

### Added: `render_page_pdfium_budgeted()` (`src/pdf.rs`)
A new public function that renders a PDF page to a raster while enforcing a maximum pixel budget (width × height). Construction/architecture PDFs can be extremely large — rendering a 19866×14041 page at 300 DPI produces ~1 GB of pixel data, which causes OOM kills in memory-constrained containers. This function accepts a `max_pixels` budget and automatically reduces DPI when the full-resolution output would exceed it. Returns `BudgetRenderResult` containing the raster, the actual DPI used, and whether the DPI was capped, so callers can log the degradation.

### Added: `BudgetRenderResult` struct (`src/pdf.rs`)
Return type for the budgeted render function. Exposes `raster`, `dpi_used`, and `capped` so the caller knows exactly what happened during rendering — needed by the tiling server to log DPI reductions and store accurate raster dimensions in tile metadata.

### Changed: Refactored pdfium internals into `init_pdfium()` and `render_at_size()` helpers (`src/pdf.rs`)
`render_page_pdfium` and `render_page_pdfium_budgeted` share the same PDFium initialization and bitmap-to-raster conversion logic. Extracting `init_pdfium()` (handles dynamic vs static binding) and `render_at_size()` (config → bitmap → raster) eliminates duplication and ensures both code paths use the same binding strategy — particularly important now that `pdfium-static` selects a different binding method at compile time.

### Changed: Re-export ordering in `src/lib.rs`
Moved the `#[cfg(feature = "pdfium")]` gated re-exports and added `BudgetRenderResult` and `render_page_pdfium_budgeted` to the public API. Reordered to satisfy `rustfmt` — the `#[cfg]` attribute must attach to the line immediately below it, and imports within a `use` statement must be alphabetically sorted.

### Fixed: `rustfmt` violations (`src/lib.rs`, `src/pdf.rs`)
Corrected three formatting issues caught by CI: re-export ordering, a line-wrap on `bind_to_statically_linked_library()`, and an unnecessary line-wrap on the `pixels_at_max` computation.