### PR TITLE
feat(engine): add configurable background color for edge tile padding

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -27,6 +27,9 @@ pub struct EngineConfig {
     pub concurrency: usize,
     /// Maximum tiles buffered between producer and sink. Controls backpressure.
     pub buffer_size: usize,
+    /// Background color (RGB) used to pad edge tiles to the full tile size.
+    /// Defaults to white (255, 255, 255).
+    pub background_rgb: [u8; 3],
 }
 
 impl Default for EngineConfig {
@@ -34,6 +37,7 @@ impl Default for EngineConfig {
         Self {
             concurrency: 0,
             buffer_size: 64,
+            background_rgb: [255, 255, 255],
         }
     }
 }
@@ -158,7 +162,7 @@ fn extract_and_emit_level(
         for row in 0..level_plan.rows {
             for col in 0..level_plan.cols {
                 let coord = TileCoord::new(level, col, row);
-                let tile_raster = extract_tile(raster, plan, coord)?;
+                let tile_raster = extract_tile(raster, plan, coord, config.background_rgb)?;
                 sink.write_tile(&Tile {
                     coord,
                     raster: tile_raster,
@@ -212,10 +216,11 @@ fn extract_and_emit_parallel(
             let raster = Arc::clone(&raster);
             let plan = Arc::clone(&plan);
             let chunk = chunk.to_vec();
+            let bg = config.background_rgb;
 
             s.spawn(move || {
                 for coord in chunk {
-                    let result = extract_tile(&raster, &plan, coord)
+                    let result = extract_tile(&raster, &plan, coord, bg)
                         .map(|tile_raster| Tile {
                             coord,
                             raster: tile_raster,
@@ -248,12 +253,47 @@ fn extract_tile(
     raster: &Raster,
     plan: &PyramidPlan,
     coord: TileCoord,
+    background_rgb: [u8; 3],
 ) -> Result<Raster, RasterError> {
     let rect = plan
         .tile_rect(coord)
         .expect("tile_rect returned None for valid coord");
 
-    raster.extract(rect.x, rect.y, rect.width, rect.height)
+    let content = raster.extract(rect.x, rect.y, rect.width, rect.height)?;
+    let ts = plan.tile_size;
+
+    // Pad edge tiles to the full tile size with the background color.
+    // Only pad when there's no overlap — overlap tiles have intentionally
+    // different sizes and must not be resized.
+    if plan.overlap == 0 && (content.width() < ts || content.height() < ts) {
+        let bpp = content.format().bytes_per_pixel();
+        let mut padded = vec![0u8; ts as usize * ts as usize * bpp];
+
+        // Fill with background color (repeat the RGB pattern for each pixel)
+        let bg_pixel: Vec<u8> = match bpp {
+            1 => vec![background_rgb[0]],
+            3 => background_rgb.to_vec(),
+            4 => vec![background_rgb[0], background_rgb[1], background_rgb[2], 255],
+            _ => vec![background_rgb[0]; bpp],
+        };
+        for pixel in padded.chunks_exact_mut(bpp) {
+            pixel.copy_from_slice(&bg_pixel);
+        }
+
+        // Copy content rows into the padded buffer
+        let src_stride = content.width() as usize * bpp;
+        let dst_stride = ts as usize * bpp;
+        for row in 0..content.height() as usize {
+            let src_start = row * src_stride;
+            let dst_start = row * dst_stride;
+            padded[dst_start..dst_start + src_stride]
+                .copy_from_slice(&content.data()[src_start..src_start + src_stride]);
+        }
+
+        Raster::new(ts, ts, content.format(), padded)
+    } else {
+        Ok(content)
+    }
 }
 
 /// Check if a tile is "blank" — all pixels are identical.
@@ -379,9 +419,12 @@ mod tests {
 
         for tile in sink.tiles() {
             let rect = plan.tile_rect(tile.coord).unwrap();
-            assert_eq!(tile.width, rect.width, "Width mismatch at {:?}", tile.coord);
+            // Edge tiles are padded to the full tile size when overlap=0
+            let expected_w = if rect.width < 256 { 256 } else { rect.width };
+            let expected_h = if rect.height < 256 { 256 } else { rect.height };
+            assert_eq!(tile.width, expected_w, "Width mismatch at {:?}", tile.coord);
             assert_eq!(
-                tile.height, rect.height,
+                tile.height, expected_h,
                 "Height mismatch at {:?}",
                 tile.coord
             );


### PR DESCRIPTION
Edge tiles at the raster boundary are clipped to the image dimensions by tile_rect(), producing tiles smaller than tile_size x tile_size. When a map renderer like MapLibre receives a sub-sized PNG, it stretches it to fill the tile cell, creating visible white strips along the right and bottom edges of the rendered image.

This was a problem for PDF blueprint viewing where the rasterized page rarely aligns perfectly to the 256px tile grid. For example, an 11853x8378 raster produces 47x33 tiles, but the last column is only 179px wide and the last row is only 70px tall. MapLibre stretched these into full 256x256 cells, leaving large white borders around the PDF content that looked like a misaligned square frame.

The fix pads edge tiles to the full tile_size with a configurable background color (EngineConfig.background_rgb), defaulting to white (255,255,255) for backwards compatibility. Consumers can set this to match their map background color (e.g. 231,231,231 for a light grey) so tile boundaries are visually seamless.

Implementation details:

- extract_tile() detects when the extracted content is smaller than tile_size in either dimension
- Allocates a full tile_size x tile_size buffer pre-filled with the background color
- Copies the content rows into the top-left of the padded buffer
- Returns the padded raster instead of the clipped one
- Handles all pixel formats: Gray8 (1 bpp), Rgb8 (3 bpp), Rgba8 (4 bpp, alpha set to 255)
- Only pads when overlap=0 to avoid interfering with Deep Zoom Image overlap tiles, which are intentionally non-square

Alternatives considered:

- Pad in the sink (FsSink) instead of the engine: rejected because the sink receives a Raster and shouldn't need to know about tile geometry. The engine owns the extraction logic and is the right place to ensure tiles are correctly sized.

- Let the frontend handle sub-sized tiles: rejected because MapLibre has no built-in support for sub-sized raster tiles and the stretching behavior is not configurable.

- Always generate power-of-2 aligned rasters: rejected because it would require upscaling the source image and wasting memory/disk, and the alignment depends on tile_size which is a pyramid parameter, not a rasterization parameter.