### PR TITLE
fix(tests): disable proptest file persistence for Miri compatibility

### DIFF
--- a/src/planner.rs
+++ b/src/planner.rs
@@ -859,6 +859,10 @@ mod proptests {
     use proptest::prelude::*;
 
     proptest! {
+        #![proptest_config(ProptestConfig {
+            failure_persistence: None,
+            .. ProptestConfig::default()
+        })]
         // Property test: tiles with no overlap cover every pixel at every level exactly once.
         // Works by checking that the bounding box of all tile rects spans (0,0) to (width,height)
         // and the total tile area equals the level's pixel area (no gaps or overlaps).

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -454,6 +454,10 @@ mod proptests {
     use proptest::prelude::*;
 
     proptest! {
+        #![proptest_config(ProptestConfig {
+            failure_persistence: None,
+            .. ProptestConfig::default()
+        })]
         // Tests that buffer size always equals w*h*bpp for all formats and dimensions.
         // Works by generating random dimensions and checking the invariant across
         // all 6 PixelFormat variants.


### PR DESCRIPTION
## Summary

- Disable proptest's `FileFailurePersistence` in `planner::proptests` and `raster::proptests` by setting `failure_persistence: None` in the proptest config
- Fixes Miri test failures caused by proptest calling `getcwd`, which Miri blocks under isolation mode
- Matches the existing pattern already used in `geo::proptests`

## Context

Miri CI was failing with:
```
error: unsupported operation: `getcwd` not available when isolation is enabled
```

The root cause is proptest's file-based failure persistence, which calls `std::env::current_dir()` to resolve persisted failure file paths. The `geo` module already had the fix; `planner` and `raster` were missed.

## Test plan

- [ ] `cargo test` — all 124 unit tests pass
- [ ] `cargo +nightly miri test` — no `getcwd` errors