### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libviprs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 authors = ["Roman Goldmann <roman@devshell.org>"]
 rust-version = "1.85"


### PR DESCRIPTION
## Summary

- Bump crate version from 0.1.2 to 0.1.3 in `Cargo.toml` in preparation for the next crates.io release

This release will include all features and fixes merged to main since 0.1.2: streaming pyramid engine, peak memory estimation, alpha-weighted RGBA downscaling, MSRV enforcement, and pdfium docstring improvements.