### PR TITLE
Add crates.io metadata and PDFium setup docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 edition = "2024"
 authors = ["Roman Goldmann <roman@devshell.org>"]
 rust-version = "1.85"
+description = "A pure-Rust, thread-safe image pyramiding engine for blueprint PDFs and raster images"
+license = "MIT"
+repository = "https://github.com/libviprs/libviprs"
+homepage = "https://libviprs.org"
+keywords = ["image", "pyramid", "tiles", "deepzoom", "pdf"]
+categories = ["multimedia::images", "graphics"]
+readme = "README.md"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/README.md
+++ b/README.md
@@ -88,6 +88,27 @@ println!(
 - Rust 1.85+ (edition 2024)
 - libpdfium shared library (only if using the `pdfium` feature)
 
+### PDFium setup
+
+The `pdfium` feature requires `libpdfium.so` at runtime. Pre-compiled binaries built from source are available from [libviprs-dep](https://github.com/libviprs/libviprs-dep/releases):
+
+```bash
+# x86_64
+curl -L -o pdfium.tgz \
+  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-x64.tgz
+
+# arm64
+curl -L -o pdfium.tgz \
+  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-arm64.tgz
+
+# Extract and install
+tar xzf pdfium.tgz
+sudo cp pdfium-linux-*/lib/libpdfium.so /usr/local/lib/
+sudo ldconfig
+```
+
+See the [libviprs-dep pdfium README](https://github.com/libviprs/libviprs-dep/tree/main/pdfium) for building PDFium from source or finding other versions.
+
 ## Related Crates
 
 | Crate | Description |


### PR DESCRIPTION
## Summary
- Add required crates.io package metadata (description, license, repository, homepage, keywords, categories)
- Add PDFium setup section to README with download instructions from libviprs-dep releases

## Test plan
- [x] `cargo publish --dry-run --allow-dirty` succeeds
- [x] PDFium download URLs in README resolve correctly