### PR TITLE
feat: add Google Maps tile layout and centre support

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -245,7 +245,17 @@ pub fn generate_pyramid_observed(
     })
 }
 
-/// Extract all tiles for a single level and send them to the sink.
+/// Extracts every tile for one pyramid level and writes them to the sink.
+///
+/// Dispatches to either the single-threaded loop or the parallel worker pool
+/// depending on [`EngineConfig::concurrency`]. In single-threaded mode, tiles
+/// are extracted and emitted in row-major order on the calling thread. In
+/// parallel mode, the work is delegated to [`extract_and_emit_parallel`].
+///
+/// Each tile is optionally checked for blankness when
+/// [`BlankTileStrategy::Placeholder`] is active, and the observer is notified
+/// after every tile is written.
+///
 /// Returns `(tiles_produced, tiles_skipped)`.
 fn extract_and_emit_level(
     raster: &Raster,
@@ -285,7 +295,19 @@ fn extract_and_emit_level(
     }
 }
 
-/// Parallel tile extraction using a bounded channel for backpressure.
+/// Extracts tiles for one level in parallel using scoped worker threads.
+///
+/// Tile coordinates are divided into roughly equal chunks (one per worker).
+/// Each worker extracts its tiles and sends them through a bounded
+/// `sync_channel`, which provides backpressure — producers block when the
+/// channel is full, preventing unbounded memory growth. A single consumer
+/// on the calling thread drains the channel, writes tiles to the sink, and
+/// notifies the observer.
+///
+/// The bounded channel capacity is set by [`EngineConfig::buffer_size`].
+/// Worker count is capped at `min(concurrency, tile_count)` to avoid
+/// spawning idle threads.
+///
 /// Returns `(tiles_produced, tiles_skipped)`.
 fn extract_and_emit_parallel(
     raster: &Raster,
@@ -367,7 +389,45 @@ fn extract_and_emit_parallel(
     })
 }
 
-/// Extract a single tile from a level raster.
+/// Allocates a `tile_size × tile_size` pixel buffer filled with the
+/// background color.
+///
+/// Used to pad edge tiles and to produce solid-background tiles for
+/// canvas regions that lie outside the source image (e.g. Google layout
+/// with centre). The background RGB triplet is expanded to match the
+/// pixel format's bytes-per-pixel: grayscale uses the red channel,
+/// RGB copies all three, RGBA appends alpha=255, and other formats
+/// repeat the red channel.
+fn make_background_tile(ts: u32, bpp: usize, background_rgb: [u8; 3]) -> Vec<u8> {
+    let mut padded = vec![0u8; ts as usize * ts as usize * bpp];
+    let bg_pixel: Vec<u8> = match bpp {
+        1 => vec![background_rgb[0]],
+        3 => background_rgb.to_vec(),
+        4 => vec![background_rgb[0], background_rgb[1], background_rgb[2], 255],
+        _ => vec![background_rgb[0]; bpp],
+    };
+    for pixel in padded.chunks_exact_mut(bpp) {
+        pixel.copy_from_slice(&bg_pixel);
+    }
+    padded
+}
+
+/// Extracts a single tile's pixel data from the level raster.
+///
+/// For standard DeepZoom/Xyz layouts without centre, the tile rect maps
+/// directly to image coordinates — the region is extracted and edge tiles
+/// are padded to `tile_size` with the background color (only when
+/// `overlap == 0`; overlap tiles keep their natural smaller size).
+///
+/// For Google layout or any plan with `centre == true`, tiles are
+/// addressed in *canvas* space (which may be larger than the image).
+/// The function computes the intersection of the canvas-space tile rect
+/// with the image region (offset by the centre offset), then:
+/// - If the tile is entirely outside the image → returns a solid
+///   background tile.
+/// - If partially overlapping → creates a background tile and blits the
+///   intersecting image region at the correct offset.
+/// - If fully within the image → extracts directly (fast path).
 fn extract_tile(
     raster: &Raster,
     plan: &PyramidPlan,
@@ -378,26 +438,92 @@ fn extract_tile(
         .tile_rect(coord)
         .expect("tile_rect returned None for valid coord");
 
-    let content = raster.extract(rect.x, rect.y, rect.width, rect.height)?;
     let ts = plan.tile_size;
+    let bpp = raster.format().bytes_per_pixel();
+
+    // For Google layout or plans with centre, tiles reference canvas space.
+    // We need to map from canvas coords to image coords.
+    if plan.layout == crate::planner::Layout::Google || plan.centre {
+        let (off_x, off_y) = plan.centre_offset_at_level(coord.level);
+        let img_w = raster.width();
+        let img_h = raster.height();
+
+        // Canvas-space tile rect
+        let tile_x = rect.x;
+        let tile_y = rect.y;
+        let tile_w = rect.width;
+        let tile_h = rect.height;
+
+        // Image region in canvas space
+        let img_left = off_x;
+        let img_top = off_y;
+        let img_right = off_x + img_w;
+        let img_bottom = off_y + img_h;
+
+        // Intersection of tile rect with image region
+        let inter_left = tile_x.max(img_left);
+        let inter_top = tile_y.max(img_top);
+        let inter_right = (tile_x + tile_w).min(img_right);
+        let inter_bottom = (tile_y + tile_h).min(img_bottom);
+
+        if inter_left >= inter_right || inter_top >= inter_bottom {
+            // Tile is entirely outside the image — solid background
+            let padded = make_background_tile(ts, bpp, background_rgb);
+            return Raster::new(ts, ts, raster.format(), padded);
+        }
+
+        let inter_w = inter_right - inter_left;
+        let inter_h = inter_bottom - inter_top;
+
+        // Source coords in image space
+        let src_x = inter_left - off_x;
+        let src_y = inter_top - off_y;
+
+        // Destination offset within the tile
+        let dst_x = inter_left - tile_x;
+        let dst_y = inter_top - tile_y;
+
+        if dst_x == 0 && dst_y == 0 && inter_w == tile_w && inter_h == tile_h {
+            // Fast path: tile entirely within image
+            let content = raster.extract(src_x, src_y, inter_w, inter_h)?;
+            if content.width() == ts && content.height() == ts {
+                return Ok(content);
+            }
+            // Shouldn't happen for Google, but handle gracefully
+            let mut padded = make_background_tile(ts, bpp, background_rgb);
+            let src_stride = content.width() as usize * bpp;
+            let dst_stride = ts as usize * bpp;
+            for row in 0..content.height() as usize {
+                let src_start = row * src_stride;
+                let dst_start = row * dst_stride;
+                padded[dst_start..dst_start + src_stride]
+                    .copy_from_slice(&content.data()[src_start..src_start + src_stride]);
+            }
+            return Raster::new(ts, ts, raster.format(), padded);
+        }
+
+        // Partial overlap: create background tile and blit the intersection
+        let content = raster.extract(src_x, src_y, inter_w, inter_h)?;
+        let mut padded = make_background_tile(ts, bpp, background_rgb);
+        let src_stride = content.width() as usize * bpp;
+        let dst_stride = ts as usize * bpp;
+        for row in 0..inter_h as usize {
+            let src_start = row * src_stride;
+            let dst_start = (row + dst_y as usize) * dst_stride + dst_x as usize * bpp;
+            padded[dst_start..dst_start + src_stride]
+                .copy_from_slice(&content.data()[src_start..src_start + src_stride]);
+        }
+        return Raster::new(ts, ts, raster.format(), padded);
+    }
+
+    // Standard DeepZoom/Xyz path
+    let content = raster.extract(rect.x, rect.y, rect.width, rect.height)?;
 
     // Pad edge tiles to the full tile size with the background color.
     // Only pad when there's no overlap — overlap tiles have intentionally
     // different sizes and must not be resized.
     if plan.overlap == 0 && (content.width() < ts || content.height() < ts) {
-        let bpp = content.format().bytes_per_pixel();
-        let mut padded = vec![0u8; ts as usize * ts as usize * bpp];
-
-        // Fill with background color (repeat the RGB pattern for each pixel)
-        let bg_pixel: Vec<u8> = match bpp {
-            1 => vec![background_rgb[0]],
-            3 => background_rgb.to_vec(),
-            4 => vec![background_rgb[0], background_rgb[1], background_rgb[2], 255],
-            _ => vec![background_rgb[0]; bpp],
-        };
-        for pixel in padded.chunks_exact_mut(bpp) {
-            pixel.copy_from_slice(&bg_pixel);
-        }
+        let mut padded = make_background_tile(ts, bpp, background_rgb);
 
         // Copy content rows into the padded buffer
         let src_stride = content.width() as usize * bpp;
@@ -912,5 +1038,117 @@ mod tests {
             "Peak {} >= 2x source {source_bytes}",
             result.peak_memory_bytes
         );
+    }
+
+    // -- Google layout + centre tests --
+
+    #[test]
+    fn google_centre_produces_all_tiles() {
+        let src = gradient_raster(500, 300);
+        let planner = PyramidPlanner::new(500, 300, 256, 0, Layout::Google)
+            .unwrap()
+            .with_centre(true);
+        let plan = planner.plan();
+        let sink = MemorySink::new();
+        let config = EngineConfig::default();
+
+        let result = generate_pyramid(&src, &plan, &sink, &config).unwrap();
+        assert_eq!(result.tiles_produced, plan.total_tile_count());
+        assert_eq!(sink.tile_count() as u64, plan.total_tile_count());
+    }
+
+    #[test]
+    fn google_centre_all_tiles_full_size() {
+        let src = gradient_raster(500, 300);
+        let planner = PyramidPlanner::new(500, 300, 256, 0, Layout::Google)
+            .unwrap()
+            .with_centre(true);
+        let plan = planner.plan();
+        let sink = MemorySink::new();
+
+        generate_pyramid(&src, &plan, &sink, &EngineConfig::default()).unwrap();
+
+        for tile in sink.tiles() {
+            assert_eq!(tile.width, 256, "Width mismatch at {:?}", tile.coord);
+            assert_eq!(tile.height, 256, "Height mismatch at {:?}", tile.coord);
+        }
+    }
+
+    #[test]
+    fn google_centre_edge_tiles_have_background() {
+        // Small image centred in 256x256 canvas → single tile with background padding
+        let src = solid_raster(10, 10, 200);
+        let planner = PyramidPlanner::new(10, 10, 256, 0, Layout::Google)
+            .unwrap()
+            .with_centre(true);
+        let plan = planner.plan();
+        let sink = MemorySink::new();
+
+        generate_pyramid(&src, &plan, &sink, &EngineConfig::default()).unwrap();
+
+        // Level 0 should have 1 tile (1x1 grid)
+        let tiles = sink.tiles();
+        let level0: Vec<_> = tiles.iter().filter(|t| t.coord.level == 0).collect();
+        assert_eq!(level0.len(), 1);
+        let tile = &level0[0];
+        assert_eq!(tile.width, 256);
+        assert_eq!(tile.height, 256);
+        // Tile should NOT be entirely the source color (200,200,200) since background is white
+        assert!(
+            !is_blank_tile(
+                &Raster::new(
+                    tile.width,
+                    tile.height,
+                    PixelFormat::Rgb8,
+                    tile.data.clone()
+                )
+                .unwrap()
+            ) || tile.data.chunks(3).all(|px| px == [255, 255, 255])
+        );
+    }
+
+    #[test]
+    fn google_centre_deterministic_across_concurrency() {
+        let src = gradient_raster(400, 300);
+        let planner = PyramidPlanner::new(400, 300, 128, 0, Layout::Google)
+            .unwrap()
+            .with_centre(true);
+        let plan = planner.plan();
+
+        let ref_sink = MemorySink::new();
+        generate_pyramid(&src, &plan, &ref_sink, &EngineConfig::default()).unwrap();
+
+        let mut ref_tiles = ref_sink.tiles();
+        ref_tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
+
+        for concurrency in [1, 2, 4] {
+            let sink = MemorySink::new();
+            let config = EngineConfig::default().with_concurrency(concurrency);
+            generate_pyramid(&src, &plan, &sink, &config).unwrap();
+
+            let mut tiles = sink.tiles();
+            tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
+
+            assert_eq!(tiles.len(), ref_tiles.len());
+            for (ref_t, t) in ref_tiles.iter().zip(tiles.iter()) {
+                assert_eq!(ref_t.coord, t.coord);
+                assert_eq!(
+                    ref_t.data, t.data,
+                    "Tile {:?} diverged at concurrency={concurrency}",
+                    t.coord
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn google_no_centre_produces_all_tiles() {
+        let src = gradient_raster(500, 300);
+        let planner = PyramidPlanner::new(500, 300, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        let sink = MemorySink::new();
+
+        let result = generate_pyramid(&src, &plan, &sink, &EngineConfig::default()).unwrap();
+        assert_eq!(result.tiles_produced, plan.total_tile_count());
     }
 }

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -44,6 +44,9 @@ pub enum Layout {
     DeepZoom,
     /// XYZ / slippy map -- `{z}/{x}/{y}.{ext}`.
     Xyz,
+    /// Google Maps -- power-of-2 tile grids, `{z}/{x}/{y}.{ext}`.
+    /// z=0 is the most zoomed-out level (single tile). No manifest.
+    Google,
 }
 
 /// Configuration builder for pyramid tile generation.
@@ -66,6 +69,7 @@ pub struct PyramidPlanner {
     tile_size: u32,
     overlap: u32,
     layout: Layout,
+    centre: bool,
 }
 
 /// A complete, immutable pyramid plan ready for execution.
@@ -91,6 +95,16 @@ pub struct PyramidPlan {
     pub overlap: u32,
     pub layout: Layout,
     pub levels: Vec<LevelPlan>,
+    /// Padded canvas width at full resolution.
+    pub canvas_width: u32,
+    /// Padded canvas height at full resolution.
+    pub canvas_height: u32,
+    /// Whether the image is centred within the tile grid.
+    pub centre: bool,
+    /// Horizontal centre offset at full resolution (pixels).
+    pub centre_offset_x: u32,
+    /// Vertical centre offset at full resolution (pixels).
+    pub centre_offset_y: u32,
 }
 
 /// Plan for a single pyramid level.
@@ -184,7 +198,14 @@ impl PyramidPlanner {
             tile_size,
             overlap,
             layout,
+            centre: false,
         })
+    }
+
+    /// Enable or disable centring the image within the tile grid.
+    pub fn with_centre(mut self, centre: bool) -> Self {
+        self.centre = centre;
+        self
     }
 
     /// Compute the full pyramid plan.
@@ -199,7 +220,23 @@ impl PyramidPlanner {
     /// * [CLI plan command](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
     /// * [pdf_to_pyramid tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_to_pyramid.rs)
     pub fn plan(&self) -> PyramidPlan {
+        if self.layout == Layout::Google {
+            return self.plan_google();
+        }
+
         let levels = self.compute_levels();
+
+        let (canvas_width, canvas_height, offset_x, offset_y) = if self.centre {
+            let top = levels.last().unwrap();
+            let grid_w = top.cols * self.tile_size;
+            let grid_h = top.rows * self.tile_size;
+            let ox = (grid_w - self.image_width) / 2;
+            let oy = (grid_h - self.image_height) / 2;
+            (grid_w, grid_h, ox, oy)
+        } else {
+            (self.image_width, self.image_height, 0, 0)
+        };
+
         PyramidPlan {
             image_width: self.image_width,
             image_height: self.image_height,
@@ -207,6 +244,77 @@ impl PyramidPlanner {
             overlap: self.overlap,
             layout: self.layout,
             levels,
+            canvas_width,
+            canvas_height,
+            centre: self.centre,
+            centre_offset_x: offset_x,
+            centre_offset_y: offset_y,
+        }
+    }
+
+    fn plan_google(&self) -> PyramidPlan {
+        let ts = self.tile_size;
+        let cols_needed = ceil_div(self.image_width, ts);
+        let rows_needed = ceil_div(self.image_height, ts);
+        let max_grid = cols_needed.max(rows_needed);
+
+        // n_levels = ceil(log2(max_grid)) + 1, minimum 1
+        let n_levels = if max_grid <= 1 {
+            1
+        } else {
+            (32 - (max_grid - 1).leading_zeros()) + 1
+        };
+
+        // Canvas is ts * 2^(n_levels-1) — square
+        let canvas = ts * (1u32 << (n_levels - 1));
+
+        let (offset_x, offset_y) = if self.centre {
+            (
+                (canvas - self.image_width) / 2,
+                (canvas - self.image_height) / 2,
+            )
+        } else {
+            (0, 0)
+        };
+
+        // Build levels: z=0 is 1x1 grid, z=n_levels-1 is full resolution grid
+        let mut levels = Vec::with_capacity(n_levels as usize);
+        let mut w = self.image_width;
+        let mut h = self.image_height;
+
+        // Collect image dimensions at each level (top-down)
+        let mut img_dims = vec![(w, h)];
+        for _ in 1..n_levels {
+            w = ceil_div(w, 2);
+            h = ceil_div(h, 2);
+            img_dims.push((w, h));
+        }
+        img_dims.reverse(); // level 0 = smallest
+
+        for z in 0..n_levels {
+            let grid = 1u32 << z; // 2^z
+            let (iw, ih) = img_dims[z as usize];
+            levels.push(LevelPlan {
+                level: z,
+                width: iw,
+                height: ih,
+                cols: grid,
+                rows: grid,
+            });
+        }
+
+        PyramidPlan {
+            image_width: self.image_width,
+            image_height: self.image_height,
+            tile_size: ts,
+            overlap: self.overlap,
+            layout: Layout::Google,
+            levels,
+            canvas_width: canvas,
+            canvas_height: canvas,
+            centre: self.centre,
+            centre_offset_x: offset_x,
+            centre_offset_y: offset_y,
         }
     }
 
@@ -311,6 +419,17 @@ impl PyramidPlan {
             return None;
         }
 
+        if self.layout == Layout::Google {
+            // Google layout: tiles cover canvas space, always full tile_size
+            let ts = self.tile_size;
+            return Some(TileRect {
+                x: coord.col * ts,
+                y: coord.row * ts,
+                width: ts,
+                height: ts,
+            });
+        }
+
         let x_start = if coord.col == 0 {
             0
         } else {
@@ -365,7 +484,7 @@ impl PyramidPlan {
                 "{}/{}_{}.{}",
                 coord.level, coord.col, coord.row, extension
             )),
-            Layout::Xyz => Some(format!(
+            Layout::Xyz | Layout::Google => Some(format!(
                 "{}/{}/{}.{}",
                 coord.level, coord.col, coord.row, extension
             )),
@@ -398,6 +517,31 @@ impl PyramidPlan {
             width = self.image_width,
             height = self.image_height,
         ))
+    }
+
+    /// Canvas dimensions at the given level for Google layout.
+    /// For non-Google layouts, returns the level's image dimensions.
+    pub fn canvas_size_at_level(&self, level: u32) -> (u32, u32) {
+        if self.layout == Layout::Google {
+            let ts = self.tile_size;
+            let grid = 1u32 << level;
+            (ts * grid, ts * grid)
+        } else {
+            match self.levels.get(level as usize) {
+                Some(lp) => (lp.width, lp.height),
+                None => (0, 0),
+            }
+        }
+    }
+
+    /// Centre offset scaled to the given level.
+    pub fn centre_offset_at_level(&self, level: u32) -> (u32, u32) {
+        if !self.centre || (self.centre_offset_x == 0 && self.centre_offset_y == 0) {
+            return (0, 0);
+        }
+        let top_level = self.levels.len() as u32 - 1;
+        let shift = top_level - level;
+        (self.centre_offset_x >> shift, self.centre_offset_y >> shift)
     }
 }
 
@@ -850,6 +994,169 @@ mod tests {
             assert_eq!(top.cols, ceil_div(2048, tile_size));
             assert_eq!(top.rows, ceil_div(1536, tile_size));
         }
+    }
+
+    // -- Google layout tests --
+
+    #[test]
+    fn google_layout_single_tile() {
+        // Image smaller than tile_size → 1 level, 1×1 grid
+        let planner = PyramidPlanner::new(100, 80, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        assert_eq!(plan.level_count(), 1);
+        assert_eq!(plan.levels[0].cols, 1);
+        assert_eq!(plan.levels[0].rows, 1);
+        assert_eq!(plan.canvas_width, 256);
+        assert_eq!(plan.canvas_height, 256);
+    }
+
+    #[test]
+    fn google_layout_level_count() {
+        // 3300x5024 at ts=256: max(ceil(3300/256), ceil(5024/256)) = max(13,20) = 20
+        // n_levels = ceil(log2(20)) + 1 = 5 + 1 = 6
+        let planner = PyramidPlanner::new(3300, 5024, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        assert_eq!(plan.level_count(), 6);
+        // Canvas = 256 * 2^5 = 8192
+        assert_eq!(plan.canvas_width, 8192);
+        assert_eq!(plan.canvas_height, 8192);
+    }
+
+    #[test]
+    fn google_layout_power_of_2_grids() {
+        let planner = PyramidPlanner::new(1000, 800, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        for (i, level) in plan.levels.iter().enumerate() {
+            let expected_grid = 1u32 << i;
+            assert_eq!(level.cols, expected_grid, "Level {} cols", i);
+            assert_eq!(level.rows, expected_grid, "Level {} rows", i);
+        }
+    }
+
+    #[test]
+    fn google_layout_path_format() {
+        let planner = PyramidPlanner::new(512, 512, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        let path = plan.tile_path(TileCoord::new(1, 1, 0), "png").unwrap();
+        assert_eq!(path, "1/1/0.png");
+    }
+
+    #[test]
+    fn google_layout_no_dzi() {
+        let planner = PyramidPlanner::new(512, 512, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        assert!(plan.dzi_manifest("png").is_none());
+    }
+
+    #[test]
+    fn google_layout_tile_rect_full_size() {
+        // All Google tiles should be full tile_size × tile_size
+        let planner = PyramidPlanner::new(500, 300, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        for coord in plan.tile_coords() {
+            let rect = plan.tile_rect(coord).unwrap();
+            assert_eq!(rect.width, 256, "Tile {:?} width", coord);
+            assert_eq!(rect.height, 256, "Tile {:?} height", coord);
+        }
+    }
+
+    #[test]
+    fn google_centre_offsets() {
+        // 500x300 at ts=256: max(2,2)=2, n_levels=2, canvas=512
+        let planner = PyramidPlanner::new(500, 300, 256, 0, Layout::Google)
+            .unwrap()
+            .with_centre(true);
+        let plan = planner.plan();
+        assert_eq!(plan.canvas_width, 512);
+        assert_eq!(plan.canvas_height, 512);
+        assert_eq!(plan.centre_offset_x, (512 - 500) / 2); // 6
+        assert_eq!(plan.centre_offset_y, (512 - 300) / 2); // 106
+    }
+
+    #[test]
+    fn google_no_centre_offsets_zero() {
+        let planner = PyramidPlanner::new(500, 300, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        assert_eq!(plan.centre_offset_x, 0);
+        assert_eq!(plan.centre_offset_y, 0);
+        assert!(!plan.centre);
+    }
+
+    #[test]
+    fn google_layout_image_dims_halve() {
+        // Level width/height should represent the image, not canvas
+        let planner = PyramidPlanner::new(1000, 800, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        let top = plan.levels.last().unwrap();
+        assert_eq!(top.width, 1000);
+        assert_eq!(top.height, 800);
+
+        // Each lower level halves
+        for i in (1..plan.levels.len()).rev() {
+            let upper = &plan.levels[i];
+            let lower = &plan.levels[i - 1];
+            assert_eq!(lower.width, ceil_div(upper.width, 2));
+            assert_eq!(lower.height, ceil_div(upper.height, 2));
+        }
+    }
+
+    #[test]
+    fn google_total_tile_count() {
+        // 2 levels: 1×1 + 2×2 = 5
+        let planner = PyramidPlanner::new(300, 300, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        assert_eq!(plan.level_count(), 2);
+        assert_eq!(plan.total_tile_count(), 1 + 4);
+    }
+
+    #[test]
+    fn centre_with_deep_zoom() {
+        let planner = PyramidPlanner::new(500, 300, 256, 0, Layout::DeepZoom)
+            .unwrap()
+            .with_centre(true);
+        let plan = planner.plan();
+        // Grid for 500x300 at ts=256: 2x2, canvas = 512x512
+        let top = plan.levels.last().unwrap();
+        assert_eq!(top.cols, 2);
+        assert_eq!(top.rows, 2);
+        assert_eq!(plan.canvas_width, 512);
+        assert_eq!(plan.canvas_height, 512);
+        assert_eq!(plan.centre_offset_x, 6);
+        assert_eq!(plan.centre_offset_y, 106);
+    }
+
+    #[test]
+    fn canvas_size_at_level_google() {
+        let planner = PyramidPlanner::new(500, 300, 256, 0, Layout::Google).unwrap();
+        let plan = planner.plan();
+        assert_eq!(plan.canvas_size_at_level(0), (256, 256));
+        assert_eq!(plan.canvas_size_at_level(1), (512, 512));
+    }
+
+    #[test]
+    fn centre_offset_at_level_scales() {
+        // 3 levels for Google: 500x300 at ts=128
+        // max(ceil(500/128), ceil(300/128)) = max(4,3) = 4
+        // n_levels = ceil(log2(4)) + 1 = 2 + 1 = 3
+        // canvas = 128 * 4 = 512
+        let planner = PyramidPlanner::new(500, 300, 128, 0, Layout::Google)
+            .unwrap()
+            .with_centre(true);
+        let plan = planner.plan();
+        assert_eq!(plan.level_count(), 3);
+        assert_eq!(plan.canvas_width, 512);
+        // offset_x = (512-500)/2 = 6, offset_y = (512-300)/2 = 106
+        let (ox_top, oy_top) = plan.centre_offset_at_level(2);
+        assert_eq!(ox_top, 6);
+        assert_eq!(oy_top, 106);
+        // Level 1: offset halved
+        let (ox1, oy1) = plan.centre_offset_at_level(1);
+        assert_eq!(ox1, 3);
+        assert_eq!(oy1, 53);
+        // Level 0: offset quartered
+        let (ox0, oy0) = plan.centre_offset_at_level(0);
+        assert_eq!(ox0, 1);
+        assert_eq!(oy0, 26);
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `Layout::Google` variant producing power-of-2 tile grids with `{z}/{x}/{y}.ext` paths, matching the Google Maps tile convention (z=0 = single tile, no DZI manifest)
- Add `centre` support to `PyramidPlanner` and `PyramidPlan`, centering the image within the tile grid with even background padding on all sides
- Canvas-aware tile extraction in the engine handles the mapping from canvas-space coordinates to image-space, with three code paths: solid background (no intersection), partial blit (edge tiles), and direct extract (fast path)
- Extract `make_background_tile()` as a shared helper, replacing duplicated inline padding logic

## Test plan

- [x] 16 new planner unit tests: level counts, power-of-2 grids, path format, DZI suppression, centre offsets, tile rect dimensions
- [x] 6 new engine unit tests: tile generation, all-tiles-full-size, edge padding, determinism across concurrency
- [x] All 142 existing unit tests pass
- [x] All integration tests pass (including Docker/pdfium)