### PR TITLE
docs(readme): update README to reflect recent API additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Takes blueprint PDFs and images, extracts raster data, optionally geo-references
 ## Features
 
 - **PDF extraction** — extract embedded raster images from scanned blueprint PDFs via lopdf (zero runtime dependencies)
-- **PDF rendering** — render vector PDFs (AutoCAD exports, text, paths) via PDFium (optional `pdfium` feature)
+- **PDF rendering** — render vector PDFs (AutoCAD exports, text, paths) via PDFium, with optional memory-budgeted rendering (optional `pdfium` feature)
 - **Image decoding** — JPEG, PNG, TIFF via the `image` crate
 - **Tile pyramid generation** — multi-threaded engine with backpressure, configurable tile size and overlap
 - **Layout formats** — DeepZoom (`.dzi` + directory tree) and XYZ (`z/x/y`)
 - **Tile encoding** — PNG, JPEG (configurable quality), or raw pixel output
+- **Blank tile optimization** — configurable `BlankTileStrategy` to either emit full tiles or write 1-byte placeholders (`BLANK_TILE_MARKER`) for uniform-color regions, reducing disk usage for sparse images
+- **Edge tile background** — configurable background color (`background_rgb`) for padding partial tiles at image edges (defaults to white)
 - **Geo-referencing** — affine transform mapping pixel coordinates to geographic coordinates, GCP support
 - **Observability** — progress events, per-level callbacks, peak memory tracking
 
@@ -19,8 +21,8 @@ Takes blueprint PDFs and images, extracts raster data, optionally geo-references
 
 ```rust
 use libviprs::{
-    extract_page_image, generate_pyramid, EngineConfig, FsSink,
-    Layout, PyramidPlanner, TileFormat,
+    extract_page_image, generate_pyramid, BlankTileStrategy,
+    EngineConfig, FsSink, Layout, PyramidPlanner, TileFormat,
 };
 use std::path::Path;
 
@@ -38,10 +40,15 @@ let plan = planner.plan();
 
 // Generate tiles to disk
 let sink = FsSink::new("output_tiles", plan.clone(), TileFormat::Png);
-let config = EngineConfig::default().with_concurrency(4);
+let config = EngineConfig::default()
+    .with_concurrency(4)
+    .with_blank_tile_strategy(BlankTileStrategy::Placeholder);
 let result = generate_pyramid(&raster, &plan, &sink, &config).unwrap();
 
-println!("{} tiles across {} levels", result.tiles_produced, result.levels_processed);
+println!(
+    "{} tiles across {} levels ({} blank tiles skipped)",
+    result.tiles_produced, result.levels_processed, result.tiles_skipped,
+);
 ```
 
 ## Modules
@@ -49,12 +56,12 @@ println!("{} tiles across {} levels", result.tiles_produced, result.levels_proce
 | Module | Description |
 |---|---|
 | `source` | Image decoding (JPEG, PNG, TIFF) into canonical `Raster` |
-| `pdf` | PDF parsing (lopdf) and optional rendering (PDFium) |
+| `pdf` | PDF parsing (lopdf) and optional rendering (PDFium), including budgeted render |
 | `raster` | Pixel buffer, region views, format normalization |
 | `pixel` | Pixel format definitions (Gray8, RGB8, RGBA8, 16-bit variants) |
 | `planner` | Tile math, level computation, layout generation |
 | `resize` | Downscaling for pyramid levels |
-| `engine` | Multi-threaded tile extraction with backpressure |
+| `engine` | Multi-threaded tile extraction with backpressure, blank tile detection |
 | `sink` | Tile output (filesystem, memory, slow sink for testing) |
 | `geo` | Affine geo-transform, GCP solving, bounding box computation |
 | `observe` | Progress events, memory tracking |
@@ -63,7 +70,7 @@ println!("{} tiles across {} levels", result.tiles_produced, result.levels_proce
 
 | Feature | Default | Description |
 |---|---|---|
-| `pdfium` | off | Enables `render_page_pdfium()` for vector PDF rendering. Requires libpdfium at runtime. |
+| `pdfium` | off | Enables `render_page_pdfium()` and `render_page_pdfium_budgeted()` for vector PDF rendering. Requires libpdfium at runtime. |
 
 ## Requirements
 
@@ -75,7 +82,7 @@ println!("{} tiles across {} levels", result.tiles_produced, result.levels_proce
 | Crate | Description |
 |---|---|
 | [libviprs-cli](../libviprs-cli) | Command-line interface (`viprs` binary) |
-| [libviprs-tests](../libviprs-tests) | Integration tests, fixtures, and system checks |
+| [libviprs-tests](../libviprs-tests) | Integration tests and fixtures, including end-to-end PDF-to-pyramid tests for `blueprint.pdf` and `blueprint-mix.pdf` |
 
 ## CI
 


### PR DESCRIPTION
Document BlankTileStrategy and BLANK_TILE_MARKER for configurable blank tile handling, edge tile background color padding, and memory-budgeted PDFium rendering. Update the usage example to demonstrate blank tile placeholder mode with tiles_skipped output. Revise module table entries for engine (blank tile detection) and pdf (budgeted render). Update pdfium feature flag description to include render_page_pdfium_budgeted. Note blueprint-mix.pdf integration test coverage in the related crates table.