### PR TITLE
feat: add run-tests.sh delegating to libviprs-tests Docker test runner

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Delegates to libviprs-tests/run-tests.sh — can be invoked from this repo.
+# Delegates to libviprs-tests/tools/run-tests.sh — can be invoked from this repo.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-exec "$SCRIPT_DIR/../libviprs-tests/run-tests.sh" "$@"
+exec "$SCRIPT_DIR/../libviprs-tests/tools/run-tests.sh" "$@"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Delegates to libviprs-tests/run-tests.sh — can be invoked from this repo.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../libviprs-tests/run-tests.sh" "$@"


### PR DESCRIPTION
Thin wrapper that delegates to ../libviprs-tests/run-tests.sh, allowing tests to be invoked from this repo. Runs both libviprs unit tests and libviprs-tests integration tests in Docker with PDFium installed, supporting amd64 and arm64 architectures.