### PR TITLE
Add centered logo and CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# libviprs
+<p align="center">
+  <img src="images/libviprs-logo-claws.svg" alt="libviprs" width="200">
+</p>
+
+<h1 align="center">libviprs</h1>
+
+<p align="center">
+  <a href="https://github.com/libviprs/libviprs/actions/workflows/ci.yml"><img src="https://github.com/libviprs/libviprs/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/libviprs/libviprs/actions/workflows/merge-gate.yml"><img src="https://github.com/libviprs/libviprs/actions/workflows/merge-gate.yml/badge.svg" alt="Merge Gate"></a>
+  <img src="https://img.shields.io/badge/rust-1.85%2B-orange?logo=rust" alt="Rust 1.85+">
+  <img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License">
+</p>
 
 A pure-Rust, thread-safe image pyramiding engine. Inspired by [libvips](https://www.libvips.org/), built from scratch for the AEC/construction domain.
 


### PR DESCRIPTION
## Summary

- Add SVG logo centered at the top of the README
- Add status badges for CI, Merge Gate, Rust version, and license

## Test plan

- [x] Verify logo renders correctly on GitHub
- [x] Verify badge links resolve to correct workflow pages