### PR TITLE
fix(tests): mark phase-3 filesystem tests Miri-compatible

### DIFF
--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -611,6 +611,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn materialize_reference_creates_a_readable_tile() {
         let tmp = tempfile::tempdir().unwrap();
         let shared_dir = tmp.path().join("_shared");

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -458,6 +458,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn save_and_load_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let plan = sample_plan();
@@ -469,12 +470,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn load_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
         assert!(JobCheckpoint::load(dir.path()).unwrap().is_none());
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn load_rejects_corrupt_json() {
         let dir = tempfile::tempdir().unwrap();
         let path = JobCheckpoint::checkpoint_path(dir.path());
@@ -486,6 +489,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn load_rejects_schema_mismatch() {
         let dir = tempfile::tempdir().unwrap();
         let path = JobCheckpoint::checkpoint_path(dir.path());
@@ -511,6 +515,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn save_is_atomic_no_tmp_left_behind() {
         let dir = tempfile::tempdir().unwrap();
         let plan = sample_plan();

--- a/src/sink_packfile.rs
+++ b/src/sink_packfile.rs
@@ -450,6 +450,7 @@ mod tests {
     /// resulting stem mirrors what the test suite expects (`output.tar` →
     /// `"output"`, `pyramid.tar.gz` → `"pyramid"`).
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn archive_stem_handles_common_suffixes() {
         let plan = make_plan(64, 64, 32);
 
@@ -476,6 +477,7 @@ mod tests {
     /// `tile_archive_path` emits the expected DeepZoom layout string
     /// `<stem>_files/<level>/<x>_<y>.<ext>`.
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn tile_archive_path_uses_deep_zoom_layout() {
         let plan = make_plan(128, 128, 64);
         let top_level = plan.levels.last().unwrap().level;
@@ -498,6 +500,7 @@ mod tests {
     /// `build_manifest_json` emits well-formed JSON containing the expected
     /// structural fields.
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn manifest_json_contains_structural_fields() {
         let plan = make_plan(128, 128, 64);
 
@@ -522,6 +525,7 @@ mod tests {
     /// Smoke: writing a single tile + calling `finish()` on a tar sink
     /// produces a non-empty archive file.
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn end_to_end_tar_smoke() {
         let plan = make_plan(64, 64, 32);
         let top = plan.levels.last().unwrap();


### PR DESCRIPTION
## Summary
- Phase 3's dedupe / resume / packfile unit tests use \`tempfile::tempdir()\`, which Miri blocks under its default isolation mode (\`mkdir\` is unsupported).
- Mark the affected tests with \`#[cfg_attr(miri, ignore)]\` to mirror the existing pattern in \`source.rs\` and the older \`sink.rs\` tests, restoring the Miri merge gate.

## Affected tests
- \`dedupe::tests::materialize_reference_creates_a_readable_tile\`
- \`resume::tests::save_and_load_roundtrip\`
- \`resume::tests::load_returns_none_when_missing\`
- \`resume::tests::load_rejects_corrupt_json\`
- \`resume::tests::load_rejects_schema_mismatch\`
- \`resume::tests::save_is_atomic_no_tmp_left_behind\`
- \`sink_packfile::tests::archive_stem_handles_common_suffixes\`
- \`sink_packfile::tests::tile_archive_path_uses_deep_zoom_layout\`
- \`sink_packfile::tests::manifest_json_contains_structural_fields\`
- \`sink_packfile::tests::end_to_end_tar_smoke\`

## Test plan
- [x] Pre-push test suite green (host-side, via \`run-tests.sh\` Docker harness)
- [ ] CI: Miri merge-gate green