### PR TITLE
docs(pdf): clarify render_page_pdfium_budgeted vs render_page_pdfium

### DIFF
--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -608,14 +608,24 @@ pub struct BudgetRenderResult {
     pub capped: bool,
 }
 
-/// Render a PDF page to a raster, capping the output size to a maximum pixel
-/// budget to prevent excessive memory use on large documents.
+/// Render a PDF page to a raster with a memory safety net.
 ///
-/// - `max_dpi`: the preferred DPI (e.g. 300). Used when the result fits within
-///   the budget.
-/// - `max_pixels`: maximum total pixel count (width * height). If rendering at
-///   `max_dpi` would exceed this, the DPI is automatically reduced so the
-///   output fits.
+/// Unlike [`render_page_pdfium`] which renders at exactly the requested DPI
+/// regardless of output size, this function caps the total pixel count to
+/// prevent OOM when rendering large-format PDFs (e.g. a 48"x36" AutoCAD
+/// blueprint at 300 DPI = 518 megapixels). It picks whichever constraint
+/// is more restrictive — the requested DPI or the pixel budget — and
+/// reduces DPI automatically if needed.
+///
+/// Use [`render_page_pdfium`] when you control the DPI and know the output
+/// will fit in memory. Use this function in pipelines where the PDF page
+/// size is unknown and you need a memory ceiling.
+///
+/// - `max_dpi`: the preferred DPI (e.g. 300). Used when the result fits
+///   within the budget.
+/// - `max_pixels`: maximum total pixel count (width * height). If rendering
+///   at `max_dpi` would exceed this, the DPI is automatically reduced so
+///   the output fits.
 ///
 /// Returns the raster along with the actual DPI used and whether it was capped.
 #[cfg(feature = "pdfium")]


### PR DESCRIPTION
## Summary

- Enhance `render_page_pdfium_budgeted` docstring to explain when to use it vs `render_page_pdfium`: the former caps total pixel count as a memory safety net for large-format PDFs with unknown page sizes, the latter renders at exactly the requested DPI

## Test plan

- [x] 142 unit tests pass
- [x] Full Docker integration suite passes (including pdfium)