### PR TITLE
fix(phase3): restore root re-exports + Rust 1.95 derivable_impls

### DIFF
--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -40,10 +40,11 @@ use crate::manifest::ChecksumAlgo;
 // ---------------------------------------------------------------------------
 
 /// Selects how tiles are content-addressed prior to being written to disk.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum DedupeStrategy {
     /// No deduplication — every tile is written to its own file. Default.
+    #[default]
     None,
     /// Only blank (uniform-colour) tiles are deduplicated. Non-blank tiles
     /// are written individually.
@@ -54,12 +55,6 @@ pub enum DedupeStrategy {
         /// Hash algorithm used to derive the shared-key filename.
         algo: ChecksumAlgo,
     },
-}
-
-impl Default for DedupeStrategy {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub use checksum::{ChecksumMode, VerifyError, VerifyReport};
 pub use dedupe::{DedupeDecision, DedupeIndex, DedupeStrategy, LinkResult};
 pub use engine::{
     BlankTileStrategy, EngineConfig, EngineError, EngineResult, StageDurations, generate_pyramid,
-    generate_pyramid_observed, generate_pyramid_resumable,
+    generate_pyramid_observed, generate_pyramid_resumable, is_blank_tile,
 };
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};
 pub use manifest::{
@@ -76,7 +76,9 @@ pub use planner::{
 pub use raster::{Raster, RasterError, RegionView};
 pub use resume::{JobCheckpoint, JobMetadata, ResumeError, ResumeMode};
 pub use retry::{FailurePolicy, RetryPolicy, RetryingSink};
-pub use sink::{CollectedTile, FsSink, MemorySink, SinkError, Tile, TileFormat, TileSink};
+pub use sink::{
+    BLANK_TILE_MARKER, CollectedTile, FsSink, MemorySink, SinkError, Tile, TileFormat, TileSink,
+};
 #[cfg(feature = "s3")]
 pub use sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 #[cfg(feature = "packfile")]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -163,18 +163,13 @@ impl RetryPolicy {
 /// * [`FailurePolicy::RetryThenSkip`] — retry per the embedded policy; on
 ///   exhaustion, account the tile in
 ///   `EngineResult::skipped_due_to_failure` and continue.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 #[non_exhaustive]
 pub enum FailurePolicy {
+    #[default]
     FailFast,
     RetryThenFail(RetryPolicy),
     RetryThenSkip(RetryPolicy),
-}
-
-impl Default for FailurePolicy {
-    fn default() -> Self {
-        Self::FailFast
-    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two CI failures surfaced when libviprs#39 ran fresh after the conflict-resolution merge from libviprs#44:

1. **Integration Tests (libviprs-tests)** — failed to compile \`tests/blank_tile_strategy.rs\` because libviprs/main no longer re-exported \`is_blank_tile\` and \`BLANK_TILE_MARKER\` at the crate root. The phase 3 surface reorg moved them out of \`pub use\`. \`libviprs-tests/main\` (which the CI clones as the fallback when no matching branch exists) imports them at root and fails to build.
2. **Check & Lint** — the Rust 1.95 toolchain on CI promoted \`clippy::derivable_impls\` errors for \`impl Default for DedupeStrategy\` and \`impl Default for FailurePolicy\`.

## Changes

- \`src/lib.rs\` — re-add \`is_blank_tile\` to the engine re-exports and \`BLANK_TILE_MARKER\` to the sink re-exports.
- \`src/dedupe.rs\` — replace manual \`impl Default for DedupeStrategy\` with \`#[derive(Default)]\` + \`#[default]\` on \`None\`.
- \`src/retry.rs\` — same treatment for \`FailurePolicy::FailFast\`.

## Verification

- \`cargo fmt --check\` — clean
- \`cargo clippy --all-targets -- -D warnings -W clippy::incompatible_msrv -W deprecated\` — clean
- \`cargo clippy --all-targets --features pdfium -- -D warnings -W clippy::incompatible_msrv -W deprecated\` — clean
- Pre-commit hook passed
- Pre-push hook (full Docker test suite, \`pdfium\` enabled) — all tests passed

## Test plan

- [ ] Once merged here, libviprs#39's CI should pass.