### PR TITLE
Enforce MSRV compliance and deprecated API detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,18 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt -- --check
-      - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo clippy --all-targets --features pdfium -- -D warnings
+      - run: cargo clippy --all-targets -- -D warnings -W clippy::incompatible_msrv -W deprecated
+      - run: cargo clippy --all-targets --features pdfium -- -D warnings -W clippy::incompatible_msrv -W deprecated
+
+  msrv:
+    name: MSRV (1.85)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.85
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-targets
+      - run: cargo check --all-targets --features pdfium
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ readme = "README.md"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+deprecated = "deny"
+
+[lints.clippy]
+incompatible_msrv = "warn"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

- Add manifest-level lint configuration to catch deprecated API usage and MSRV-incompatible calls at compile time
- Add a dedicated MSRV CI job that builds against the declared minimum Rust version (1.85)
- Strengthen clippy invocations in CI with `incompatible_msrv` and `deprecated` warnings

## Changes

### `Cargo.toml` — Lint configuration

- **`[lints.rust] deprecated = "deny"`**: Promotes usage of deprecated standard library APIs (e.g. `Error::description()`, `Error::cause()`) from a warning to a hard compile error. Configured at the manifest level so it applies uniformly across all crate targets — library, tests, and examples — without requiring `#![deny(deprecated)]` attributes in source files.

- **`[lints.clippy] incompatible_msrv = "warn"`**: Enables the `clippy::incompatible_msrv` lint, which cross-references every standard library API call against the `rust-version` field in `Cargo.toml`. Any API that was stabilized after Rust 1.85 will produce a warning. This catches the common scenario where a developer on a newer toolchain introduces an API that would fail for users on the declared MSRV.

### `.github/workflows/ci.yml` — CI pipeline

- **Check & Lint job**: Added `-W clippy::incompatible_msrv -W deprecated` flags to both clippy steps (default features and pdfium feature). This ensures CI enforces the same rules as the manifest lints, providing a safety net even for clippy versions that may not fully read the `[lints]` table.

- **New `MSRV (1.85)` job**: Installs the exact minimum supported toolchain via `dtolnay/rust-toolchain@1.85` and runs `cargo check --all-targets` with both default and pdfium features. This is the definitive compatibility gate — if any API, language feature, or dependency bumps the minimum required Rust version above 1.85, this job will fail. Unlike the clippy lint (which only checks standard library APIs), this job also catches MSRV-incompatible dependencies and language edition features.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings -W clippy::incompatible_msrv -W deprecated` passes (default features)
- [x] `cargo clippy --all-targets --features pdfium -- -D warnings -W clippy::incompatible_msrv -W deprecated` passes
- [x] All 147 unit tests pass
- [x] Full Docker integration test suite passes