### PR TITLE
fix(retry): round backoff nanoseconds to avoid FP truncation

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -201,9 +201,10 @@ pub fn compute_backoff(policy: &RetryPolicy, attempt: u32) -> Duration {
         scaled
     };
 
-    // Safe: `clamped` is non-negative and bounded by `max_nanos`, which fits
-    // in u128 by construction (it came from a Duration).
-    let nanos = clamped as u128;
+    // Round to the nearest nanosecond before casting: `f64` cannot exactly
+    // represent every product of `initial * multiplier^attempt`, so a naive
+    // truncating cast can produce 39_999_999 ns where 40_000_000 is intended.
+    let nanos = clamped.round() as u128;
     duration_from_nanos_u128(nanos)
 }
 


### PR DESCRIPTION
## Summary
- `retry::compute_backoff` multiplies `initial_backoff_nanos × multiplier^attempt` in `f64`, then casts to `u128`. The product `10_000_000.0 × 2.0² = 40_000_000.0` is not exactly representable in `f64` on every backend; under Miri's strict-FP path the result evaluates to `39_999_999.99…`, and the truncating `as u128` cast produces `39_999_999` instead of the intended `40_000_000`.
- Round to the nearest nanosecond before the cast so the integer result matches the integer-arithmetic equivalent on every backend.
- Surfaced by Merge Gate's Miri job on Release 0.2.0 (`retry::tests::compute_backoff_is_geometric` failed with `left: 39.999999ms / right: 40ms`).

## Test plan
- [x] `cargo test --lib retry::tests::compute_backoff` passes locally
- [x] Pre-push integration suite (libviprs + libviprs-tests) passes
- [ ] Merge Gate Miri passes on this PR's downstream re-run of #47