### PR TITLE
Address Phase 3 code review: hot-loop contention, schema versioning, typed errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,25 +23,25 @@ incompatible_msrv = "warn"
 default = []
 pdfium = ["dep:pdfium-render"]
 pdfium-static = ["pdfium", "pdfium-render/static"]
-s3 = ["dep:object_store", "dep:tokio"]
+# `s3` gates the ObjectStoreSink module. The in-tree sink uses a hand-rolled
+# `ObjectStore` trait and is wired for user-injected backends. A real S3 client
+# path (object_store + tokio) will land in a follow-up PR; until then the
+# feature pulls in no extra crates.
+s3 = []
 tracing = ["dep:tracing"]
 packfile = ["dep:tar", "dep:zip"]
-checksum = []
-dedupe = []
 
 [dependencies]
 blake3 = "1.8.4"
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "tiff"] }
 lopdf = "0.36"
-object_store = { version = "0.11", optional = true, features = ["aws"] }
 pdfium-render = { version = "0.8", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.11.0"
 tar = { version = "0.4.45", optional = true }
 thiserror = "2"
-tokio = { version = "1", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
 tracing = { version = "0.1", optional = true }
 zip = { version = "7.2.0", optional = true }
 

--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -28,7 +28,7 @@
 //! `blank_<hex-hash>`. This is asserted by
 //! `libviprs-tests/tests/phase3_dedupe_blanks.rs::determinism_of_dedupe_hashes`.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -41,6 +41,7 @@ use crate::manifest::ChecksumAlgo;
 
 /// Selects how tiles are content-addressed prior to being written to disk.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DedupeStrategy {
     /// No deduplication — every tile is written to its own file. Default.
     None,
@@ -67,6 +68,7 @@ impl Default for DedupeStrategy {
 
 /// Outcome of a [`DedupeIndex::record`] call.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DedupeDecision {
     /// This content hash was not previously seen. The caller must write
     /// `bytes` to `shared_path` and then materialize a reference at the
@@ -93,15 +95,62 @@ pub enum DedupeDecision {
 // Index
 // ---------------------------------------------------------------------------
 
+/// Compact, `Ord`-able tag for the hash algorithm component of the `seen`
+/// map's key. `ChecksumAlgo` itself doesn't derive `Ord` and we can't touch
+/// `manifest.rs` on this branch, so we project it onto a single byte.
+type AlgoTag = u8;
+
+const ALGO_TAG_BLAKE3: AlgoTag = 1;
+const ALGO_TAG_SHA256: AlgoTag = 2;
+
+fn algo_tag(a: ChecksumAlgo) -> AlgoTag {
+    match a {
+        ChecksumAlgo::Blake3 => ALGO_TAG_BLAKE3,
+        ChecksumAlgo::Sha256 => ALGO_TAG_SHA256,
+    }
+}
+
+/// Inner shared state for [`DedupeIndex`], wrapped in a single mutex so the
+/// `seen` / `refs` maps always observe a coherent invariant (Mara Bos B5:
+/// readers that held two independent locks could see `refs` populated before
+/// `seen` caught up, briefly violating "refs is a subset of seen's producible
+/// keys"). Coalescing into one lock takes the same number of lock operations
+/// as the previous two-mutex layout.
+///
+/// The `seen` map is keyed by `(algo_tag, raw_digest_bytes)` rather than hex
+/// strings: Blake3 and SHA-256 both produce 32-byte digests, so a single
+/// `[u8; 32]` representation avoids the ~2 GB of per-tile `String`
+/// allocations BurntSushi flagged on a 10M-tile run. The `algo_tag`
+/// component of the key prevents collisions between two runs where different
+/// algorithms happen to produce the same byte pattern (they won't in
+/// practice, but bundling the algo is free and makes the invariant
+/// explicit). We use a local [`AlgoTag`] (a `u8`) rather than
+/// `ChecksumAlgo` directly because the latter doesn't derive `Ord` and this
+/// branch is restricted to editing `dedupe.rs`.
+///
+/// `BTreeMap` is used instead of `HashMap` (dtolnay #5) so
+/// `references()`-derived output — which is serialized into
+/// `manifest.json`'s `blank_references` field — iterates in a deterministic
+/// order regardless of hash-state randomization.
+#[derive(Debug, Default)]
+struct DedupeState {
+    /// `(algo_tag, digest) -> shared_key` for first-write / reference
+    /// decisions.
+    seen: BTreeMap<(AlgoTag, [u8; 32]), String>,
+    /// `tile_path -> shared_key` for manifest emission.
+    refs: BTreeMap<String, String>,
+}
+
 /// In-memory mapping from content-hash to shared-key. One instance per
 /// generation run; not persisted across restarts (resume-mode sinks rebuild
 /// the index by walking `_shared/`).
+#[non_exhaustive]
 pub struct DedupeIndex {
     strategy: DedupeStrategy,
-    /// Content-hash (hex) -> shared_key.
-    seen: Mutex<HashMap<String, String>>,
-    /// Tile path -> shared_key (for manifest emission).
-    refs: Mutex<HashMap<String, String>>,
+    /// Single mutex guarding both the hash->shared-key map and the
+    /// path->shared-key map, so callers never observe one updated without
+    /// the other.
+    state: Mutex<DedupeState>,
 }
 
 impl DedupeIndex {
@@ -109,8 +158,7 @@ impl DedupeIndex {
     pub fn new(strategy: DedupeStrategy) -> Self {
         Self {
             strategy,
-            seen: Mutex::new(HashMap::new()),
-            refs: Mutex::new(HashMap::new()),
+            state: Mutex::new(DedupeState::default()),
         }
     }
 
@@ -119,24 +167,39 @@ impl DedupeIndex {
         self.strategy
     }
 
-    /// Compute the content hash using the algorithm dictated by `strategy`.
-    /// For [`DedupeStrategy::Blanks`] this is always blake3 (fast, unkeyed);
-    /// for [`DedupeStrategy::All`] the caller-chosen algorithm is used.
-    fn hash_content(&self, bytes: &[u8]) -> String {
+    /// Algorithm used to produce the raw digest for `hash_content_raw`.
+    /// [`DedupeStrategy::Blanks`] and [`DedupeStrategy::None`] always hash
+    /// with Blake3 (fast, unkeyed); [`DedupeStrategy::All`] honours the
+    /// caller-chosen algorithm.
+    fn effective_algo(&self) -> ChecksumAlgo {
         match self.strategy {
-            DedupeStrategy::None => {
-                // No hashing needed, but callers shouldn't invoke `record`
-                // in this mode. We still produce a stable hex string so the
-                // returned decision is self-consistent.
-                let h = blake3::hash(bytes);
-                hex_lower(h.as_bytes())
-            }
-            DedupeStrategy::Blanks => {
-                let h = blake3::hash(bytes);
-                hex_lower(h.as_bytes())
-            }
-            DedupeStrategy::All { algo } => algo.hash(bytes),
+            DedupeStrategy::None | DedupeStrategy::Blanks => ChecksumAlgo::Blake3,
+            DedupeStrategy::All { algo } => algo,
         }
+    }
+
+    /// Compute the content hash using the algorithm dictated by `strategy`,
+    /// returning the raw 32-byte digest alongside the algorithm that
+    /// produced it. Keeping raw bytes avoids the per-tile `String`
+    /// allocation that `ChecksumAlgo::hash` would incur.
+    fn hash_content_raw(&self, bytes: &[u8]) -> (ChecksumAlgo, [u8; 32]) {
+        let algo = self.effective_algo();
+        let digest = match algo {
+            ChecksumAlgo::Blake3 => {
+                let h = blake3::hash(bytes);
+                *h.as_bytes()
+            }
+            ChecksumAlgo::Sha256 => {
+                use sha2::Digest;
+                let mut hasher = sha2::Sha256::new();
+                hasher.update(bytes);
+                let out = hasher.finalize();
+                let mut buf = [0u8; 32];
+                buf.copy_from_slice(&out);
+                buf
+            }
+        };
+        (algo, digest)
     }
 
     /// Record a tile whose byte contents are `bytes` at the planned path
@@ -153,31 +216,28 @@ impl DedupeIndex {
             .and_then(|e| e.to_str())
             .unwrap_or("bin");
 
-        let hash = self.hash_content(bytes);
-        let shared_key = format!("blank_{hash}");
+        let (algo, digest) = self.hash_content_raw(bytes);
+        let hash_hex = hex_lower(&digest);
+        let shared_key = format!("blank_{hash_hex}");
         let shared_path = Self::shared_path(&shared_key, ext);
 
-        // Record the reference for manifest emission unconditionally — the
-        // sink may choose to suppress it when it successfully symlinked or
-        // hardlinked (that's a sink decision, not ours).
-        {
-            let mut refs = self.refs.lock().expect("dedupe refs mutex poisoned");
-            refs.insert(path.to_string(), shared_key.clone());
-        }
+        // Single lock: update `refs` and `seen` atomically so readers never
+        // observe one populated without the other (Mara B5).
+        let mut state = self.state.lock().expect("dedupe state mutex poisoned");
+        state.refs.insert(path.to_string(), shared_key.clone());
 
-        // First-write vs. reference.
-        let mut seen = self.seen.lock().expect("dedupe seen mutex poisoned");
-        if let std::collections::hash_map::Entry::Vacant(e) = seen.entry(hash) {
-            e.insert(shared_key.clone());
-            DedupeDecision::WriteNew {
+        match state.seen.entry((algo_tag(algo), digest)) {
+            std::collections::btree_map::Entry::Vacant(e) => {
+                e.insert(shared_key.clone());
+                DedupeDecision::WriteNew {
+                    shared_key,
+                    shared_path,
+                }
+            }
+            std::collections::btree_map::Entry::Occupied(_) => DedupeDecision::Reference {
                 shared_key,
                 shared_path,
-            }
-        } else {
-            DedupeDecision::Reference {
-                shared_key,
-                shared_path,
-            }
+            },
         }
     }
 
@@ -185,17 +245,28 @@ impl DedupeIndex {
     /// a symlink / hardlink and no manifest pointer is required). No-op if
     /// the path was never recorded.
     pub fn forget_reference(&self, path: &str) {
-        let mut refs = self.refs.lock().expect("dedupe refs mutex poisoned");
-        refs.remove(path);
+        let mut state = self.state.lock().expect("dedupe state mutex poisoned");
+        state.refs.remove(path);
     }
 
-    /// Record an already-known shared key for a given shared-key filename,
-    /// used by resume-mode sinks when walking an existing `_shared/`
-    /// directory so that subsequent `record` calls don't emit `WriteNew`
-    /// for content that's already physically present on disk.
+    /// Record an already-known shared key for a given content hash, used by
+    /// resume-mode sinks when walking an existing `_shared/` directory so
+    /// that subsequent `record` calls don't emit `WriteNew` for content
+    /// that's already physically present on disk.
+    ///
+    /// `hash_hex` must be the lowercase hex of the 32-byte digest produced
+    /// by the index's effective algorithm. Invalid or wrong-length hex is
+    /// silently ignored — the index will simply emit `WriteNew` on first
+    /// encounter, which is benign (the sink's rename-into-_shared path
+    /// already tolerates an existing target).
     pub fn seed_shared_key(&self, hash_hex: String, shared_key: String) {
-        let mut seen = self.seen.lock().expect("dedupe seen mutex poisoned");
-        seen.insert(hash_hex, shared_key);
+        let digest = match decode_hex_32(&hash_hex) {
+            Some(d) => d,
+            None => return,
+        };
+        let algo = self.effective_algo();
+        let mut state = self.state.lock().expect("dedupe state mutex poisoned");
+        state.seen.insert((algo_tag(algo), digest), shared_key);
     }
 
     /// Compute the on-disk relative path for a shared blob.
@@ -207,17 +278,25 @@ impl DedupeIndex {
 
     /// Consume-style snapshot of the current tile-path -> shared-key map for
     /// `manifest.json::blank_references` emission.
-    pub fn references(&self) -> HashMap<String, String> {
-        self.refs
+    ///
+    /// Returns a `BTreeMap` so callers that serialize the result get
+    /// deterministic key order (dtolnay #5).
+    pub fn references(&self) -> BTreeMap<String, String> {
+        self.state
             .lock()
-            .expect("dedupe refs mutex poisoned")
+            .expect("dedupe state mutex poisoned")
+            .refs
             .clone()
     }
 
     /// Total number of distinct content hashes seen so far. Useful for
     /// diagnostics and tests.
     pub fn distinct_count(&self) -> usize {
-        self.seen.lock().expect("dedupe seen mutex poisoned").len()
+        self.state
+            .lock()
+            .expect("dedupe state mutex poisoned")
+            .seen
+            .len()
     }
 }
 
@@ -228,6 +307,7 @@ impl DedupeIndex {
 /// Outcome of [`materialize_reference`]: which strategy was ultimately used
 /// to point `tile_path` at `shared_path`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum LinkResult {
     /// A symbolic link was created at `tile_path` pointing at `shared_path`.
     Symlink,
@@ -340,7 +420,15 @@ fn pathdiff(to: &Path, from: &Path) -> Option<PathBuf> {
 
 /// Materialize a reference at `tile_path` that resolves to `shared_path`.
 ///
-/// Tries, in order: symlink, hardlink, 1-byte placeholder + manifest entry.
+/// Per-platform fallback order (BurntSushi honourable mention):
+///
+/// * **Unix**: symlink → hardlink → 1-byte placeholder + manifest entry.
+///   Symlinks work unprivileged on unix; hardlinks can fail across mount
+///   points, so they come second.
+/// * **Windows**: hardlink → symlink → 1-byte placeholder + manifest entry.
+///   Symlink creation requires admin / Developer Mode on Windows, while
+///   hardlinks work unprivileged. Since `tile_path` and `shared_path` both
+///   live under the sink base dir, hardlinks almost always succeed there.
 ///
 /// The parent directory of `tile_path` must already exist; the caller is
 /// responsible for `std::fs::create_dir_all`. Any pre-existing file at
@@ -353,12 +441,28 @@ pub fn materialize_reference(tile_path: &Path, shared_path: &Path) -> LinkResult
         let _ = std::fs::remove_file(tile_path);
     }
 
-    if try_symlink(shared_path, tile_path).is_ok() {
-        return LinkResult::Symlink;
+    #[cfg(windows)]
+    {
+        // Windows: hardlink first (works without admin), then symlink.
+        if try_hardlink(shared_path, tile_path).is_ok() {
+            return LinkResult::Hardlink;
+        }
+        if try_symlink(shared_path, tile_path).is_ok() {
+            return LinkResult::Symlink;
+        }
     }
-    if try_hardlink(shared_path, tile_path).is_ok() {
-        return LinkResult::Hardlink;
+
+    #[cfg(not(windows))]
+    {
+        // Unix (and other unix-like targets): symlink first, then hardlink.
+        if try_symlink(shared_path, tile_path).is_ok() {
+            return LinkResult::Symlink;
+        }
+        if try_hardlink(shared_path, tile_path).is_ok() {
+            return LinkResult::Hardlink;
+        }
     }
+
     // Final fallback: placeholder file.
     match std::fs::write(tile_path, PLACEHOLDER_MARKER) {
         Ok(()) => LinkResult::ManifestOnly,
@@ -372,6 +476,11 @@ pub fn materialize_reference(tile_path: &Path, shared_path: &Path) -> LinkResult
     }
 }
 
+/// Lowercase-hex encode a byte slice. Duplicated (as of this writing) in
+/// `manifest.rs` and `checksum.rs`; dtolnay flagged the three copies as a
+/// consolidation opportunity. Deferred to a follow-up because promoting the
+/// helper to `pub(crate)` requires touching a file outside this branch's
+/// scope.
 fn hex_lower(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut s = String::with_capacity(bytes.len() * 2);
@@ -380,6 +489,33 @@ fn hex_lower(bytes: &[u8]) -> String {
         s.push(HEX[(b & 0x0f) as usize] as char);
     }
     s
+}
+
+/// Decode a lowercase or uppercase hex string into a fixed 32-byte digest.
+/// Returns `None` if the input isn't exactly 64 hex characters. Used by
+/// [`DedupeIndex::seed_shared_key`] to convert a caller-supplied hex hash
+/// back into the raw-byte form now stored in `DedupeState::seen`.
+fn decode_hex_32(s: &str) -> Option<[u8; 32]> {
+    let bytes = s.as_bytes();
+    if bytes.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for (i, chunk) in bytes.chunks_exact(2).enumerate() {
+        let hi = hex_nibble(chunk[0])?;
+        let lo = hex_nibble(chunk[1])?;
+        out[i] = (hi << 4) | lo;
+    }
+    Some(out)
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(10 + (b - b'a')),
+        b'A'..=b'F' => Some(10 + (b - b'A')),
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -521,5 +657,23 @@ mod tests {
         idx.seed_shared_key(hash.clone(), format!("blank_{hash}"));
         let decision = idx.record("a.png", b"payload");
         assert!(matches!(decision, DedupeDecision::Reference { .. }));
+    }
+
+    #[test]
+    fn decode_hex_32_roundtrip() {
+        let bytes = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+            0xee, 0xff, 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0x01, 0x02, 0x03, 0x04,
+            0x05, 0x06, 0x07, 0x08,
+        ];
+        let hex = hex_lower(&bytes);
+        let back = decode_hex_32(&hex).expect("valid hex round-trips");
+        assert_eq!(back, bytes);
+    }
+
+    #[test]
+    fn decode_hex_32_rejects_bad_length() {
+        assert!(decode_hex_32("").is_none());
+        assert!(decode_hex_32("abcd").is_none());
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -22,6 +23,7 @@ use crate::sink::{SinkError, Tile, TileSink};
 /// all failure modes uniformly. Also covers engine-specific conditions such as
 /// cancellation and worker panics.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum EngineError {
     #[error("raster error: {0}")]
     Raster(#[from] RasterError),
@@ -45,6 +47,13 @@ pub enum EngineError {
     /// A resumable job could not be initialised or advanced.
     #[error("resume failed: {0}")]
     ResumeFailed(#[from] ResumeError),
+    /// `ResumeMode::Verify` was requested but no on-disk checkpoint root could
+    /// be resolved from either [`EngineConfig::checkpoint_root`] or
+    /// [`TileSink::checkpoint_root`]. Verify mode requires an on-disk sink
+    /// (or an explicit `checkpoint_root` on the config) to read back the
+    /// previously-written tiles.
+    #[error("Verify mode requires an on-disk sink or EngineConfig::checkpoint_root")]
+    VerifyRequiresOnDiskSink,
 }
 
 /// Controls how blank (uniform-color) tiles are handled during pyramid generation.
@@ -58,6 +67,7 @@ pub enum EngineError {
 /// for integration-level examples. In the CLI, the `--skip-blank` flag selects
 /// [`BlankTileStrategy::Placeholder`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BlankTileStrategy {
     /// Emit blank tiles as full raster data (default). Every tile coordinate
     /// produces a complete image file, including tiles that are entirely one color.
@@ -90,6 +100,7 @@ pub enum BlankTileStrategy {
 /// [CLI pyramid command](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 /// for command-line construction of this config.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct EngineConfig {
     /// Number of worker threads for tile extraction. 0 = single-threaded (current thread).
     pub concurrency: usize,
@@ -107,6 +118,10 @@ pub struct EngineConfig {
     pub checkpoint_every: u64,
     /// Optional engine-level content-addressed deduplication strategy.
     pub dedupe_strategy: Option<crate::dedupe::DedupeStrategy>,
+    /// Explicit on-disk root for resume checkpoints and Verify-mode reads.
+    /// If None, falls back to `sink.checkpoint_root()`.
+    /// Required when the sink is an opaque user wrapper that does not forward checkpoint_root().
+    pub checkpoint_root: Option<PathBuf>,
 }
 
 impl Default for EngineConfig {
@@ -119,6 +134,7 @@ impl Default for EngineConfig {
             failure_policy: FailurePolicy::default(),
             checkpoint_every: 0,
             dedupe_strategy: None,
+            checkpoint_root: None,
         }
     }
 }
@@ -181,6 +197,16 @@ impl EngineConfig {
         self.dedupe_strategy = Some(strategy);
         self
     }
+
+    /// Configure an explicit on-disk root for resume checkpoints and
+    /// Verify-mode reads. When unset, the engine falls back to
+    /// [`TileSink::checkpoint_root`]. Supplying this is the preferred way
+    /// to drive resume/verify against an opaque user-wrapped sink that does
+    /// not forward `checkpoint_root()`.
+    pub fn with_checkpoint_root(mut self, root: PathBuf) -> Self {
+        self.checkpoint_root = Some(root);
+        self
+    }
 }
 
 /// Per-stage duration breakdown for a single pyramid run.
@@ -190,6 +216,7 @@ impl EngineConfig {
 /// durations (end-to-end time is reported via [`EngineResult::duration`]
 /// instead).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct StageDurations {
     /// Time spent planning / validating the pyramid layout.
     pub planning: Duration,
@@ -210,6 +237,7 @@ pub struct StageDurations {
 /// directly. Every field is populated by [`generate_pyramid`] /
 /// [`generate_pyramid_observed`].
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct EngineResult {
     /// Total number of tiles written to the sink (including placeholders).
     pub tiles_produced: u64,
@@ -311,6 +339,12 @@ fn run_pyramid(
     // background / blank-strategy into the emitted manifest without a
     // secondary plumbing path.
     sink.record_engine_config(config);
+
+    // Let the sink preallocate per-level bookkeeping (e.g. `FsSink` uses
+    // this to size its per-level counter atomics up-front rather than
+    // locking-and-growing on the first tile of each level). The default
+    // trait impl is a no-op, so unaware sinks silently ignore the hint.
+    sink.init_level_count(plan.levels.len());
 
     let top_level = plan.levels.len() - 1;
     let mut tiles_produced: u64 = 0;
@@ -525,10 +559,15 @@ impl CheckpointState {
         }
         // Flush periodically. `checkpoint_every == 0` disables this path and
         // leaves only the final flush (done by `run_pyramid` on success).
+        //
+        // `Relaxed` is sufficient: `flush()` takes the `meta` mutex
+        // internally, which provides the happens-before edge between the
+        // worker that appended the tile and the thread that serialises
+        // the snapshot. The counter itself is a pure cadence gauge.
         if self.checkpoint_every > 0 {
-            let n = self.pending_since_flush.fetch_add(1, Ordering::SeqCst) + 1;
+            let n = self.pending_since_flush.fetch_add(1, Ordering::Relaxed) + 1;
             if n >= self.checkpoint_every {
-                self.pending_since_flush.store(0, Ordering::SeqCst);
+                self.pending_since_flush.store(0, Ordering::Relaxed);
                 self.flush()?;
             }
         }
@@ -688,7 +727,7 @@ fn run_overwrite(
     // If the sink exposes an on-disk root, wipe its stale contents so
     // pre-existing garbage (files from an aborted run, a checkpoint with
     // the wrong plan_hash, etc.) does not survive into the new run.
-    if let Some(root) = resolve_checkpoint_root(sink) {
+    if let Some(root) = resolve_checkpoint_root(config, sink) {
         wipe_directory(&root).map_err(|e| EngineError::ResumeFailed(ResumeError::from(e)))?;
     }
 
@@ -697,17 +736,19 @@ fn run_overwrite(
     run_pyramid_with_cp(source, plan, sink, config, cp.as_ref(), &skip, false)
 }
 
-/// Resolve the on-disk checkpoint root for a sink, falling back to the
-/// thread-local [`crate::sink::last_fs_sink_root_hint`] when the outer sink
-/// does not override [`TileSink::checkpoint_root`]. This lets the resume
-/// layer work with user-supplied wrapper sinks (e.g. `RecordingSink`
-/// wrappers in the test suite) that forward `write_tile` / `finish` to an
-/// inner `FsSink` but do not re-export the on-disk root.
-fn resolve_checkpoint_root(sink: &dyn TileSink) -> Option<std::path::PathBuf> {
-    if let Some(root) = sink.checkpoint_root() {
-        return Some(root.to_path_buf());
-    }
-    crate::sink::last_fs_sink_root_hint()
+/// Resolve the on-disk checkpoint root. Prefers the explicit
+/// [`EngineConfig::checkpoint_root`] when set; otherwise consults
+/// [`TileSink::checkpoint_root`]. Returns `None` when neither is available
+/// (e.g. a pure in-memory sink with no config override).
+///
+/// The explicit config path exists so that callers wrapping [`FsSink`] in
+/// an opaque user sink (e.g. recording / tee / retry wrappers) can still
+/// drive resume and Verify without needing each wrapper to forward
+/// `checkpoint_root()` through its trait impl.
+fn resolve_checkpoint_root(cfg: &EngineConfig, sink: &dyn TileSink) -> Option<PathBuf> {
+    cfg.checkpoint_root
+        .clone()
+        .or_else(|| sink.checkpoint_root().map(|p| p.to_path_buf()))
 }
 
 /// Resume-from-checkpoint branch of [`generate_pyramid_resumable`].
@@ -719,22 +760,27 @@ fn run_resume(
 ) -> Result<EngineResult, EngineError> {
     let expected_hash = compute_plan_hash(plan);
 
-    let (existing_completed, existing_levels) = if let Some(root) = resolve_checkpoint_root(sink) {
-        match JobCheckpoint::load(&root) {
-            Some(meta) => {
-                if meta.plan_hash != expected_hash {
-                    return Err(EngineError::PlanHashMismatch {
-                        expected: meta.plan_hash.clone(),
-                        got: expected_hash,
-                    });
+    let (existing_completed, existing_levels) =
+        if let Some(root) = resolve_checkpoint_root(config, sink) {
+            // `JobCheckpoint::load` returns `Result<Option<_>, ResumeError>`:
+            // `?` surfaces real corruption as an engine error (via
+            // `EngineError::ResumeFailed`) rather than silently degrading
+            // to "no checkpoint". A missing file is still `Ok(None)`.
+            match JobCheckpoint::load(&root)? {
+                Some(meta) => {
+                    if meta.plan_hash != expected_hash {
+                        return Err(EngineError::PlanHashMismatch {
+                            expected: meta.plan_hash.clone(),
+                            got: expected_hash,
+                        });
+                    }
+                    (meta.completed_tiles, meta.levels_completed)
                 }
-                (meta.completed_tiles, meta.levels_completed)
+                None => (Vec::new(), Vec::new()),
             }
-            None => (Vec::new(), Vec::new()),
-        }
-    } else {
-        (Vec::new(), Vec::new())
-    };
+        } else {
+            (Vec::new(), Vec::new())
+        };
 
     let skip: HashSet<TileCoord> = existing_completed.iter().copied().collect();
     let cp = cp_for_sink(sink, plan, config, existing_completed, existing_levels);
@@ -751,10 +797,10 @@ fn cp_for_sink(
     completed_tiles: Vec<TileCoord>,
     levels_completed: Vec<u32>,
 ) -> Option<CheckpointState> {
-    let root = resolve_checkpoint_root(sink)?;
+    let root = resolve_checkpoint_root(config, sink)?;
     let now = now_rfc3339_engine();
     let meta = JobMetadata {
-        schema_version: SCHEMA_VERSION,
+        schema_version: SCHEMA_VERSION.to_string(),
         plan_hash: compute_plan_hash(plan),
         completed_tiles,
         levels_completed,
@@ -802,11 +848,8 @@ fn run_verify(
     config: &EngineConfig,
 ) -> Result<EngineResult, EngineError> {
     let started = Instant::now();
-    let root_buf = resolve_checkpoint_root(sink).ok_or_else(|| {
-        EngineError::Sink(SinkError::Other(
-            "Verify mode requires a sink with an on-disk root".into(),
-        ))
-    })?;
+    let root_buf =
+        resolve_checkpoint_root(config, sink).ok_or(EngineError::VerifyRequiresOnDiskSink)?;
     let root = root_buf.as_path();
 
     // Try every known tile-file extension until we find one that matches.
@@ -1085,15 +1128,6 @@ fn extract_and_emit_level(
                         continue;
                     }
                 }
-                #[cfg(feature = "tracing")]
-                let _tile_span = tracing::trace_span!(
-                    target: "libviprs",
-                    "tile",
-                    x = coord.col,
-                    y = coord.row,
-                    level = coord.level
-                )
-                .entered();
                 let encode_start = Instant::now();
                 let tile_raster = extract_tile(raster, plan, coord, config.background_rgb)?;
                 ctx.stage_encode
@@ -1142,6 +1176,16 @@ fn extract_and_emit_level(
                     }
                 }
                 observer.on_event(EngineEvent::TileCompleted { coord });
+                #[cfg(feature = "tracing")]
+                if tracing::enabled!(target: "libviprs::tile", tracing::Level::TRACE) {
+                    tracing::trace!(
+                        target: "libviprs::tile",
+                        x = coord.col,
+                        y = coord.row,
+                        level = coord.level,
+                        "tile done"
+                    );
+                }
                 count += 1;
             }
         }
@@ -1250,8 +1294,12 @@ fn extract_and_emit_parallel(
                     // tile and attempting to hand it off. The peak is
                     // bounded by the worker count (plus up to one on the
                     // consumer side while it writes to the sink).
-                    let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
-                    let _ = queue_peak.fetch_max(cur, Ordering::SeqCst);
+                    //
+                    // Pure gauge — no happens-before needed between the
+                    // counter and any tile payload, so `Relaxed` is safe
+                    // (and avoids a useless full fence in the hot loop).
+                    let cur = in_flight.fetch_add(1, Ordering::Relaxed) + 1;
+                    let _ = queue_peak.fetch_max(cur, Ordering::Relaxed);
 
                     let encode_start = Instant::now();
                     let result = extract_tile(&raster, &plan, coord, bg)
@@ -1270,8 +1318,9 @@ fn extract_and_emit_parallel(
                     // Balance the counter as soon as the tile leaves the
                     // producer — either the consumer has taken ownership
                     // (and the channel buffers it briefly) or the consumer
-                    // is gone and we're about to exit.
-                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                    // is gone and we're about to exit. `Relaxed` matches
+                    // the corresponding `fetch_add` above.
+                    in_flight.fetch_sub(1, Ordering::Relaxed);
                     if send_failed {
                         break; // Consumer dropped
                     }
@@ -1315,6 +1364,16 @@ fn extract_and_emit_parallel(
                 }
             }
             observer.on_event(EngineEvent::TileCompleted { coord });
+            #[cfg(feature = "tracing")]
+            if tracing::enabled!(target: "libviprs::tile", tracing::Level::TRACE) {
+                tracing::trace!(
+                    target: "libviprs::tile",
+                    x = coord.col,
+                    y = coord.row,
+                    level = coord.level,
+                    "tile done"
+                );
+            }
             count += 1;
         }
         Ok((count, skipped))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,17 +50,20 @@ pub mod source;
 pub mod streaming;
 pub mod streaming_mapreduce;
 
-pub use checksum::{ChecksumMode, VerifyError, VerifyReport, hash_tile, verify_output};
-pub use dedupe::{DedupeDecision, DedupeIndex, DedupeStrategy, LinkResult, materialize_reference};
+// Curated crate-root surface: types and high-level entry points only.
+// Leaf helpers, constants, and free functions stay behind their module path
+// (e.g. `libviprs::resume::SCHEMA_VERSION`) so `use libviprs::*` does not
+// flood callers with implementation detail.
+pub use checksum::{ChecksumMode, VerifyError, VerifyReport};
+pub use dedupe::{DedupeDecision, DedupeIndex, DedupeStrategy, LinkResult};
 pub use engine::{
     BlankTileStrategy, EngineConfig, EngineError, EngineResult, StageDurations, generate_pyramid,
-    generate_pyramid_observed, generate_pyramid_resumable, is_blank_tile,
-    is_blank_tile_with_tolerance,
+    generate_pyramid_observed, generate_pyramid_resumable,
 };
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};
 pub use manifest::{
-    ChecksumAlgo, Checksums, GenerationSettings, LevelMetadata, ManifestBuilder, ManifestError,
-    ManifestV1, SourceMetadata, SparsePolicy,
+    ChecksumAlgo, Checksums, GenerationSettings, LevelMetadata, Manifest, ManifestBuilder,
+    ManifestError, ManifestV1, SourceMetadata, SparsePolicy,
 };
 pub use observe::{CollectingObserver, EngineEvent, EngineObserver, MemoryTracker};
 #[cfg(feature = "pdfium")]
@@ -71,26 +74,20 @@ pub use planner::{
     Layout, LevelPlan, PlannerError, PyramidPlan, PyramidPlanner, TileCoord, TileRect,
 };
 pub use raster::{Raster, RasterError, RegionView};
-pub use resume::{
-    CHECKPOINT_FILENAME, JobCheckpoint, JobMetadata, ResumeError, ResumeMode, SCHEMA_VERSION,
-    compute_plan_hash, is_tile_completed,
-};
-pub use retry::{FailurePolicy, RetryPolicy, RetryingSink, compute_backoff};
-pub use sink::{
-    BLANK_TILE_MARKER, CollectedTile, FsSink, MemorySink, SinkError, Tile, TileFormat, TileSink,
-};
+pub use resume::{JobCheckpoint, JobMetadata, ResumeError, ResumeMode};
+pub use retry::{FailurePolicy, RetryPolicy, RetryingSink};
+pub use sink::{CollectedTile, FsSink, MemorySink, SinkError, Tile, TileFormat, TileSink};
 #[cfg(feature = "s3")]
-pub use sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink, deep_zoom_key};
+pub use sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 #[cfg(feature = "packfile")]
 pub use sink_packfile::{PackfileFormat, PackfileSink};
 pub use source::{SourceError, decode_bytes, decode_file, generate_test_raster};
 #[cfg(feature = "pdfium")]
 pub use streaming::PdfiumStripSource;
 pub use streaming::{
-    RasterStripSource, StreamingConfig, StripSource, compute_strip_height,
-    estimate_streaming_memory, generate_pyramid_auto, generate_pyramid_streaming,
+    RasterStripSource, StreamingConfig, StripSource, generate_pyramid_auto,
+    generate_pyramid_streaming,
 };
 pub use streaming_mapreduce::{
-    MapReduceConfig, compute_inflight_strips, estimate_mapreduce_peak_memory,
-    generate_pyramid_mapreduce, generate_pyramid_mapreduce_auto,
+    MapReduceConfig, generate_pyramid_mapreduce, generate_pyramid_mapreduce_auto,
 };

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -2,20 +2,35 @@
 //!
 //! Emits a `manifest.json` alongside the DZI XML that records generation
 //! settings, source metadata, per-level counts, sparse policy, and optional
-//! per-tile checksums. The top-level struct carries a `schema_version` field
-//! to support forward-compatible evolution.
+//! per-tile checksums. The top-level [`Manifest`] is a serde-tagged enum on
+//! `schema_version` so future schema bumps reject old-reader parses cleanly
+//! instead of silently falling through with default values.
 //!
-//! This module is intentionally self-contained: helper adapters for
-//! serializing the existing `Layout`, `TileFormat`, `BlankTileStrategy`, and
-//! `PixelFormat` enums (which do not derive serde traits upstream) live here.
+//! # Canonical wire format
+//!
+//! The upstream enums [`Layout`], [`TileFormat`], [`PixelFormat`], and
+//! [`BlankTileStrategy`] do not derive serde, so this module owns thin
+//! adapter modules that define the canonical on-disk representation:
+//!
+//! - `Layout`: `"deep_zoom"`, `"xyz"`, `"google"` (snake_case only).
+//! - `TileFormat`: `{"kind": "png"}`, `{"kind": "jpeg", "quality": N}`,
+//!   `{"kind": "raw"}`.
+//! - `PixelFormat`: `"gray8"`, `"gray16"`, `"rgb8"`, `"rgba8"`, `"rgb16"`,
+//!   `"rgba16"`.
+//! - `BlankTileStrategy`: `{"kind": "emit"}`, `{"kind": "placeholder"}`,
+//!   `{"kind": "placeholder_with_tolerance", "tolerance": N}`.
+//!
+//! Alternate spellings (PascalCase, etc.) are rejected. A follow-up can
+//! delete these adapters once the upstream types derive serde.
+//!
 //! Forward compatibility is preserved by NOT using `#[serde(deny_unknown_fields)]`.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fs;
 use std::io;
 use std::path::Path;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::engine::BlankTileStrategy;
@@ -27,7 +42,7 @@ use crate::sink::TileFormat;
 // Errors
 // ---------------------------------------------------------------------------
 
-/// Errors that can occur while reading or writing a [`ManifestV1`].
+/// Errors that can occur while reading or writing a [`Manifest`].
 #[derive(Debug, Error)]
 pub enum ManifestError {
     /// Underlying I/O failure (file not found, permission denied, etc.).
@@ -39,6 +54,14 @@ pub enum ManifestError {
 }
 
 // ---------------------------------------------------------------------------
+// Type aliases
+// ---------------------------------------------------------------------------
+
+/// Deterministic map type used for `blank_references`. `BTreeMap` keeps
+/// serialization order reproducible across runs.
+pub type BlankReferences = BTreeMap<String, String>;
+
+// ---------------------------------------------------------------------------
 // ChecksumAlgo
 // ---------------------------------------------------------------------------
 
@@ -46,7 +69,8 @@ pub enum ManifestError {
 ///
 /// Serializes as a lowercase string (`"blake3"` / `"sha256"`) so the
 /// manifest.json is human-readable and stable across releases.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ChecksumAlgo {
     /// BLAKE3 cryptographic hash. Hex digest is 64 characters.
     Blake3,
@@ -89,25 +113,6 @@ impl ChecksumAlgo {
     }
 }
 
-impl Serialize for ChecksumAlgo {
-    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-        ser.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for ChecksumAlgo {
-    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(de)?;
-        match s.as_str() {
-            "blake3" => Ok(Self::Blake3),
-            "sha256" => Ok(Self::Sha256),
-            other => Err(serde::de::Error::custom(format!(
-                "unknown checksum algorithm: {other}"
-            ))),
-        }
-    }
-}
-
 fn hex_lower(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut s = String::with_capacity(bytes.len() * 2);
@@ -119,7 +124,14 @@ fn hex_lower(bytes: &[u8]) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// Serde adapters for upstream enums (which do not derive Serialize/Deserialize)
+// Serde adapters for upstream enums (which do not derive Serialize/Deserialize).
+//
+// These are kept in place because the upstream types live in other modules
+// (`planner.rs`, `sink.rs`, `engine.rs`, `pixel.rs`) and deriving serde on
+// them would require edits outside this file. Each adapter accepts ONLY the
+// canonical snake_case form on deserialize; alternate spellings are rejected.
+// Once the upstream types derive serde, these adapters can be deleted and the
+// fields can use direct serde attributes.
 // ---------------------------------------------------------------------------
 
 mod layout_serde {
@@ -138,9 +150,9 @@ mod layout_serde {
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Layout, D::Error> {
         let s = String::deserialize(d)?;
         match s.as_str() {
-            "deep_zoom" | "DeepZoom" | "deepzoom" => Ok(Layout::DeepZoom),
-            "xyz" | "Xyz" | "XYZ" => Ok(Layout::Xyz),
-            "google" | "Google" => Ok(Layout::Google),
+            "deep_zoom" => Ok(Layout::DeepZoom),
+            "xyz" => Ok(Layout::Xyz),
+            "google" => Ok(Layout::Google),
             other => Err(serde::de::Error::custom(format!("unknown layout: {other}"))),
         }
     }
@@ -178,30 +190,53 @@ mod tile_format_serde {
 }
 
 mod blank_strategy_serde {
+    //! Canonical wire format for [`BlankTileStrategy`]:
+    //! - `{"kind": "emit"}`
+    //! - `{"kind": "placeholder"}`
+    //! - `{"kind": "placeholder_with_tolerance", "tolerance": N}`
+    //!
+    //! `tolerance` maps to the upstream `max_channel_delta` field. It defaults
+    //! to 0 when missing so manifests produced by older writers (or older
+    //! `"placeholder"`-as-string values round-tripped through tooling) still
+    //! parse cleanly.
     use super::BlankTileStrategy;
-    use serde::{Deserialize, Deserializer, Serializer};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(tag = "kind", rename_all = "snake_case")]
+    enum Repr {
+        Emit,
+        Placeholder,
+        PlaceholderWithTolerance {
+            #[serde(default)]
+            tolerance: u8,
+        },
+    }
 
     pub fn serialize<S: Serializer>(v: &BlankTileStrategy, s: S) -> Result<S::Ok, S::Error> {
-        // `PlaceholderWithTolerance` serializes as `"placeholder"` to remain
-        // forward compatible with readers that do not yet understand the new
-        // variant; the tolerance value is recorded in `SparsePolicy.tolerance`.
-        let name = match v {
-            BlankTileStrategy::Emit => "emit",
-            BlankTileStrategy::Placeholder => "placeholder",
-            BlankTileStrategy::PlaceholderWithTolerance { .. } => "placeholder",
+        let r = match *v {
+            BlankTileStrategy::Emit => Repr::Emit,
+            BlankTileStrategy::Placeholder => Repr::Placeholder,
+            BlankTileStrategy::PlaceholderWithTolerance { max_channel_delta } => {
+                Repr::PlaceholderWithTolerance {
+                    tolerance: max_channel_delta,
+                }
+            }
         };
-        s.serialize_str(name)
+        r.serialize(s)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<BlankTileStrategy, D::Error> {
-        let s = String::deserialize(d)?;
-        match s.as_str() {
-            "emit" | "Emit" => Ok(BlankTileStrategy::Emit),
-            "placeholder" | "Placeholder" => Ok(BlankTileStrategy::Placeholder),
-            other => Err(serde::de::Error::custom(format!(
-                "unknown blank_tile_strategy: {other}"
-            ))),
-        }
+        let r = Repr::deserialize(d)?;
+        Ok(match r {
+            Repr::Emit => BlankTileStrategy::Emit,
+            Repr::Placeholder => BlankTileStrategy::Placeholder,
+            Repr::PlaceholderWithTolerance { tolerance } => {
+                BlankTileStrategy::PlaceholderWithTolerance {
+                    max_channel_delta: tolerance,
+                }
+            }
+        })
     }
 }
 
@@ -224,12 +259,12 @@ mod pixel_format_serde {
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<PixelFormat, D::Error> {
         let s = String::deserialize(d)?;
         match s.as_str() {
-            "gray8" | "Gray8" => Ok(PixelFormat::Gray8),
-            "gray16" | "Gray16" => Ok(PixelFormat::Gray16),
-            "rgb8" | "Rgb8" => Ok(PixelFormat::Rgb8),
-            "rgba8" | "Rgba8" => Ok(PixelFormat::Rgba8),
-            "rgb16" | "Rgb16" => Ok(PixelFormat::Rgb16),
-            "rgba16" | "Rgba16" => Ok(PixelFormat::Rgba16),
+            "gray8" => Ok(PixelFormat::Gray8),
+            "gray16" => Ok(PixelFormat::Gray16),
+            "rgb8" => Ok(PixelFormat::Rgb8),
+            "rgba8" => Ok(PixelFormat::Rgba8),
+            "rgb16" => Ok(PixelFormat::Rgb16),
+            "rgba16" => Ok(PixelFormat::Rgba16),
             other => Err(serde::de::Error::custom(format!(
                 "unknown pixel_format: {other}"
             ))),
@@ -246,6 +281,7 @@ mod pixel_format_serde {
 /// Captured at the moment the manifest is emitted so downstream consumers can
 /// reproduce or verify the run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct GenerationSettings {
     /// Width/height of each tile in pixels (square tiles).
     pub tile_size: u32,
@@ -272,6 +308,7 @@ pub struct GenerationSettings {
 
 /// Metadata describing the source raster the pyramid was built from.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SourceMetadata {
     /// Source image width in pixels.
     pub width: u32,
@@ -292,6 +329,7 @@ pub struct SourceMetadata {
 
 /// Per-level counts and dimensions.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct LevelMetadata {
     /// Zero-based level index (0 == smallest / most zoomed out for DeepZoom).
     pub level_index: u32,
@@ -311,6 +349,7 @@ pub struct LevelMetadata {
 
 /// Sparse-tile handling policy active during generation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SparsePolicy {
     /// Per-channel tolerance used when detecting "blank" (uniform) tiles.
     /// 0 means exact-match only.
@@ -327,11 +366,27 @@ pub struct SparsePolicy {
 ///
 /// Uses `BTreeMap` so the serialized order is deterministic across runs.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Checksums {
     /// Hash algorithm used to compute each digest.
     pub algo: ChecksumAlgo,
     /// Map from relative tile path to lowercase hex digest.
     pub per_tile: BTreeMap<String, String>,
+}
+
+// ---------------------------------------------------------------------------
+// BlankReference
+// ---------------------------------------------------------------------------
+
+/// Single blank-tile dedupe reference entry (reserved for future richer
+/// metadata than the current `BTreeMap<String, String>` wire format).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct BlankReference {
+    /// Canonical relative path within the pyramid root.
+    pub path: String,
+    /// Digest (or other dedupe key) identifying the shared payload.
+    pub digest: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -341,15 +396,12 @@ pub struct Checksums {
 /// Versioned pyramid manifest (schema v1).
 ///
 /// Emitted by [`FsSink`](crate::sink::FsSink) when a [`ManifestBuilder`] is
-/// attached via `with_manifest(...)`. Consumers should inspect the
-/// [`ManifestV1::schema_version`] field before interpreting the payload and
-/// tolerate unknown future fields (which this struct explicitly preserves by
-/// not setting `deny_unknown_fields`).
+/// attached via `with_manifest(...)`. Consumers should route through
+/// [`Manifest`] (the tagged enum wrapper) so that future schema bumps can be
+/// distinguished rather than silently accepted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ManifestV1 {
-    /// Schema discriminator. Always `"1"` for this struct.
-    #[serde(default = "default_schema_version")]
-    pub schema_version: String,
     /// Engine/pipeline settings that produced the pyramid.
     pub generation: GenerationSettings,
     /// Source raster metadata.
@@ -366,25 +418,20 @@ pub struct ManifestV1 {
     pub created_at: String,
     /// Optional dedupe interop: map of canonical blank-tile reference paths to
     /// the digest (or equivalent key) of the shared blank payload.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub blank_references: HashMap<String, String>,
-}
-
-fn default_schema_version() -> String {
-    "1".to_string()
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub blank_references: BlankReferences,
 }
 
 impl ManifestV1 {
     /// The schema version literal this module emits.
     pub const SCHEMA_VERSION: &'static str = "1";
 
-    /// Construct an empty manifest with the current schema version.
+    /// Construct an empty manifest.
     ///
-    /// Every field is zero/default; callers are expected to fill in real
-    /// values before emitting.
+    /// Every optional field is zero/default; callers are expected to fill in
+    /// real values before emitting.
     pub fn new(generation: GenerationSettings, source: SourceMetadata) -> Self {
         Self {
-            schema_version: Self::SCHEMA_VERSION.to_string(),
             generation,
             source,
             levels: Vec::new(),
@@ -394,41 +441,105 @@ impl ManifestV1 {
             },
             checksums: None,
             created_at: String::new(),
-            blank_references: HashMap::new(),
+            blank_references: BTreeMap::new(),
         }
     }
 
-    /// Serialize this manifest to a JSON string.
+    /// Wrap this `ManifestV1` in the versioned [`Manifest`] enum.
+    pub fn into_manifest(self) -> Manifest {
+        Manifest::V1(self)
+    }
+
+    /// Serialize this manifest (as a v1) to a JSON string.
     ///
-    /// All maps inside the manifest are `BTreeMap`, so iteration order is
-    /// deterministic across runs. Any fields whose order is structural (the
-    /// struct field order and the `Vec<LevelMetadata>`) are controlled by the
-    /// engine producing the manifest.
-    pub fn to_json_string(&self) -> String {
-        // Unwrap is safe: ManifestV1 only contains types with infallible
-        // Serialize implementations.
-        serde_json::to_string_pretty(self).expect("ManifestV1 serialization must not fail")
+    /// Delegates to [`Manifest::to_json_string`] via a clone-and-wrap step for
+    /// backward compatibility with call sites that still hold a `ManifestV1`.
+    pub fn to_json_string(&self) -> Result<String, ManifestError> {
+        self.clone().into_manifest().to_json_string()
     }
 
     /// Serialize and write this manifest to `path`, creating parent
     /// directories as needed.
-    pub fn write_to(&self, path: &Path) -> io::Result<()> {
+    pub fn write_to(&self, path: &Path) -> Result<(), ManifestError> {
+        self.clone().into_manifest().write_to(path)
+    }
+
+    /// Read and parse a `ManifestV1` from `path`.
+    ///
+    /// Unknown fields are silently ignored (forward compatibility). Returns an
+    /// error if the on-disk schema version is not `"1"`.
+    pub fn read_from(path: &Path) -> Result<Self, ManifestError> {
+        match Manifest::read_from(path)? {
+            Manifest::V1(m) => Ok(m),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Manifest (versioned wrapper)
+// ---------------------------------------------------------------------------
+
+/// Versioned pyramid manifest.
+///
+/// The `schema_version` JSON field is the serde tag: `"1"` maps to
+/// [`Manifest::V1`]. Unknown versions produce a deserialization error, which
+/// is the intentional contrast with the forward-compatible "unknown inner
+/// fields are ignored" policy on [`ManifestV1`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "schema_version")]
+pub enum Manifest {
+    /// Schema v1.
+    #[serde(rename = "1")]
+    V1(ManifestV1),
+}
+
+impl Manifest {
+    /// Returns the inner v1 payload by reference.
+    pub fn as_v1(&self) -> &ManifestV1 {
+        match self {
+            Manifest::V1(m) => m,
+        }
+    }
+
+    /// Consumes the wrapper and returns the inner v1 payload.
+    pub fn into_v1(self) -> ManifestV1 {
+        match self {
+            Manifest::V1(m) => m,
+        }
+    }
+
+    /// Serialize this manifest to a pretty JSON string.
+    pub fn to_json_string(&self) -> Result<String, ManifestError> {
+        serde_json::to_string_pretty(self).map_err(ManifestError::Json)
+    }
+
+    /// Serialize and write this manifest to `path`, creating parent
+    /// directories as needed.
+    pub fn write_to(&self, path: &Path) -> Result<(), ManifestError> {
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {
                 fs::create_dir_all(parent)?;
             }
         }
-        let json = self.to_json_string();
-        fs::write(path, json)
+        let json = self.to_json_string()?;
+        fs::write(path, json)?;
+        Ok(())
     }
 
-    /// Read and parse a `ManifestV1` from `path`.
-    ///
-    /// Unknown fields are silently ignored (forward compatibility).
+    /// Read and parse a `Manifest` from `path`.
     pub fn read_from(path: &Path) -> Result<Self, ManifestError> {
         let bytes = fs::read(path)?;
-        let value: Self = serde_json::from_slice(&bytes)?;
-        Ok(value)
+        Self::from_json_slice(&bytes)
+    }
+
+    /// Parse a `Manifest` from a byte slice.
+    pub fn from_json_slice(bytes: &[u8]) -> Result<Self, ManifestError> {
+        serde_json::from_slice(bytes).map_err(ManifestError::Json)
+    }
+
+    /// Parse a `Manifest` from any `io::Read`.
+    pub fn from_json_reader<R: io::Read>(reader: R) -> Result<Self, ManifestError> {
+        serde_json::from_reader(reader).map_err(ManifestError::Json)
     }
 }
 
@@ -531,7 +642,6 @@ mod tests {
 
     fn sample_manifest() -> ManifestV1 {
         ManifestV1 {
-            schema_version: "1".to_string(),
             generation: GenerationSettings {
                 tile_size: 256,
                 overlap: 0,
@@ -560,28 +670,42 @@ mod tests {
             },
             checksums: None,
             created_at: "2026-01-01T00:00:00Z".to_string(),
-            blank_references: HashMap::new(),
+            blank_references: BTreeMap::new(),
         }
     }
 
     #[test]
     fn round_trips_through_json() {
-        let m = sample_manifest();
-        let s = m.to_json_string();
-        let parsed: ManifestV1 = serde_json::from_str(&s).unwrap();
+        let m = sample_manifest().into_manifest();
+        let s = m.to_json_string().unwrap();
+        let parsed: Manifest = serde_json::from_str(&s).unwrap();
         assert_eq!(parsed, m);
     }
 
     #[test]
     fn ignores_unknown_fields() {
-        let mut v: serde_json::Value =
-            serde_json::from_str(&sample_manifest().to_json_string()).unwrap();
+        let m = sample_manifest().into_manifest();
+        let mut v: serde_json::Value = serde_json::from_str(&m.to_json_string().unwrap()).unwrap();
         v.as_object_mut()
             .unwrap()
             .insert("future".into(), serde_json::json!("ignored"));
         let bumped = serde_json::to_string(&v).unwrap();
-        let parsed: ManifestV1 = serde_json::from_str(&bumped).unwrap();
-        assert_eq!(parsed.schema_version, "1");
+        let parsed: Manifest = serde_json::from_str(&bumped).unwrap();
+        match parsed {
+            Manifest::V1(_) => {}
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_schema_version() {
+        let m = sample_manifest().into_manifest();
+        let mut v: serde_json::Value = serde_json::from_str(&m.to_json_string().unwrap()).unwrap();
+        v.as_object_mut()
+            .unwrap()
+            .insert("schema_version".into(), serde_json::json!("99"));
+        let bumped = serde_json::to_string(&v).unwrap();
+        let parsed: Result<Manifest, _> = serde_json::from_str(&bumped);
+        assert!(parsed.is_err(), "unknown schema_version must fail to parse");
     }
 
     #[test]
@@ -624,5 +748,46 @@ mod tests {
         assert!(b.wants_source_hash());
         assert_eq!(b.dedupe_override(), Some(true));
         assert_eq!(b.tolerance_override(), Some(4));
+    }
+
+    #[test]
+    fn blank_strategy_with_tolerance_round_trips() {
+        let m_in = ManifestV1 {
+            generation: GenerationSettings {
+                tile_size: 256,
+                overlap: 0,
+                layout: Layout::Xyz,
+                format: TileFormat::Png,
+                concurrency: 1,
+                background_rgb: [0, 0, 0],
+                blank_strategy: BlankTileStrategy::PlaceholderWithTolerance {
+                    max_channel_delta: 7,
+                },
+            },
+            source: SourceMetadata {
+                width: 10,
+                height: 10,
+                pixel_format: PixelFormat::Rgb8,
+                bytes_hash: None,
+            },
+            levels: Vec::new(),
+            sparse_policy: SparsePolicy {
+                tolerance: 7,
+                dedupe: true,
+            },
+            checksums: None,
+            created_at: String::new(),
+            blank_references: BTreeMap::new(),
+        };
+        let wire = m_in.to_json_string().unwrap();
+        let parsed = Manifest::from_json_slice(wire.as_bytes())
+            .unwrap()
+            .into_v1();
+        assert_eq!(
+            parsed.generation.blank_strategy,
+            BlankTileStrategy::PlaceholderWithTolerance {
+                max_channel_delta: 7,
+            }
+        );
     }
 }

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -93,75 +93,52 @@ pub enum ResumeMode {
 /// `schema_version` is stored as a [`String`] so we can read back old
 /// checkpoints, compare them against [`SCHEMA_VERSION`], and return a
 /// structured error if they disagree.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub struct JobMetadata {
-    /// On-disk schema version. Always equal to [`SCHEMA_VERSION`] ("1") for
-    /// checkpoints produced by this crate version. Stored as `&'static str`
-    /// so test fixtures can use a plain string literal.
-    pub schema_version: &'static str,
+    /// On-disk schema version. Equal to [`SCHEMA_VERSION`] ("1") for
+    /// checkpoints produced by this crate version. Stored as a plain
+    /// [`String`] so the value read from disk is preserved verbatim and can
+    /// be compared against the binary's expected version.
+    pub schema_version: String,
     /// Lowercase hex Blake3 digest of the plan's canonical byte
     /// representation (see [`compute_plan_hash`]).
     pub plan_hash: String,
     /// Coordinates of every tile that has been successfully written and
     /// flushed since the job started.
+    ///
+    /// Uses the [`tile_coord_vec_serde`] adapter because [`TileCoord`] in
+    /// `crate::planner` does not itself implement [`Serialize`] /
+    /// [`Deserialize`].
+    #[serde(with = "tile_coord_vec_serde")]
     pub completed_tiles: Vec<TileCoord>,
     /// Level indices that have been fully completed (every tile in the level
     /// is present in `completed_tiles`). Populated eagerly so resumption can
     /// skip whole levels without re-checking each tile.
+    #[serde(default)]
     pub levels_completed: Vec<u32>,
     /// RFC 3339 timestamp captured when the job first started (Overwrite
     /// mode) or when an existing checkpoint was first resumed.
+    #[serde(default)]
     pub started_at: String,
     /// RFC 3339 timestamp of the most recent checkpoint write.
+    #[serde(default)]
     pub last_checkpoint_at: String,
 }
 
-// Manual Serialize / Deserialize so the `&'static str` schema_version field
-// doesn't force the whole struct into `Deserialize<'static>`.
-impl Serialize for JobMetadata {
-    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeStruct;
-        let mut st = s.serialize_struct("JobMetadata", 6)?;
-        st.serialize_field("schema_version", self.schema_version)?;
-        st.serialize_field("plan_hash", &self.plan_hash)?;
-        let shadow: Vec<tile_coord_vec_serde::CoordShadow> = self
-            .completed_tiles
-            .iter()
-            .map(tile_coord_vec_serde::CoordShadow::from)
-            .collect();
-        st.serialize_field("completed_tiles", &shadow)?;
-        st.serialize_field("levels_completed", &self.levels_completed)?;
-        st.serialize_field("started_at", &self.started_at)?;
-        st.serialize_field("last_checkpoint_at", &self.last_checkpoint_at)?;
-        st.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for JobMetadata {
-    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        #[derive(Deserialize)]
-        struct Raw {
-            #[serde(default)]
-            #[allow(dead_code)]
-            schema_version: Option<String>,
-            plan_hash: String,
-            completed_tiles: Vec<tile_coord_vec_serde::CoordShadow>,
-            #[serde(default)]
-            levels_completed: Vec<u32>,
-            #[serde(default)]
-            started_at: String,
-            #[serde(default)]
-            last_checkpoint_at: String,
+impl JobMetadata {
+    /// Construct a fresh [`JobMetadata`] tagged with the current
+    /// [`SCHEMA_VERSION`]. All other fields default to empty / zero values;
+    /// callers fill them in as the job progresses.
+    pub fn new(plan_hash: String, started_at: String) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION.to_string(),
+            plan_hash,
+            completed_tiles: Vec::new(),
+            levels_completed: Vec::new(),
+            last_checkpoint_at: started_at.clone(),
+            started_at,
         }
-        let raw = Raw::deserialize(d)?;
-        Ok(Self {
-            schema_version: SCHEMA_VERSION,
-            plan_hash: raw.plan_hash,
-            completed_tiles: raw.completed_tiles.into_iter().map(Into::into).collect(),
-            levels_completed: raw.levels_completed,
-            started_at: raw.started_at,
-            last_checkpoint_at: raw.last_checkpoint_at,
-        })
     }
 }
 
@@ -171,7 +148,6 @@ impl<'de> Deserialize<'de> for JobMetadata {
 /// [`Serialize`] / [`Deserialize`] directly — wiring serde into that module
 /// is out of scope for the resume module. Instead we serialise each coord as
 /// a small `{ level, col, row }` JSON object via a local shadow struct.
-#[allow(dead_code)]
 pub(super) mod tile_coord_vec_serde {
     use super::TileCoord;
     use serde::de::{SeqAccess, Visitor};
@@ -259,11 +235,26 @@ pub enum ResumeError {
         actual: String,
     },
     /// The checkpoint's `schema_version` does not match [`SCHEMA_VERSION`].
-    #[error(
-        "checkpoint schema mismatch: expected '{}', file is not compatible",
-        SCHEMA_VERSION
-    )]
-    SchemaMismatch,
+    #[error("checkpoint schema mismatch: binary speaks version {expected}, file declares {found}")]
+    SchemaMismatch {
+        /// Schema version this binary knows how to read.
+        expected: &'static str,
+        /// Schema version declared by the on-disk checkpoint.
+        found: String,
+    },
+    /// The checkpoint file exists but does not deserialise as valid JSON.
+    ///
+    /// Distinct from [`ResumeError::Io`] so callers can tell "couldn't read
+    /// the file" from "read the file but couldn't parse it" — the latter
+    /// indicates a corrupt or truncated checkpoint.
+    #[error("checkpoint at {path} is corrupt: {source}")]
+    Corrupt {
+        /// Absolute path of the malformed checkpoint file.
+        path: PathBuf,
+        /// Underlying serde_json parse error.
+        #[source]
+        source: serde_json::Error,
+    },
     /// Underlying filesystem error.
     #[error("checkpoint I/O error: {0}")]
     Io(#[from] io::Error),
@@ -288,13 +279,34 @@ impl JobCheckpoint {
 
     /// Load and deserialise the checkpoint from `dir`.
     ///
-    /// Returns `None` if the file does not exist, cannot be read, or fails to
-    /// deserialise. Callers that need to distinguish "no checkpoint" from
-    /// "corrupt checkpoint" should read the file directly.
-    pub fn load(dir: &Path) -> Option<JobMetadata> {
+    /// * `Ok(None)` — the checkpoint file does not exist.
+    /// * `Ok(Some(meta))` — the file exists, parses cleanly, and its
+    ///   `schema_version` matches [`SCHEMA_VERSION`].
+    /// * `Err(ResumeError::Io)` — the file exists but could not be read.
+    /// * `Err(ResumeError::Corrupt)` — the file exists but does not parse as
+    ///   valid JSON for [`JobMetadata`].
+    /// * `Err(ResumeError::SchemaMismatch)` — the file parsed but declares a
+    ///   `schema_version` this binary does not understand.
+    ///
+    /// Corrupt and mismatched checkpoints are surfaced as errors rather than
+    /// swallowed as `None` so callers do not silently overwrite a file that
+    /// might be recoverable.
+    pub fn load(dir: &Path) -> Result<Option<JobMetadata>, ResumeError> {
         let path = Self::checkpoint_path(dir);
-        let bytes = std::fs::read(&path).ok()?;
-        serde_json::from_slice::<JobMetadata>(&bytes).ok()
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(ResumeError::Io(e)),
+        };
+        let meta: JobMetadata = serde_json::from_slice(&bytes)
+            .map_err(|source| ResumeError::Corrupt { path, source })?;
+        if meta.schema_version != SCHEMA_VERSION {
+            return Err(ResumeError::SchemaMismatch {
+                expected: SCHEMA_VERSION,
+                found: meta.schema_version,
+            });
+        }
+        Ok(Some(meta))
     }
 
     /// Persist `meta` to `<dir>/.libviprs-job.json` atomically.
@@ -303,6 +315,7 @@ impl JobCheckpoint {
     /// the final path. On POSIX filesystems this rename is atomic, so a crash
     /// mid-write cannot leave a torn checkpoint — the old file either remains
     /// intact or is fully replaced by the new one.
+    // TODO(windows): `std::fs::rename` is not atomic-replace on Windows; switch to `ReplaceFileW` (dtolnay #9).
     pub fn save(dir: &Path, meta: &JobMetadata) -> io::Result<()> {
         // Make sure the target directory exists; callers typically create it,
         // but checkpointing should not fail just because the sink has not yet
@@ -424,7 +437,7 @@ mod tests {
 
     fn sample_meta(hash: &str) -> JobMetadata {
         JobMetadata {
-            schema_version: SCHEMA_VERSION,
+            schema_version: SCHEMA_VERSION.to_string(),
             plan_hash: hash.to_string(),
             completed_tiles: vec![TileCoord::new(0, 0, 0), TileCoord::new(1, 1, 0)],
             levels_completed: vec![0],
@@ -451,14 +464,50 @@ mod tests {
         let hash = compute_plan_hash(&plan);
         let meta = sample_meta(&hash);
         JobCheckpoint::save(dir.path(), &meta).unwrap();
-        let loaded = JobCheckpoint::load(dir.path()).unwrap();
+        let loaded = JobCheckpoint::load(dir.path()).unwrap().unwrap();
         assert_eq!(loaded, meta);
     }
 
     #[test]
     fn load_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(JobCheckpoint::load(dir.path()).is_none());
+        assert!(JobCheckpoint::load(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_rejects_corrupt_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = JobCheckpoint::checkpoint_path(dir.path());
+        std::fs::write(&path, b"{not valid json").unwrap();
+        match JobCheckpoint::load(dir.path()) {
+            Err(ResumeError::Corrupt { path: p, .. }) => assert_eq!(p, path),
+            other => panic!("expected Corrupt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_rejects_schema_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = JobCheckpoint::checkpoint_path(dir.path());
+        std::fs::write(
+            &path,
+            br#"{
+                "schema_version": "999",
+                "plan_hash": "deadbeef",
+                "completed_tiles": [],
+                "levels_completed": [],
+                "started_at": "",
+                "last_checkpoint_at": ""
+            }"#,
+        )
+        .unwrap();
+        match JobCheckpoint::load(dir.path()) {
+            Err(ResumeError::SchemaMismatch { expected, found }) => {
+                assert_eq!(expected, SCHEMA_VERSION);
+                assert_eq!(found, "999");
+            }
+            other => panic!("expected SchemaMismatch, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -16,9 +16,10 @@
 //!   beyond the single atomic read in the happy path.
 //! * Backoff is computed by the free function [`compute_backoff`], which is
 //!   deterministic (jitter-free) so unit tests can pin exact values.
-//! * Jitter is produced from a cheap pseudo-random source built on
-//!   [`std::hash::DefaultHasher`] seeded by a per-sink monotonic counter and
-//!   high-resolution clock — no external `rand` dependency.
+//! * Jitter is produced from a cheap xorshift64 PRNG seeded once per
+//!   process (via `RandomState::new().hash_one(&())`) and mixed with a
+//!   per-sink monotonic counter — no external `rand` dependency and no
+//!   per-call syscalls after the first invocation.
 //!
 //! # Example
 //!
@@ -34,12 +35,45 @@
 //! `EngineConfig` to decide how to interpret a terminal error from
 //! `write_tile`.
 
-use std::hash::{BuildHasher, Hasher, RandomState};
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use crate::sink::{SinkError, Tile, TileSink};
+
+// ---------------------------------------------------------------------------
+// Process-wide PRNG seed
+// ---------------------------------------------------------------------------
+
+/// Returns a per-process random seed drawn once from OS entropy via
+/// [`std::hash::RandomState`]. Subsequent calls reuse the cached value, so
+/// jitter sampling is syscall-free after the first invocation.
+fn process_seed() -> u64 {
+    static SEED: OnceLock<u64> = OnceLock::new();
+    *SEED.get_or_init(|| {
+        use std::hash::{BuildHasher, RandomState};
+        RandomState::new().hash_one(()) // one OS-entropy draw per process
+    })
+}
+
+/// Cheap xorshift64-based pseudo-random nanosecond value in `[0, max_nanos)`.
+///
+/// Combines the per-process seed with a monotonic per-sink counter to
+/// de-correlate jitter across both calls and sinks without touching the OS
+/// on every invocation. Good enough for jitter; not cryptographic.
+fn sample_jitter(max_nanos: u64, jitter_tick: &AtomicU64) -> u64 {
+    if max_nanos == 0 {
+        return 0;
+    }
+    let tick = jitter_tick.fetch_add(1, Ordering::Relaxed);
+    let mut x = process_seed().wrapping_add(tick.wrapping_mul(0x9E3779B97F4A7C15));
+    // xorshift64
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    x % max_nanos
+}
 
 // ---------------------------------------------------------------------------
 // RetryPolicy
@@ -58,6 +92,7 @@ use crate::sink::{SinkError, Tile, TileSink};
 ///   `[0, backoff / 2]` is added to each sleep. Jitter helps de-synchronise
 ///   many parallel workers hammering the same flaky endpoint.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct RetryPolicy {
     pub max_retries: u32,
     pub initial_backoff: Duration,
@@ -78,6 +113,44 @@ impl Default for RetryPolicy {
     }
 }
 
+impl RetryPolicy {
+    /// Construct a policy with explicit retry count and initial backoff,
+    /// defaulting the remaining fields. Combine with the `with_*` builders
+    /// to tune `multiplier`, `max_backoff`, and `jitter`.
+    pub fn new(max_retries: u32, initial_backoff: Duration) -> Self {
+        Self {
+            max_retries,
+            initial_backoff,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_max_retries(mut self, n: u32) -> Self {
+        self.max_retries = n;
+        self
+    }
+
+    pub fn with_initial_backoff(mut self, d: Duration) -> Self {
+        self.initial_backoff = d;
+        self
+    }
+
+    pub fn with_multiplier(mut self, m: f32) -> Self {
+        self.multiplier = m;
+        self
+    }
+
+    pub fn with_max_backoff(mut self, d: Duration) -> Self {
+        self.max_backoff = d;
+        self
+    }
+
+    pub fn with_jitter(mut self, enabled: bool) -> Self {
+        self.jitter = enabled;
+        self
+    }
+}
+
 // ---------------------------------------------------------------------------
 // FailurePolicy
 // ---------------------------------------------------------------------------
@@ -91,6 +164,7 @@ impl Default for RetryPolicy {
 ///   exhaustion, account the tile in
 ///   `EngineResult::skipped_due_to_failure` and continue.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum FailurePolicy {
     FailFast,
     RetryThenFail(RetryPolicy),
@@ -192,13 +266,13 @@ impl<S: TileSink> RetryingSink<S> {
 
     /// Total number of retry attempts observed by this sink so far.
     pub fn retry_count(&self) -> u64 {
-        self.retry_count.load(Ordering::SeqCst)
+        self.retry_count.load(Ordering::Relaxed)
     }
 
     /// Total number of tiles the engine marked as skipped via this sink
     /// under a `RetryThenSkip` failure policy.
     pub fn skipped_due_to_failure(&self) -> u64 {
-        self.skipped_due_to_failure.load(Ordering::SeqCst)
+        self.skipped_due_to_failure.load(Ordering::Relaxed)
     }
 
     /// Accessor for the wrapped sink — useful for integration tests that
@@ -211,7 +285,7 @@ impl<S: TileSink> RetryingSink<S> {
     /// Bump the skip counter. Called by the engine, not by the retry loop.
     #[doc(hidden)]
     pub fn note_skipped(&self) {
-        self.skipped_due_to_failure.fetch_add(1, Ordering::SeqCst);
+        self.skipped_due_to_failure.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Borrow the retry policy this sink was configured with.
@@ -223,51 +297,15 @@ impl<S: TileSink> RetryingSink<S> {
     fn backoff_sleep(&self, attempt: u32) {
         let base = compute_backoff(&self.policy, attempt);
         let total = if self.policy.jitter {
-            let max_jitter = base / 2;
-            base + self.sample_jitter(max_jitter)
+            let max_jitter_nanos = (base / 2).as_nanos() as u64;
+            let jitter_nanos = sample_jitter(max_jitter_nanos, &self.jitter_tick);
+            base + Duration::from_nanos(jitter_nanos)
         } else {
             base
         };
         if !total.is_zero() {
             thread::sleep(total);
         }
-    }
-
-    /// Cheap pseudo-random `Duration` in `[0, max]`. Derives entropy from a
-    /// per-sink counter XORed with a high-resolution clock reading, hashed
-    /// through the standard library's default hasher. Good enough for
-    /// jitter — not cryptographic.
-    fn sample_jitter(&self, max: Duration) -> Duration {
-        if max.is_zero() {
-            return Duration::ZERO;
-        }
-        let tick = self.jitter_tick.fetch_add(1, Ordering::Relaxed);
-        let now = Instant::now();
-        // Instant isn't convertible to a u64 directly, but an `Instant`
-        // hash on nightly isn't stable either — so we mix the elapsed
-        // time-since-start into the state via the elapsed duration nanos.
-        //
-        // To avoid a global `OnceLock<Instant>` we just hash the address
-        // of a stack-local alongside the tick; it's ample entropy for a
-        // jitter value.
-        let stack_anchor = &tick as *const _ as usize as u64;
-        let mut hasher = RandomState::new().build_hasher();
-        hasher.write_u64(tick);
-        hasher.write_u64(stack_anchor);
-        // `Instant::elapsed_since` is unstable; instead use the low bits
-        // of the Instant by re-reading a freshly-constructed one and
-        // comparing — but since Instant is opaque we fall back to hashing
-        // the debug representation's bit pattern via a transient Duration.
-        let since_epoch_ish = now.elapsed().as_nanos() as u64;
-        hasher.write_u64(since_epoch_ish);
-        let rand_u64 = hasher.finish();
-
-        let max_nanos = max.as_nanos() as u64;
-        if max_nanos == 0 {
-            return Duration::ZERO;
-        }
-        let jitter_nanos = rand_u64 % max_nanos.saturating_add(1);
-        Duration::from_nanos(jitter_nanos)
     }
 }
 
@@ -284,7 +322,7 @@ impl<S: TileSink> TileSink for RetryingSink<S> {
                 let mut last_err = first_err;
                 for attempt in 0..self.policy.max_retries {
                     self.backoff_sleep(attempt);
-                    self.retry_count.fetch_add(1, Ordering::SeqCst);
+                    self.retry_count.fetch_add(1, Ordering::Relaxed);
                     match self.inner.write_tile(tile) {
                         Ok(()) => return Ok(()),
                         Err(e) => last_err = e,
@@ -304,16 +342,16 @@ impl<S: TileSink> TileSink for RetryingSink<S> {
     }
 
     fn sink_retry_count(&self) -> u64 {
-        self.retry_count.load(Ordering::SeqCst) + self.inner.sink_retry_count()
+        self.retry_count.load(Ordering::Relaxed) + self.inner.sink_retry_count()
     }
 
     fn sink_skipped_due_to_failure(&self) -> u64 {
-        self.skipped_due_to_failure.load(Ordering::SeqCst)
+        self.skipped_due_to_failure.load(Ordering::Relaxed)
             + self.inner.sink_skipped_due_to_failure()
     }
 
     fn note_sink_skipped(&self) {
-        self.skipped_due_to_failure.fetch_add(1, Ordering::SeqCst);
+        self.skipped_due_to_failure.fetch_add(1, Ordering::Relaxed);
         // Forward so inner wrappers (e.g. another RetryingSink) can also
         // observe the skip. An actual terminal sink ignores the hook via the
         // default no-op implementation.
@@ -335,7 +373,16 @@ mod tests {
     use crate::pixel::PixelFormat;
     use crate::planner::TileCoord;
     use crate::raster::Raster;
+    use crate::sink::MemorySink;
     use std::sync::atomic::AtomicU32;
+
+    // Compile-time assertion that `RetryingSink<S>` is `Send + Sync` for a
+    // concrete `Send + Sync` inner sink. If this ever breaks, the engine's
+    // parallel use of `RetryingSink` will stop compiling — catch it here.
+    const _: fn() = || {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<RetryingSink<MemorySink>>();
+    };
 
     fn dummy_tile() -> Tile {
         let raster = Raster::new(1, 1, PixelFormat::Rgb8, vec![0, 0, 0]).unwrap();

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,42 +1,12 @@
-use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use crate::planner::{PyramidPlan, TileCoord};
 use crate::raster::Raster;
 use thiserror::Error;
-
-thread_local! {
-    /// Thread-local hint for the most recently constructed `FsSink`'s base
-    /// directory. Provides a best-effort fallback when the engine needs to
-    /// locate the on-disk root of a sink that is wrapped in a user-supplied
-    /// adapter (e.g. a `RecordingSink` test wrapper) that does not override
-    /// [`TileSink::checkpoint_root`].
-    ///
-    /// The registry is thread-local and LIFO — the most recently created
-    /// `FsSink` wins. This matches the `cargo test` execution model (each
-    /// test runs in its own thread and creates its own `FsSink` first), and
-    /// degrades gracefully in production: the primary lookup
-    /// (`sink.checkpoint_root()`) succeeds for any directly-owned `FsSink`,
-    /// so the fallback is only ever consulted when the trait path fails.
-    static LAST_FS_SINK_ROOT: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
-}
-
-/// Best-effort lookup for the most recently-created `FsSink` base directory
-/// on the current thread. Used by the engine's resume layer to locate the
-/// on-disk checkpoint when the user passes a wrapper sink that does not
-/// forward [`TileSink::checkpoint_root`].
-pub fn last_fs_sink_root_hint() -> Option<PathBuf> {
-    LAST_FS_SINK_ROOT.with(|slot| slot.borrow().clone())
-}
-
-fn register_fs_sink_root(root: &Path) {
-    LAST_FS_SINK_ROOT.with(|slot| {
-        *slot.borrow_mut() = Some(root.to_path_buf());
-    });
-}
 
 // -- Namespace re-exports --------------------------------------------------
 //
@@ -66,13 +36,36 @@ pub use crate::sink_packfile::{PackfileFormat, PackfileSink};
 /// See [pyramid_fs_sink tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pyramid_fs_sink.rs)
 /// for error handling patterns.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SinkError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+    /// Legacy free-form encode error. Prefer [`SinkError::Encode`] with the
+    /// typed `format` + `source` pair for new call sites.
     #[error("image encode error: {0}")]
-    Encode(String),
+    EncodeMsg(String),
+    /// Typed variant for image-encoder failures. The `format` field is the
+    /// human-readable target format (e.g. `"png"` / `"jpeg"`) and `source` is
+    /// the underlying [`image::ImageError`].
+    #[error("encoding tile to {format:?} failed: {source}")]
+    Encode {
+        format: String,
+        #[source]
+        source: image::ImageError,
+    },
+    /// Used for all catch-all string errors that haven't yet been promoted to
+    /// a typed variant. New code should prefer the typed variants below.
     #[error("sink error: {0}")]
     Other(String),
+    /// A tile coordinate fell outside the plan's level bounds. Raised from
+    /// [`FsSink::write_tile`] when [`PyramidPlan::tile_path`] returns `None`.
+    #[error("tile coord {coord:?} is outside level bounds")]
+    InvalidCoord { coord: TileCoord },
+    /// A sink that requires the active [`crate::engine::EngineConfig`] was
+    /// invoked without one. Sinks that need this should be constructed via
+    /// [`TileSink::record_engine_config`] before the tile loop starts.
+    #[error("engine config not available on sink (construct via with_engine_config)")]
+    MissingEngineConfig,
     /// A per-tile checksum did not match the expected digest. Engine-level
     /// code promotes this to [`crate::engine::EngineError::ChecksumMismatch`]
     /// so callers see the dedicated error variant rather than a generic
@@ -165,6 +158,13 @@ pub trait TileSink: Send + Sync {
     fn checkpoint_root(&self) -> Option<&Path> {
         None
     }
+
+    /// Engine hook: tell the sink how many pyramid levels will appear in
+    /// this run, so sinks that keep per-level counters can pre-size their
+    /// backing storage before the tile loop starts. Default is a no-op.
+    /// [`FsSink`] already sizes its counters from the plan in
+    /// [`FsSink::new`], so calling this is idempotent there.
+    fn init_level_count(&self, _levels: usize) {}
 }
 
 // ---------------------------------------------------------------------------
@@ -342,6 +342,14 @@ impl TileFormat {
 ///
 /// `Debug` is implemented manually because the internal [`DedupeIndex`] does
 /// not derive `Debug`.
+///
+/// # Lock order
+///
+/// `pixel_format` (OnceLock, no lock) -> `per_level_counts` (atomics, no
+/// lock) -> `tile_digests` -> `manifest_refs` -> `pending_first` ->
+/// `completed_tiles` -> `engine_config` -> dedupe mutexes. **Do not nest**
+/// locks in a different order; the hot write path acquires only the
+/// tile-local mutexes it needs and never reaches back up the chain.
 pub struct FsSink {
     base_dir: PathBuf,
     plan: PyramidPlan,
@@ -356,8 +364,9 @@ pub struct FsSink {
     resume_enabled: bool,
     /// Running per-tile checksum table, populated only when `checksums` is
     /// non-[`ChecksumMode::None`]. Keyed by the relative tile path inside
-    /// `base_dir`.
-    tile_digests: Mutex<BTreeMap<String, String>>,
+    /// `base_dir`. Stores the raw 32-byte digest to keep the hot path
+    /// allocation-free; the manifest writer hex-encodes once at emit time.
+    tile_digests: Mutex<BTreeMap<String, [u8; 32]>>,
     /// Tile rel-path -> shared file rel-path (e.g. `_shared/blank_abc.png`).
     /// Populated by the dedupe write path; emitted into the manifest's
     /// `blank_references` field.
@@ -367,15 +376,20 @@ pub struct FsSink {
     /// first tile's bytes into `_shared/` and then link both tile paths to
     /// the shared file.
     pending_first: Mutex<HashMap<String, PendingFirst>>,
-    /// Per-level tile counters: `level -> (produced, skipped)`. `skipped`
-    /// tracks blank placeholders or deduped references.
-    per_level_counts: Mutex<HashMap<u32, (u64, u64)>>,
+    /// Per-level tile counters, indexed by level. Each entry is
+    /// `[produced, skipped]` atomically-updated from the hot path. `skipped`
+    /// tracks blank placeholders or deduped references. The Vec is sized
+    /// eagerly at construction from the plan so per-tile writes are pure
+    /// atomics (no lock, no growth).
+    per_level_counts: Vec<[AtomicU64; 2]>,
     /// Captured from the first tile's raster so the manifest can record
-    /// `source.pixel_format`.
-    pixel_format: Mutex<Option<crate::pixel::PixelFormat>>,
+    /// `source.pixel_format`. Written once at first tile; readers use
+    /// `.get()`.
+    pixel_format: OnceLock<crate::pixel::PixelFormat>,
     /// Completed tile coordinates. Populated when resume is enabled so
     /// [`FsSink::finish`] can write a [`JobMetadata`](crate::resume::JobMetadata)
-    /// checkpoint.
+    /// checkpoint. Capacity is pre-reserved from the plan's total tile
+    /// count at construction so per-tile pushes never reallocate.
     completed_tiles: Mutex<Vec<TileCoord>>,
     /// Set to true the first time we observe `tile.blank == true` or a
     /// blank tile is detected while deduping. Used to infer
@@ -428,7 +442,23 @@ impl FsSink {
     /// pyramid plan and tile encoding format.
     pub fn new(base_dir: impl Into<PathBuf>, plan: PyramidPlan, format: TileFormat) -> Self {
         let base_dir = base_dir.into();
-        register_fs_sink_root(&base_dir);
+        // Pre-size the per-level atomic counter vector so that the hot
+        // write path can index by `level as usize` without any lock or
+        // allocation. `levels.len()` matches the highest level index + 1
+        // for every layout libviprs supports.
+        let level_slots = plan.levels.len().max(1);
+        let mut per_level_counts: Vec<[AtomicU64; 2]> = Vec::with_capacity(level_slots);
+        for _ in 0..level_slots {
+            per_level_counts.push([AtomicU64::new(0), AtomicU64::new(0)]);
+        }
+        // Pre-reserve the completed-tiles Vec so resume-mode runs don't
+        // reallocate under the mutex on every tile.
+        let total_tiles: u64 = plan
+            .levels
+            .iter()
+            .map(|lp| (lp.cols as u64) * (lp.rows as u64))
+            .sum();
+        let completed_cap = usize::try_from(total_tiles).unwrap_or(0);
         Self {
             base_dir,
             plan,
@@ -442,9 +472,9 @@ impl FsSink {
             tile_digests: Mutex::new(BTreeMap::new()),
             manifest_refs: Mutex::new(HashMap::new()),
             pending_first: Mutex::new(HashMap::new()),
-            per_level_counts: Mutex::new(HashMap::new()),
-            pixel_format: Mutex::new(None),
-            completed_tiles: Mutex::new(Vec::new()),
+            per_level_counts,
+            pixel_format: OnceLock::new(),
+            completed_tiles: Mutex::new(Vec::with_capacity(completed_cap)),
             saw_blank: AtomicBool::new(false),
             engine_config: Mutex::new(None),
         }
@@ -572,7 +602,7 @@ impl TileSink for FsSink {
         let rel_string = self
             .plan
             .tile_path(tile.coord, self.format.extension())
-            .ok_or_else(|| SinkError::Other(format!("invalid coord {:?}", tile.coord)))?;
+            .ok_or(SinkError::InvalidCoord { coord: tile.coord })?;
         let abs_path = self.base_dir.join(&rel_string);
 
         if let Some(parent) = abs_path.parent() {
@@ -588,12 +618,9 @@ impl TileSink for FsSink {
 
         // Capture the pixel format from the very first tile we see so the
         // manifest can record `source.pixel_format` without extra plumbing.
-        {
-            let mut slot = self.pixel_format.lock().unwrap();
-            if slot.is_none() {
-                *slot = Some(tile.raster.format());
-            }
-        }
+        // `OnceLock::set` silently ignores subsequent writes; no lock is
+        // held on the hot path after the first tile.
+        let _ = self.pixel_format.set(tile.raster.format());
 
         if tile.blank {
             self.saw_blank.store(true, Ordering::Relaxed);
@@ -612,21 +639,22 @@ impl TileSink for FsSink {
 
         // Per-level counter bookkeeping. Deduped tiles count as "skipped"
         // because their tile path does not carry unique content; blank
-        // placeholders also count as skipped.
-        {
-            let mut counts = self.per_level_counts.lock().unwrap();
-            let entry = counts.entry(tile.coord.level).or_insert((0, 0));
-            entry.0 += 1; // produced
+        // placeholders also count as skipped. Pure atomics on the hot
+        // path — the Vec was pre-sized in `FsSink::new` from the plan.
+        if let Some(slot) = self.per_level_counts.get(tile.coord.level as usize) {
+            slot[0].fetch_add(1, Ordering::Relaxed);
             if tile.blank || dedup_used {
-                entry.1 += 1; // skipped
+                slot[1].fetch_add(1, Ordering::Relaxed);
             }
         }
 
         // Record checksum for manifest emission. Keyed by the plan-relative
-        // tile path so it round-trips through `verify_output`.
+        // tile path so it round-trips through `verify_output`. Stored as a
+        // raw 32-byte digest; hex conversion happens once at manifest-
+        // write time to keep the hot path allocation-light.
         if self.checksums != crate::checksum::ChecksumMode::None {
             if let Some(algo) = self.checksum_algo {
-                let digest = crate::checksum::hash_tile(&bytes, algo);
+                let digest = hash_tile_raw(&bytes, algo);
                 let mut map = self.tile_digests.lock().unwrap();
                 map.insert(rel_string.clone(), digest);
             }
@@ -842,19 +870,19 @@ impl FsSink {
         let Some(algo) = self.checksum_algo else {
             return Ok(());
         };
-        for (rel, expected) in &snapshot {
+        for (rel, expected_bytes) in &snapshot {
             let abs = self.base_dir.join(rel);
             let bytes = match std::fs::read(&abs) {
                 Ok(b) => b,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
                 Err(e) => return Err(SinkError::Io(e)),
             };
-            let got = crate::checksum::hash_tile(&bytes, algo);
-            if !got.eq_ignore_ascii_case(expected) {
+            let got_bytes = hash_tile_raw(&bytes, algo);
+            if got_bytes != *expected_bytes {
                 return Err(SinkError::ChecksumMismatch {
                     tile_rel_path: rel.clone(),
-                    expected: expected.clone(),
-                    got,
+                    expected: hex_encode_32(expected_bytes),
+                    got: hex_encode_32(&got_bytes),
                 });
             }
         }
@@ -895,8 +923,8 @@ impl FsSink {
         // -- source metadata ------------------------------------------------
         let pixel_format = self
             .pixel_format
-            .lock()
-            .unwrap()
+            .get()
+            .copied()
             .unwrap_or(crate::pixel::PixelFormat::Rgb8);
         let source = SourceMetadata {
             width: self.plan.image_width,
@@ -906,13 +934,23 @@ impl FsSink {
         };
 
         // -- per-level metadata --------------------------------------------
-        let counts = self.per_level_counts.lock().unwrap().clone();
+        // Snapshot the atomic counters once per level. Relaxed is fine:
+        // by the time finish() runs, all writer threads have joined.
         let levels: Vec<LevelMetadata> = self
             .plan
             .levels
             .iter()
             .map(|lp| {
-                let (produced_raw, skipped_raw) = counts.get(&lp.level).copied().unwrap_or((0, 0));
+                let (produced_raw, skipped_raw) = self
+                    .per_level_counts
+                    .get(lp.level as usize)
+                    .map(|slot| {
+                        (
+                            slot[0].load(Ordering::Relaxed),
+                            slot[1].load(Ordering::Relaxed),
+                        )
+                    })
+                    .unwrap_or((0, 0));
                 // Tests assert `tiles_produced + tiles_skipped == cols * rows`.
                 // `produced_raw` from write_tile counts every tile call (both
                 // blank and non-blank), so we split it into "produced" (non
@@ -954,23 +992,33 @@ impl FsSink {
         };
 
         // -- checksums ------------------------------------------------------
-        let tile_digests = self.tile_digests.lock().unwrap().clone();
+        // Hex-encode once at manifest-write time. Write-path stores raw
+        // 32-byte digests to keep the hot path allocation-light.
         let emit_checksums =
             self.checksum_algo.is_some() && self.checksums != crate::checksum::ChecksumMode::None;
         let checksums = if emit_checksums {
-            self.checksum_algo.map(|algo| Checksums {
-                algo,
-                per_tile: tile_digests,
-            })
+            let raw = self.tile_digests.lock().unwrap();
+            let per_tile: BTreeMap<String, String> = raw
+                .iter()
+                .map(|(k, v)| (k.clone(), hex_encode_32(v)))
+                .collect();
+            self.checksum_algo.map(|algo| Checksums { algo, per_tile })
         } else {
             None
         };
 
         // -- blank references ----------------------------------------------
-        let blank_references = self.manifest_refs.lock().unwrap().clone();
+        // sink keeps refs as HashMap for O(1) insert on the hot path; convert
+        // to the deterministic BTreeMap shape the manifest requires.
+        let blank_references: std::collections::BTreeMap<String, String> = self
+            .manifest_refs
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
 
-        let manifest = ManifestV1 {
-            schema_version: ManifestV1::SCHEMA_VERSION.to_string(),
+        let manifest_v1 = ManifestV1 {
             generation,
             source,
             levels,
@@ -980,10 +1028,10 @@ impl FsSink {
             blank_references,
         };
 
-        // Use compact JSON (no pretty-print) to keep total output bytes
-        // small on whitespace-heavy runs — callers that want a human-
-        // readable form can re-emit via `ManifestV1::to_json_string`.
-        let json = serde_json::to_vec(&manifest).expect("ManifestV1 serialization must not fail");
+        // Serialize through the tagged `Manifest` envelope so `schema_version`
+        // appears on-disk and future versions can be added without breakage.
+        let json = serde_json::to_vec(&manifest_v1.into_manifest())
+            .expect("Manifest serialization must not fail");
 
         // Preferred location: sibling file next to the DZI / base dir.
         // A single byte-identical copy is also dropped inside `base_dir` for
@@ -1014,7 +1062,7 @@ impl FsSink {
         let plan_hash = compute_plan_hash(&self.plan);
         let timestamp = now_rfc3339();
         let meta = JobMetadata {
-            schema_version: SCHEMA_VERSION,
+            schema_version: SCHEMA_VERSION.to_string(),
             plan_hash,
             completed_tiles: completed,
             levels_completed: self
@@ -1022,8 +1070,16 @@ impl FsSink {
                 .levels
                 .iter()
                 .filter_map(|lp| {
-                    let counts = self.per_level_counts.lock().unwrap();
-                    let (produced, skipped) = counts.get(&lp.level).copied().unwrap_or((0, 0));
+                    let (produced, skipped) = self
+                        .per_level_counts
+                        .get(lp.level as usize)
+                        .map(|slot| {
+                            (
+                                slot[0].load(Ordering::Relaxed),
+                                slot[1].load(Ordering::Relaxed),
+                            )
+                        })
+                        .unwrap_or((0, 0));
                     let level_total = (lp.cols as u64) * (lp.rows as u64);
                     if produced + skipped >= level_total {
                         Some(lp.level)
@@ -1084,6 +1140,42 @@ fn secs_to_ymd_hms(secs: i64) -> (i32, u32, u32, u32, u32, u32) {
 }
 
 // ---------------------------------------------------------------------------
+// Digest helpers (hot-path storage uses raw 32-byte digests)
+// ---------------------------------------------------------------------------
+
+/// Hash `bytes` with `algo` and return the raw 32-byte digest. Both
+/// supported algorithms (Blake3, SHA-256) produce exactly 32 bytes, so we
+/// can store them as fixed-size arrays on the hot path instead of paying
+/// for a `String` allocation per tile.
+fn hash_tile_raw(bytes: &[u8], algo: crate::manifest::ChecksumAlgo) -> [u8; 32] {
+    use crate::manifest::ChecksumAlgo;
+    match algo {
+        ChecksumAlgo::Blake3 => *blake3::hash(bytes).as_bytes(),
+        ChecksumAlgo::Sha256 => {
+            use sha2::Digest;
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(bytes);
+            let out = hasher.finalize();
+            let mut buf = [0u8; 32];
+            buf.copy_from_slice(&out);
+            buf
+        }
+    }
+}
+
+/// Lower-case hex encoding of a 32-byte digest, matching the format
+/// produced by [`crate::checksum::hash_tile`] (so on-disk manifests stay
+/// byte-identical to pre-refactor output).
+fn hex_encode_32(bytes: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(64);
+    use std::fmt::Write;
+    for b in bytes {
+        let _ = write!(s, "{:02x}", b);
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
 // Encoding helpers
 // ---------------------------------------------------------------------------
 
@@ -1124,7 +1216,10 @@ pub fn encode_png(raster: &Raster) -> Result<Vec<u8>, SinkError> {
         raster.height(),
         ct.into(),
     )
-    .map_err(|e| SinkError::Encode(e.to_string()))?;
+    .map_err(|e| SinkError::Encode {
+        format: "png".to_string(),
+        source: e,
+    })?;
     Ok(buf)
 }
 
@@ -1140,7 +1235,10 @@ fn encode_jpeg(raster: &Raster, quality: u8) -> Result<Vec<u8>, SinkError> {
         raster.height(),
         ct.into(),
     )
-    .map_err(|e| SinkError::Encode(e.to_string()))?;
+    .map_err(|e| SinkError::Encode {
+        format: "jpeg".to_string(),
+        source: e,
+    })?;
     Ok(buf)
 }
 

--- a/src/sink_object_store.rs
+++ b/src/sink_object_store.rs
@@ -9,13 +9,19 @@
 //! implementation: the Phase 3 TDD suite exclusively uses test doubles via
 //! [`ObjectStoreConfig::with_object_store`]. Construction without an injected
 //! backend returns an error in [`ObjectStoreSink::new`].
-
-#![cfg(feature = "s3")]
+//!
+//! Retry behaviour is **not** built into [`ObjectStoreSink`]. Callers who want
+//! automatic retries compose one externally:
+//!
+//! ```ignore
+//! use libviprs::retry::{FailurePolicy, RetryPolicy, RetryingSink};
+//! let sink = RetryingSink::new(
+//!     ObjectStoreSink::new(cfg, plan, fmt)?,
+//!     RetryPolicy::default(),
+//! );
+//! ```
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::thread;
-use std::time::Duration;
 
 use crate::pixel::PixelFormat;
 use crate::planner::{PyramidPlan, TileCoord};
@@ -34,12 +40,6 @@ pub trait ObjectStore: Send + Sync {
 }
 
 // ---------------------------------------------------------------------------
-// RetryPolicy (re-exported from retry module to avoid duplication)
-// ---------------------------------------------------------------------------
-
-pub use crate::retry::RetryPolicy;
-
-// ---------------------------------------------------------------------------
 // ObjectStoreConfig
 // ---------------------------------------------------------------------------
 
@@ -48,17 +48,23 @@ pub use crate::retry::RetryPolicy;
 ///
 /// Instances are built via the fluent [`ObjectStoreConfig::s3`] seed and the
 /// `.with_*` methods.
+///
+/// Retry behaviour is **not** configured here — wrap the resulting sink in
+/// [`crate::retry::RetryingSink`] if you need automatic retries.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct ObjectStoreConfig {
     pub endpoint: String,
     pub bucket: String,
     pub access_key: Option<String>,
     pub secret_key: Option<String>,
-    pub retry: RetryPolicy,
     pub key_prefix: String,
     pub image_name: String,
     pub multipart_threshold: usize,
-    pub store: Option<Arc<dyn ObjectStore>>,
+    /// Injected object-storage backend. Kept private so the only supported
+    /// mutation path is [`ObjectStoreConfig::with_object_store`]; tests and
+    /// production code both go through that builder.
+    store: Option<Arc<dyn ObjectStore>>,
 }
 
 impl std::fmt::Debug for ObjectStoreConfig {
@@ -74,7 +80,6 @@ impl std::fmt::Debug for ObjectStoreConfig {
                 "secret_key",
                 &self.secret_key.as_ref().map(|_| "<redacted>"),
             )
-            .field("retry", &self.retry)
             .field("key_prefix", &self.key_prefix)
             .field("image_name", &self.image_name)
             .field("multipart_threshold", &self.multipart_threshold)
@@ -91,7 +96,6 @@ impl ObjectStoreConfig {
             bucket: bucket.into(),
             access_key: None,
             secret_key: None,
-            retry: RetryPolicy::default(),
             key_prefix: String::new(),
             image_name: "image".to_string(),
             // Default multipart threshold: 8 MiB, matching common S3 defaults.
@@ -111,11 +115,6 @@ impl ObjectStoreConfig {
         self
     }
 
-    pub fn with_retry(mut self, retry: RetryPolicy) -> Self {
-        self.retry = retry;
-        self
-    }
-
     pub fn with_key_prefix(mut self, prefix: impl Into<String>) -> Self {
         self.key_prefix = prefix.into();
         self
@@ -131,6 +130,9 @@ impl ObjectStoreConfig {
         self
     }
 
+    /// Inject an [`ObjectStore`] backend — the only supported way to attach a
+    /// backend to the config. The Phase 3 TDD suite uses in-memory test
+    /// doubles here; a production integration wires up the real S3 client.
     pub fn with_object_store(mut self, store: Arc<dyn ObjectStore>) -> Self {
         self.store = Some(store);
         self
@@ -211,7 +213,10 @@ fn encode_jpeg_local(raster: &Raster, quality: u8) -> Result<Vec<u8>, SinkError>
         raster.height(),
         ct.into(),
     )
-    .map_err(|e| SinkError::Encode(e.to_string()))?;
+    .map_err(|e| SinkError::Encode {
+        format: "jpeg".into(),
+        source: e,
+    })?;
     Ok(buf)
 }
 
@@ -230,14 +235,20 @@ fn encode_tile(raster: &Raster, format: TileFormat) -> Result<Vec<u8>, SinkError
 /// A [`TileSink`] that uploads encoded tiles to an S3-compatible object store.
 ///
 /// Tile keys follow the plan's layout (Deep Zoom, XYZ, or Google) rooted at
-/// `<key_prefix>/<image_name>…`. The backend is either injected via
-/// [`ObjectStoreConfig::with_object_store`] (test path) or provided internally
-/// (real S3 path — not wired up in this build).
+/// `<key_prefix>/<image_name>…`. The backend is injected via
+/// [`ObjectStoreConfig::with_object_store`]; a built-in ureq-based S3 client
+/// is not wired into this build (see the TODO stub in [`ObjectStoreSink::new`]).
+///
+/// This sink performs **no** retries of its own — if the underlying store's
+/// `put` fails, the error is returned verbatim. Callers wanting automatic
+/// retry should wrap this sink in [`crate::retry::RetryingSink`] with the
+/// appropriate [`crate::retry::RetryPolicy`] and
+/// [`crate::retry::FailurePolicy`].
+#[non_exhaustive]
 pub struct ObjectStoreSink {
     cfg: ObjectStoreConfig,
     plan: PyramidPlan,
     format: TileFormat,
-    retry_count: AtomicU64,
 }
 
 impl std::fmt::Debug for ObjectStoreSink {
@@ -245,7 +256,6 @@ impl std::fmt::Debug for ObjectStoreSink {
         f.debug_struct("ObjectStoreSink")
             .field("cfg", &self.cfg)
             .field("format", &self.format)
-            .field("retry_count", &self.retry_count.load(Ordering::Relaxed))
             .finish()
     }
 }
@@ -253,37 +263,30 @@ impl std::fmt::Debug for ObjectStoreSink {
 impl ObjectStoreSink {
     /// Construct a new sink.
     ///
-    /// Requires `cfg.store` to be populated via
+    /// Requires a backend to have been attached to `cfg` via
     /// [`ObjectStoreConfig::with_object_store`]. The internal ureq-based S3
-    /// signer is not wired up in this build, so calling `new` without an
-    /// injected backend returns [`SinkError::Other`].
+    /// signer is not wired up in this build (tracking: Phase 3 TODO — add a
+    /// native HTTP path so production callers don't need to inject a
+    /// backend), so calling `new` without an injected backend returns
+    /// [`SinkError::Other`] with a message pointing at the injection API.
     pub fn new(
         cfg: ObjectStoreConfig,
         plan: PyramidPlan,
         format: TileFormat,
     ) -> Result<Self, SinkError> {
         if cfg.store.is_none() {
+            // Phase 3 TODO: wire up a built-in ureq-based S3 client so this
+            // branch becomes unreachable. For now, all callers (tests and
+            // production) must inject a backend via `.with_object_store(...)`.
             return Err(SinkError::Other(
-                "ObjectStoreSink requires an injected ObjectStore backend via \
-                 ObjectStoreConfig::with_object_store; the built-in S3 client \
-                 path is not compiled into this build"
+                "ObjectStoreSink: no backend attached. Call \
+                 ObjectStoreConfig::with_object_store(Arc<dyn ObjectStore>) \
+                 to inject an ObjectStore implementation (the built-in S3 \
+                 HTTP client is not compiled into this build)."
                     .into(),
             ));
         }
-        Ok(Self {
-            cfg,
-            plan,
-            format,
-            retry_count: AtomicU64::new(0),
-        })
-    }
-
-    /// Number of retry attempts made across every tile handled by this sink.
-    ///
-    /// Counts *only* the retries — the initial attempt for each tile is not
-    /// included. A value of zero means every tile was stored on its first try.
-    pub fn retry_count(&self) -> u64 {
-        self.retry_count.load(Ordering::Relaxed)
+        Ok(Self { cfg, plan, format })
     }
 
     /// List all object keys currently stored in the backing store under this
@@ -335,47 +338,6 @@ impl ObjectStoreSink {
         };
         Some(key)
     }
-
-    /// Attempt `store.put(key, bytes)` with exponential-backoff retries per
-    /// the configured [`RetryPolicy`]. The initial attempt is always made;
-    /// up to `max_retries` additional attempts follow on failure. Every retry
-    /// (i.e. every attempt *after* the first) is tallied into `retry_count`.
-    fn put_with_retry(&self, key: &str, bytes: &[u8]) -> Result<(), SinkError> {
-        let store =
-            self.cfg.store.as_ref().ok_or_else(|| {
-                SinkError::Other("ObjectStoreSink: backend is not configured".into())
-            })?;
-
-        let mut backoff = self.cfg.retry.initial_backoff;
-        let mut last_err: Option<SinkError> = None;
-
-        // Total attempts = 1 initial + max_retries retries.
-        let total_attempts = self.cfg.retry.max_retries.saturating_add(1);
-        for attempt in 0..total_attempts {
-            match store.put(key, bytes) {
-                Ok(()) => return Ok(()),
-                Err(e) => {
-                    last_err = Some(e);
-                    // If this was the final attempt, don't sleep; fall through.
-                    if attempt + 1 < total_attempts {
-                        self.retry_count.fetch_add(1, Ordering::Relaxed);
-                        // Sleep, then scale the backoff. Guard against
-                        // non-finite multipliers just in case.
-                        thread::sleep(backoff);
-                        let next_ms =
-                            (backoff.as_secs_f64() * 1000.0 * self.cfg.retry.multiplier as f64)
-                                .max(0.0);
-                        if next_ms.is_finite() {
-                            backoff = Duration::from_micros((next_ms * 1000.0) as u64);
-                        }
-                    }
-                }
-            }
-        }
-
-        Err(last_err
-            .unwrap_or_else(|| SinkError::Other(format!("object-store put failed for key {key}"))))
-    }
 }
 
 impl TileSink for ObjectStoreSink {
@@ -395,7 +357,13 @@ impl TileSink for ObjectStoreSink {
         // Tests assert on observed byte length, not on a chunking boundary.
         let _ = self.cfg.multipart_threshold;
 
-        self.put_with_retry(&key, &payload)
+        // Retries (if any) are handled by wrapping this sink in
+        // `RetryingSink` — see module-level docs.
+        let store =
+            self.cfg.store.as_ref().ok_or_else(|| {
+                SinkError::Other("ObjectStoreSink: backend is not configured".into())
+            })?;
+        store.put(&key, &payload)
     }
 
     fn finish(&self) -> Result<(), SinkError> {
@@ -439,14 +407,6 @@ mod tests {
     }
 
     #[test]
-    fn retry_policy_default_matches_spec() {
-        let p = RetryPolicy::default();
-        assert_eq!(p.max_retries, 3);
-        assert_eq!(p.initial_backoff, Duration::from_millis(50));
-        assert!((p.multiplier - 2.0).abs() < f32::EPSILON);
-    }
-
-    #[test]
     fn config_builder_sets_fields() {
         let cfg = ObjectStoreConfig::s3("http://localhost:9000", "bucket")
             .with_access_key("ak", "sk")
@@ -460,5 +420,20 @@ mod tests {
         assert_eq!(cfg.key_prefix, "p");
         assert_eq!(cfg.image_name, "img");
         assert_eq!(cfg.multipart_threshold, 1024);
+    }
+
+    #[test]
+    fn new_without_backend_mentions_with_object_store() {
+        use crate::planner::{Layout, PyramidPlanner};
+        let cfg = ObjectStoreConfig::s3("http://localhost:9000", "bucket");
+        let plan = PyramidPlanner::new(256, 256, 256, 0, Layout::DeepZoom)
+            .expect("planner params are valid")
+            .plan();
+        let err = ObjectStoreSink::new(cfg, plan, TileFormat::Png).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("with_object_store"),
+            "error should point callers to the injection API: {msg}"
+        );
     }
 }

--- a/src/sink_packfile.rs
+++ b/src/sink_packfile.rs
@@ -14,8 +14,6 @@
 //! optional `tar`, `zip`, and `flate2` crates are the only heavy
 //! dependencies pulled in — no system-level tar / gzip binary is required.
 
-#![cfg(feature = "packfile")]
-
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -23,7 +21,7 @@ use std::sync::Mutex;
 
 use crate::planner::{PyramidPlan, TileCoord};
 use crate::raster::Raster;
-use crate::sink::{BLANK_TILE_MARKER, SinkError, Tile, TileFormat, TileSink, encode_png};
+use crate::sink::{SinkError, Tile, TileFormat, TileSink, encode_png};
 
 // ---------------------------------------------------------------------------
 // PackfileFormat
@@ -82,11 +80,14 @@ enum ArchiveWriter {
     /// Uncompressed tar on top of a buffered file.
     Tar(tar::Builder<BufWriter<File>>),
     /// Tar piped through a gzip encoder, then through a buffered file.
-    TarGz(tar::Builder<flate2::write::GzEncoder<BufWriter<File>>>),
+    /// Boxed to keep the enum variants close in size (the gzip encoder is
+    /// large compared to the other writers).
+    TarGz(Box<tar::Builder<flate2::write::GzEncoder<BufWriter<File>>>>),
     /// Zip archive directly on a buffered file (zip needs seek; `File`
     /// provides that, and `BufWriter<File>` does too as long as we flush
-    /// before seek — the zip crate handles that internally).
-    Zip(zip::ZipWriter<BufWriter<File>>),
+    /// before seek — the zip crate handles that internally). Boxed to
+    /// avoid a large size disparity between enum variants.
+    Zip(Box<zip::ZipWriter<BufWriter<File>>>),
 }
 
 impl std::fmt::Debug for PackfileSink {
@@ -130,9 +131,9 @@ impl PackfileSink {
             }
             PackfileFormat::TarGz => {
                 let gz = flate2::write::GzEncoder::new(buffered, flate2::Compression::default());
-                ArchiveWriter::TarGz(tar::Builder::new(gz))
+                ArchiveWriter::TarGz(Box::new(tar::Builder::new(gz)))
             }
-            PackfileFormat::Zip => ArchiveWriter::Zip(zip::ZipWriter::new(buffered)),
+            PackfileFormat::Zip => ArchiveWriter::Zip(Box::new(zip::ZipWriter::new(buffered))),
         };
 
         Ok(Self {
@@ -166,7 +167,7 @@ impl PackfileSink {
 
         // Strip the trailing extensions we know about so that `foo.tar.gz`
         // resolves to `foo`, not `foo.tar`.
-        let stem = if let Some(rest) = file_name.strip_suffix(".tar.gz") {
+        if let Some(rest) = file_name.strip_suffix(".tar.gz") {
             rest.to_string()
         } else if let Some(rest) = file_name.strip_suffix(".tgz") {
             rest.to_string()
@@ -175,9 +176,7 @@ impl PackfileSink {
                 .file_stem()
                 .map(|s| s.to_string_lossy().into_owned())
                 .unwrap_or(file_name)
-        };
-
-        stem
+        }
     }
 
     /// Build the archive-relative path for a tile. Mirrors DeepZoom layout
@@ -276,24 +275,25 @@ impl TileSink for PackfileSink {
             return Ok(());
         }
 
-        let rel = self
-            .plan
-            .tile_path(tile.coord, self.tile_format.extension())
+        let dzi_path = self
+            .tile_archive_path(tile.coord)
             .ok_or_else(|| SinkError::Other(format!("invalid coord {:?}", tile.coord)))?;
 
         let encoded = self.encode_tile(&tile.raster)?;
-        let stem = self.archive_stem();
 
         // Primary path: DeepZoom-convention `<stem>_files/<level>/<x>_<y>.<ext>`.
         // Used by DeepZoom viewers and OpenSeadragon.
-        let dzi_path = format!("{stem}_files/{rel}");
         self.append_bytes(&dzi_path, &encoded)?;
 
         // Mirror path: `<stem>/<level>/<x>_<y>.<ext>` — mirrors the directory
         // layout that FsSink produces when its base_dir equals the archive stem.
         // This lets consumers who extract the archive and compare against an
         // FsSink-generated tree find tiles at the expected relative paths.
-        let stem_path = format!("{stem}/{rel}");
+        let rel = self
+            .plan
+            .tile_path(tile.coord, self.tile_format.extension())
+            .expect("tile_archive_path succeeded above");
+        let stem_path = format!("{}/{}", self.archive_stem(), rel);
         self.append_bytes(&stem_path, &encoded)?;
 
         Ok(())
@@ -324,7 +324,7 @@ impl TileSink for PackfileSink {
         match writer {
             ArchiveWriter::Tar(mut builder) => {
                 builder.finish()?;
-                let inner = builder.into_inner().map_err(|e| SinkError::Io(e))?;
+                let inner = builder.into_inner().map_err(SinkError::Io)?;
                 let file = inner
                     .into_inner()
                     .map_err(|e| SinkError::Io(e.into_error()))?;
@@ -332,7 +332,7 @@ impl TileSink for PackfileSink {
             }
             ArchiveWriter::TarGz(mut builder) => {
                 builder.finish()?;
-                let gz = builder.into_inner().map_err(|e| SinkError::Io(e))?;
+                let gz = builder.into_inner().map_err(SinkError::Io)?;
                 let inner = gz.finish()?;
                 let file = inner
                     .into_inner()
@@ -418,7 +418,7 @@ fn encode_jpeg(raster: &Raster, quality: u8) -> Result<Vec<u8>, SinkError> {
         raster.height(),
         ct.into(),
     )
-    .map_err(|e| SinkError::Encode(e.to_string()))?;
+    .map_err(|e| SinkError::EncodeMsg(format!("png: {e}")))?;
     Ok(buf)
 }
 

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -83,6 +83,7 @@ impl MapReduceConfig {
             failure_policy: crate::retry::FailurePolicy::default(),
             checkpoint_every: 0,
             dedupe_strategy: None,
+            checkpoint_root: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Addresses six blockers and polish items identified by a five-reviewer code
review of the Phase 3 hardening work (Niko Matsakis, Josh Triplett, Mara
Bos, dtolnay, BurntSushi). Stacked on `feat/phase3-hardening`.

### B1 — sink.rs hot-loop contention
- Replaced per-level `Mutex<HashMap>` bottleneck with `Vec<[AtomicU64; 2]>`
  (written/blank counters indexed by level).
- `OnceLock<PixelFormat>` for one-shot format discovery.
- `SinkError` variants became struct-shaped so callers can match on typed
  source errors instead of stringly-typed messages.
- Manifest writeout wraps in `Manifest::V1` and converts `HashMap` → `BTreeMap`.

### B2 — schema versioning
- `Manifest` is now a tag-enum (`#[serde(tag = \"schema_version\")]`) with
  only a `V1` variant today; loader rejects unknown versions.
- `resume::load_checkpoint` returns `Result<Option<JobMetadata>, ResumeError>`
  and validates `SchemaMismatch`; all derived `Serialize`/`Deserialize`.

### B3 — dead features + unused deps
- Deleted `checksum = []` / `dedupe = []` marker features (did nothing).
- Removed `object_store` + `tokio` from `[dependencies]`; `s3` gate is now
  dep-free (in-tree `ObjectStoreSink` uses a hand-rolled backend trait).

### B4 — retry
- xorshift64 jitter seeded from a single OS entropy draw via `OnceLock` —
  no `rand` dep.
- `RetryPolicy` marked `#[non_exhaustive]` with `::new()` + chainable
  `with_*` builders.
- `FailurePolicy::{FailFast, RetryThenFail(RetryPolicy), RetryThenSkip(RetryPolicy)}`
  carries the policy directly instead of reading a global.

### B5 — engine
- `EngineConfig::with_checkpoint_root(PathBuf)` replaces the thread-local
  checkpoint registry.
- `JobCheckpoint` threaded through `generate_pyramid_resumable`.
- Per-tile span deleted from the hot loop; Relaxed atomics on the counters.

### B6 — dedupe
- Single `Mutex<DedupeState>` over the two-map (hashlink + path-index)
  state so they can never drift.
- Platform-specific fallback order: Windows hardlink→symlink, Unix
  symlink→hardlink.

### Polish
- Curated crate-root re-exports to types + high-level entry points only;
  leaf helpers (`BLANK_TILE_MARKER`, `compute_strip_height`,
  `estimate_streaming_memory`, etc.) now live behind their module paths.
- Deleted `put_with_retry` from `ObjectStoreSink` — retry belongs to
  `RetryingSink`.
- Boxed `ZipWriter` / `TarGz` variants to equalize enum sizes.
- Cleaned redundant closures, let_and_return, and duplicated cfg
  attributes flagged by clippy.

## Test plan
- [x] `cargo clippy --all-features --tests` clean
- [x] `cargo fmt --check` clean
- [x] Docker pre-push suite: libviprs unit tests + libviprs-tests integration tests
- [ ] CI build on PR