### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libviprs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Roman Goldmann <roman@devshell.org>"]
 rust-version = "1.85"


### PR DESCRIPTION
Version bump to `0.3.0`.