### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libviprs"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 authors = ["Roman Goldmann <roman@devshell.org>"]
 rust-version = "1.85"


### PR DESCRIPTION
## Summary
Bumps `libviprs` to `0.2.0` for the upcoming v0.2.0 release.

### What's new in 0.2.0
- `PdfiumStripSource` — true source-side PDF streaming, with matrix-path strip composition and `/Rotate` handling
- `BudgetPolicy` (`Error` / `AutoAdjust`) and engine-level pre-flight memory budget check (Issue #41 fix)
- Phase 3 hardening: `Manifest v1` (schema_version, per-level metadata, sparse policy), checksums (`EmitOnly` / `Verify`), `RetryingSink` + `FailurePolicy`, `DedupeIndex` for blank/all-tile dedup, `JobCheckpoint` resume mode, object-store and packfile sinks, full pipeline tracing
- `BlankTileStrategy::PlaceholderWithTolerance` for near-uniform region collapse

## Test plan
- [x] Issue #41 regression suite (`streaming_pdfium_matrix`) — 22/23 pass (1 ignored diagnostic)
- [x] CI green on this PR