### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libviprs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Roman Goldmann <roman@devshell.org>"]
 rust-version = "1.85"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -530,7 +530,7 @@ struct EmitContext<'a> {
 /// increasing counter tracks how many tiles have been appended *since the
 /// last flush* so the "every N tiles" cadence can be implemented without
 /// poking the filesystem on every write.
-struct CheckpointState {
+pub(crate) struct CheckpointState {
     /// The directory where `.libviprs-job.json` lives — typically the sink's
     /// `base_dir`. Every call to [`CheckpointState::flush`] writes there.
     root: std::path::PathBuf,
@@ -561,7 +561,7 @@ impl CheckpointState {
     /// Append a successful write to the metadata. When `checkpoint_every`
     /// tiles have accumulated since the last flush, also persist the
     /// checkpoint to disk so a crash can resume from the latest boundary.
-    fn mark_tile_completed(&self, coord: TileCoord) -> Result<(), ResumeError> {
+    pub(crate) fn mark_tile_completed(&self, coord: TileCoord) -> Result<(), ResumeError> {
         {
             let mut meta = self.meta.lock().unwrap();
             meta.completed_tiles.push(coord);
@@ -595,7 +595,7 @@ impl CheckpointState {
 
     /// Serialise the current metadata to `<root>/.libviprs-job.json`. Atomic
     /// via the tmp+rename dance inside [`JobCheckpoint::save`].
-    fn flush(&self) -> Result<(), ResumeError> {
+    pub(crate) fn flush(&self) -> Result<(), ResumeError> {
         let snapshot = {
             let mut meta = self.meta.lock().unwrap();
             meta.last_checkpoint_at = now_rfc3339_engine();
@@ -765,7 +765,7 @@ fn run_overwrite(
 /// an opaque user sink (e.g. recording / tee / retry wrappers) can still
 /// drive resume and Verify without needing each wrapper to forward
 /// `checkpoint_root()` through its trait impl.
-fn resolve_checkpoint_root(cfg: &EngineConfig, sink: &dyn TileSink) -> Option<PathBuf> {
+pub(crate) fn resolve_checkpoint_root(cfg: &EngineConfig, sink: &dyn TileSink) -> Option<PathBuf> {
     cfg.checkpoint_root
         .clone()
         .or_else(|| sink.checkpoint_root().map(|p| p.to_path_buf()))
@@ -820,7 +820,7 @@ fn run_resume(
 /// Build a `CheckpointState` rooted at the sink's checkpoint directory, or
 /// `None` if the sink does not expose a filesystem root (no on-disk
 /// checkpoint is possible in that case).
-fn cp_for_sink(
+pub(crate) fn cp_for_sink(
     sink: &dyn TileSink,
     plan: &PyramidPlan,
     config: &EngineConfig,
@@ -1088,7 +1088,7 @@ fn read_manifest(root: &std::path::Path) -> Option<serde_json::Value> {
 /// a pre-existing but partially-populated directory can still be wiped
 /// cleanly. The directory itself is retained. Caller should have verified
 /// the path is a directory they own.
-fn wipe_directory(dir: &std::path::Path) -> std::io::Result<()> {
+pub(crate) fn wipe_directory(dir: &std::path::Path) -> std::io::Result<()> {
     if !dir.exists() {
         std::fs::create_dir_all(dir)?;
         return Ok(());

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -299,15 +299,6 @@ pub struct EngineResult {
 /// for PDF-sourced pyramids, and the
 /// [CLI pyramid command](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 /// for end-to-end CLI usage.
-pub fn generate_pyramid(
-    source: &Raster,
-    plan: &PyramidPlan,
-    sink: &dyn TileSink,
-    config: &EngineConfig,
-) -> Result<EngineResult, EngineError> {
-    generate_pyramid_observed(source, plan, sink, config, &NoopObserver)
-}
-
 /// Generates a tile pyramid with an [`EngineObserver`] for progress events.
 ///
 /// Behaves identically to [`generate_pyramid`] but emits [`EngineEvent`]s
@@ -319,7 +310,7 @@ pub fn generate_pyramid(
 /// See the
 /// [observability tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/observability.rs)
 /// for integration-level examples of observer usage.
-pub fn generate_pyramid_observed(
+pub(crate) fn generate_pyramid_observed(
     source: &Raster,
     plan: &PyramidPlan,
     sink: &dyn TileSink,
@@ -1601,7 +1592,7 @@ mod tests {
         let sink = MemorySink::new();
         let config = EngineConfig::default();
 
-        let result = generate_pyramid(&src, &plan, &sink, &config).unwrap();
+        let result = generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
 
         assert_eq!(result.tiles_produced, plan.total_tile_count());
         assert_eq!(sink.tile_count() as u64, plan.total_tile_count());
@@ -1621,7 +1612,7 @@ mod tests {
         let sink = MemorySink::new();
         let config = EngineConfig::default().with_concurrency(4);
 
-        let result = generate_pyramid(&src, &plan, &sink, &config).unwrap();
+        let result = generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
 
         assert_eq!(result.tiles_produced, plan.total_tile_count());
         assert_eq!(sink.tile_count() as u64, plan.total_tile_count());
@@ -1641,7 +1632,7 @@ mod tests {
         let sink = MemorySink::new();
         let config = EngineConfig::default().with_concurrency(2);
 
-        generate_pyramid(&src, &plan, &sink, &config).unwrap();
+        generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
 
         let tiles = sink.tiles();
         let mut coords: Vec<_> = tiles.iter().map(|t| t.coord).collect();
@@ -1667,7 +1658,7 @@ mod tests {
         let sink = MemorySink::new();
         let config = EngineConfig::default();
 
-        generate_pyramid(&src, &plan, &sink, &config).unwrap();
+        generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
 
         for tile in sink.tiles() {
             let rect = plan.tile_rect(tile.coord).unwrap();
@@ -1696,7 +1687,14 @@ mod tests {
         let plan = planner.plan();
 
         let ref_sink = MemorySink::new();
-        generate_pyramid(&src, &plan, &ref_sink, &EngineConfig::default()).unwrap();
+        generate_pyramid_observed(
+            &src,
+            &plan,
+            &ref_sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .unwrap();
 
         let mut ref_tiles = ref_sink.tiles();
         ref_tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
@@ -1704,7 +1702,7 @@ mod tests {
         for concurrency in [1, 2, 4, 8, 16] {
             let sink = MemorySink::new();
             let config = EngineConfig::default().with_concurrency(concurrency);
-            generate_pyramid(&src, &plan, &sink, &config).unwrap();
+            generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
 
             let mut tiles = sink.tiles();
             tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
@@ -1739,7 +1737,9 @@ mod tests {
         let plan = planner.plan();
         let sink = MemorySink::new();
 
-        let result = generate_pyramid(&src, &plan, &sink, &EngineConfig::default()).unwrap();
+        let result =
+            generate_pyramid_observed(&src, &plan, &sink, &EngineConfig::default(), &NoopObserver)
+                .unwrap();
         assert_eq!(result.levels_processed, plan.level_count() as u32);
     }
 
@@ -1756,7 +1756,9 @@ mod tests {
         let plan = planner.plan();
         let sink = MemorySink::new();
 
-        let result = generate_pyramid(&src, &plan, &sink, &EngineConfig::default()).unwrap();
+        let result =
+            generate_pyramid_observed(&src, &plan, &sink, &EngineConfig::default(), &NoopObserver)
+                .unwrap();
         assert_eq!(result.tiles_produced, plan.level_count() as u64);
     }
 
@@ -1776,7 +1778,7 @@ mod tests {
             .with_concurrency(4)
             .with_buffer_size(1);
 
-        let result = generate_pyramid(&src, &plan, &sink, &config).unwrap();
+        let result = generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
         assert_eq!(result.tiles_produced, plan.total_tile_count());
     }
 
@@ -1832,7 +1834,7 @@ mod tests {
         let sink = MemorySink::new();
         let config = EngineConfig::default();
 
-        generate_pyramid(&src, &plan, &sink, &config).unwrap();
+        generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
 
         for tile in sink.tiles() {
             let rect = plan.tile_rect(tile.coord).unwrap();
@@ -1860,7 +1862,7 @@ mod tests {
             .with_concurrency(4)
             .with_buffer_size(2);
 
-        let result = generate_pyramid(&src, &plan, &sink, &config).unwrap();
+        let result = generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
         assert_eq!(result.tiles_produced, plan.total_tile_count());
         assert_eq!(sink.tile_count() as u64, plan.total_tile_count());
     }
@@ -2002,7 +2004,9 @@ mod tests {
         let plan = planner.plan();
         let sink = MemorySink::new();
 
-        let result = generate_pyramid(&src, &plan, &sink, &EngineConfig::default()).unwrap();
+        let result =
+            generate_pyramid_observed(&src, &plan, &sink, &EngineConfig::default(), &NoopObserver)
+                .unwrap();
 
         // Peak should be at least the source raster size
         let source_bytes = 512 * 512 * 3;
@@ -2028,7 +2032,9 @@ mod tests {
         let plan = planner.plan();
         let sink = MemorySink::new();
 
-        let result = generate_pyramid(&src, &plan, &sink, &EngineConfig::default()).unwrap();
+        let result =
+            generate_pyramid_observed(&src, &plan, &sink, &EngineConfig::default(), &NoopObserver)
+                .unwrap();
 
         let source_bytes = 1024u64 * 1024 * 3;
         // Should be less than 2x source (current level + some overhead)
@@ -2051,7 +2057,7 @@ mod tests {
         let sink = MemorySink::new();
         let config = EngineConfig::default();
 
-        let result = generate_pyramid(&src, &plan, &sink, &config).unwrap();
+        let result = generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
         assert_eq!(result.tiles_produced, plan.total_tile_count());
         assert_eq!(sink.tile_count() as u64, plan.total_tile_count());
     }
@@ -2065,7 +2071,8 @@ mod tests {
         let plan = planner.plan();
         let sink = MemorySink::new();
 
-        generate_pyramid(&src, &plan, &sink, &EngineConfig::default()).unwrap();
+        generate_pyramid_observed(&src, &plan, &sink, &EngineConfig::default(), &NoopObserver)
+            .unwrap();
 
         for tile in sink.tiles() {
             assert_eq!(tile.width, 256, "Width mismatch at {:?}", tile.coord);
@@ -2083,7 +2090,8 @@ mod tests {
         let plan = planner.plan();
         let sink = MemorySink::new();
 
-        generate_pyramid(&src, &plan, &sink, &EngineConfig::default()).unwrap();
+        generate_pyramid_observed(&src, &plan, &sink, &EngineConfig::default(), &NoopObserver)
+            .unwrap();
 
         // Level 0 should have 1 tile (1x1 grid)
         let tiles = sink.tiles();
@@ -2115,7 +2123,14 @@ mod tests {
         let plan = planner.plan();
 
         let ref_sink = MemorySink::new();
-        generate_pyramid(&src, &plan, &ref_sink, &EngineConfig::default()).unwrap();
+        generate_pyramid_observed(
+            &src,
+            &plan,
+            &ref_sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .unwrap();
 
         let mut ref_tiles = ref_sink.tiles();
         ref_tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
@@ -2123,7 +2138,7 @@ mod tests {
         for concurrency in [1, 2, 4] {
             let sink = MemorySink::new();
             let config = EngineConfig::default().with_concurrency(concurrency);
-            generate_pyramid(&src, &plan, &sink, &config).unwrap();
+            generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
 
             let mut tiles = sink.tiles();
             tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
@@ -2147,7 +2162,9 @@ mod tests {
         let plan = planner.plan();
         let sink = MemorySink::new();
 
-        let result = generate_pyramid(&src, &plan, &sink, &EngineConfig::default()).unwrap();
+        let result =
+            generate_pyramid_observed(&src, &plan, &sink, &EngineConfig::default(), &NoopObserver)
+                .unwrap();
         assert_eq!(result.tiles_produced, plan.total_tile_count());
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,7 +6,9 @@ use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
-use crate::observe::{EngineEvent, EngineObserver, MemoryTracker, NoopObserver};
+#[cfg(test)]
+use crate::observe::NoopObserver;
+use crate::observe::{EngineEvent, EngineObserver, MemoryTracker};
 use crate::planner::{PyramidPlan, TileCoord};
 use crate::raster::{Raster, RasterError};
 use crate::resize;
@@ -716,11 +718,12 @@ pub(crate) fn generate_pyramid_resumable(
     sink: &dyn TileSink,
     config: &EngineConfig,
     mode: ResumeMode,
+    observer: &dyn EngineObserver,
 ) -> Result<EngineResult, EngineError> {
     match mode {
-        ResumeMode::Overwrite => run_overwrite(source, plan, sink, config),
-        ResumeMode::Resume => run_resume(source, plan, sink, config),
-        ResumeMode::Verify => run_verify(source, plan, sink, config),
+        ResumeMode::Overwrite => run_overwrite(source, plan, sink, config, observer),
+        ResumeMode::Resume => run_resume(source, plan, sink, config, observer),
+        ResumeMode::Verify => run_verify(source, plan, sink, config, observer),
     }
 }
 
@@ -730,6 +733,7 @@ fn run_overwrite(
     plan: &PyramidPlan,
     sink: &dyn TileSink,
     config: &EngineConfig,
+    observer: &dyn EngineObserver,
 ) -> Result<EngineResult, EngineError> {
     // If the sink exposes an on-disk root, wipe its stale contents so
     // pre-existing garbage (files from an aborted run, a checkpoint with
@@ -740,7 +744,16 @@ fn run_overwrite(
 
     let cp = cp_for_sink(sink, plan, config, Vec::new(), Vec::new());
     let skip = HashSet::new();
-    run_pyramid_with_cp(source, plan, sink, config, cp.as_ref(), &skip, false)
+    run_pyramid_with_cp(
+        source,
+        plan,
+        sink,
+        config,
+        cp.as_ref(),
+        &skip,
+        false,
+        observer,
+    )
 }
 
 /// Resolve the on-disk checkpoint root. Prefers the explicit
@@ -764,6 +777,7 @@ fn run_resume(
     plan: &PyramidPlan,
     sink: &dyn TileSink,
     config: &EngineConfig,
+    observer: &dyn EngineObserver,
 ) -> Result<EngineResult, EngineError> {
     let expected_hash = compute_plan_hash(plan);
 
@@ -791,7 +805,16 @@ fn run_resume(
 
     let skip: HashSet<TileCoord> = existing_completed.iter().copied().collect();
     let cp = cp_for_sink(sink, plan, config, existing_completed, existing_levels);
-    run_pyramid_with_cp(source, plan, sink, config, cp.as_ref(), &skip, true)
+    run_pyramid_with_cp(
+        source,
+        plan,
+        sink,
+        config,
+        cp.as_ref(),
+        &skip,
+        true,
+        observer,
+    )
 }
 
 /// Build a `CheckpointState` rooted at the sink's checkpoint directory, or
@@ -828,6 +851,7 @@ fn cp_for_sink(
 /// meaningful across both modes: a fresh Overwrite returns the total count,
 /// while Resume returns only the count of tiles written on *this* run
 /// (the tests use the difference to assert exactly how much rework happened).
+#[allow(clippy::too_many_arguments)]
 fn run_pyramid_with_cp(
     source: &Raster,
     plan: &PyramidPlan,
@@ -836,9 +860,10 @@ fn run_pyramid_with_cp(
     cp: Option<&CheckpointState>,
     skip: &HashSet<TileCoord>,
     _treat_skip_as_produced: bool,
+    observer: &dyn EngineObserver,
 ) -> Result<EngineResult, EngineError> {
     let skip_ref = if skip.is_empty() { None } else { Some(skip) };
-    run_pyramid(source, plan, sink, config, &NoopObserver, skip_ref, cp)
+    run_pyramid(source, plan, sink, config, observer, skip_ref, cp)
 }
 
 /// Verify-mode branch: walks every tile in the plan, reads the on-disk bytes
@@ -847,12 +872,15 @@ fn run_pyramid_with_cp(
 /// checksums) if the bytes do not match the recorded digest.
 ///
 /// Verify does NOT call `sink.write_tile`; the test suite asserts that
-/// `tiles_produced == 0` and that no files are mutated.
+/// `tiles_produced == 0` and that no files are mutated. Emits
+/// `LevelStarted` / `TileCompleted` / `LevelCompleted` / `Finished`
+/// events so progress observers see verify runs as first-class.
 fn run_verify(
     source: &Raster,
     plan: &PyramidPlan,
     sink: &dyn TileSink,
     config: &EngineConfig,
+    observer: &dyn EngineObserver,
 ) -> Result<EngineResult, EngineError> {
     let started = Instant::now();
     let root_buf =
@@ -950,9 +978,16 @@ fn run_verify(
         if level_idx < top_level {
             current = resize::downscale_half(&current)?;
         }
+        observer.on_event(EngineEvent::LevelStarted {
+            level: level.level,
+            width: level.width,
+            height: level.height,
+            tile_count: level.tile_count(),
+        });
         for row in 0..level.rows {
             for col in 0..level.cols {
                 let coord = TileCoord::new(level_idx as u32, col, row);
+                observer.on_event(EngineEvent::TileCompleted { coord });
                 let expected = extract_tile(&current, plan, coord, bg)?;
                 let expected_bytes = expected.data();
 
@@ -1000,7 +1035,16 @@ fn run_verify(
                 // manifest-checksum branch.
             }
         }
+        observer.on_event(EngineEvent::LevelCompleted {
+            level: level.level,
+            tiles_produced: level.tile_count(),
+        });
     }
+
+    observer.on_event(EngineEvent::Finished {
+        total_tiles: plan.total_tile_count(),
+        levels: plan.levels.len() as u32,
+    });
 
     Ok(EngineResult {
         tiles_produced: 0,
@@ -2166,5 +2210,96 @@ mod tests {
             generate_pyramid_observed(&src, &plan, &sink, &EngineConfig::default(), &NoopObserver)
                 .unwrap();
         assert_eq!(result.tiles_produced, plan.total_tile_count());
+    }
+
+    /// Observer should see LevelStarted / TileCompleted / LevelCompleted /
+    /// Finished events from the resumable path, not just the non-resumable
+    /// one. Runs all three ResumeModes against a CollectingObserver and
+    /// asserts each one drives at least the expected shape of events.
+    #[test]
+    fn resumable_emits_observer_events() {
+        use crate::observe::CollectingObserver;
+        use crate::resume::ResumeMode;
+        use tempfile::tempdir;
+
+        let src = gradient_raster(128, 96);
+        let planner = PyramidPlanner::new(128, 96, 64, 0, Layout::DeepZoom).unwrap();
+        let plan = planner.plan();
+        let dir = tempdir().unwrap();
+        let sink = crate::sink::FsSink::new(dir.path().join("tiles"), plan.clone())
+            .with_format(crate::sink::TileFormat::Raw);
+
+        // --- Overwrite --------------------------------------------------
+        let obs = CollectingObserver::new();
+        generate_pyramid_resumable(
+            &src,
+            &plan,
+            &sink,
+            &EngineConfig::default(),
+            ResumeMode::Overwrite,
+            &obs,
+        )
+        .unwrap();
+        let events = obs.events();
+        let tile_events = events
+            .iter()
+            .filter(|e| matches!(e, EngineEvent::TileCompleted { .. }))
+            .count();
+        let finished = events
+            .iter()
+            .filter(|e| matches!(e, EngineEvent::Finished { .. }))
+            .count();
+        assert_eq!(
+            tile_events as u64,
+            plan.total_tile_count(),
+            "Overwrite: tile events"
+        );
+        assert_eq!(finished, 1, "Overwrite: finished event");
+
+        // --- Resume (no-op since everything is already complete) --------
+        let obs = CollectingObserver::new();
+        generate_pyramid_resumable(
+            &src,
+            &plan,
+            &sink,
+            &EngineConfig::default(),
+            ResumeMode::Resume,
+            &obs,
+        )
+        .unwrap();
+        // Resume with a full checkpoint short-circuits without per-tile
+        // work, so we only require the engine to have produced *some*
+        // observer activity (the Finished event at minimum).
+        assert!(
+            !obs.events().is_empty(),
+            "Resume mode produced no observer events"
+        );
+
+        // --- Verify -----------------------------------------------------
+        let obs = CollectingObserver::new();
+        generate_pyramid_resumable(
+            &src,
+            &plan,
+            &sink,
+            &EngineConfig::default(),
+            ResumeMode::Verify,
+            &obs,
+        )
+        .unwrap();
+        let events = obs.events();
+        let tile_events = events
+            .iter()
+            .filter(|e| matches!(e, EngineEvent::TileCompleted { .. }))
+            .count();
+        let finished = events
+            .iter()
+            .filter(|e| matches!(e, EngineEvent::Finished { .. }))
+            .count();
+        assert_eq!(
+            tile_events as u64,
+            plan.total_tile_count(),
+            "Verify: tile events"
+        );
+        assert_eq!(finished, 1, "Verify: finished event");
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -56,6 +56,20 @@ pub enum EngineError {
     VerifyRequiresOnDiskSink,
     #[error("budget exceeded: worst-case strip {strip_bytes} bytes > budget {budget_bytes} bytes")]
     BudgetExceeded { strip_bytes: u64, budget_bytes: u64 },
+    /// The [`EngineKind`](crate::EngineKind) requested through
+    /// [`EngineBuilder::with_engine`](crate::EngineBuilder::with_engine) is
+    /// not compatible with the supplied source. For example,
+    /// [`EngineKind::Monolithic`](crate::EngineKind::Monolithic) requires an
+    /// in-memory [`Raster`]; pairing it with a [`StripSource`](crate::streaming::StripSource)
+    /// would require materialising the entire source up front, which is
+    /// exactly what a strip source is built to avoid. The builder surfaces
+    /// this condition as a typed error instead of silently pulling the
+    /// source into memory.
+    #[error("engine kind {kind:?} incompatible with supplied source: {reason}")]
+    IncompatibleSource {
+        kind: crate::EngineKind,
+        reason: &'static str,
+    },
 }
 
 /// Controls how blank (uniform-color) tiles are handled during pyramid generation.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -12,9 +12,7 @@ use crate::observe::{EngineEvent, EngineObserver, MemoryTracker};
 use crate::planner::{PyramidPlan, TileCoord};
 use crate::raster::{Raster, RasterError};
 use crate::resize;
-use crate::resume::{
-    JobCheckpoint, JobMetadata, ResumeError, ResumeMode, SCHEMA_VERSION, compute_plan_hash,
-};
+use crate::resume::{JobCheckpoint, JobMetadata, ResumeError, SCHEMA_VERSION, compute_plan_hash};
 use crate::retry::FailurePolicy;
 use crate::sink::{SinkError, Tile, TileSink};
 
@@ -696,66 +694,6 @@ fn parse_tile_rel_path(rel: &str) -> Option<TileCoord> {
     }
 }
 
-/// Resumable pyramid generation.
-///
-/// Runs `generate_pyramid` under one of three on-disk-state regimes:
-///
-/// * [`ResumeMode::Overwrite`] — wipe any stale contents of the sink's root
-///   directory (`sink.checkpoint_root()`), then generate the pyramid from
-///   scratch, writing a fresh checkpoint on every `config.checkpoint_every`
-///   tiles and one final flush at the end.
-/// * [`ResumeMode::Resume`] — load the existing `.libviprs-job.json`, verify
-///   its `plan_hash` against the current plan (bails with
-///   [`EngineError::PlanHashMismatch`] if they disagree), then generate only
-///   the tiles that are not yet recorded as complete.
-/// * [`ResumeMode::Verify`] — do not write anything to the sink. Walk every
-///   tile in the plan, read the on-disk bytes, and return an error if a
-///   tile is missing or (when the manifest includes checksums) if its bytes
-///   hash to something other than the recorded digest.
-pub(crate) fn generate_pyramid_resumable(
-    source: &Raster,
-    plan: &PyramidPlan,
-    sink: &dyn TileSink,
-    config: &EngineConfig,
-    mode: ResumeMode,
-    observer: &dyn EngineObserver,
-) -> Result<EngineResult, EngineError> {
-    match mode {
-        ResumeMode::Overwrite => run_overwrite(source, plan, sink, config, observer),
-        ResumeMode::Resume => run_resume(source, plan, sink, config, observer),
-        ResumeMode::Verify => run_verify(source, plan, sink, config, observer),
-    }
-}
-
-/// Start-from-scratch branch of [`generate_pyramid_resumable`].
-fn run_overwrite(
-    source: &Raster,
-    plan: &PyramidPlan,
-    sink: &dyn TileSink,
-    config: &EngineConfig,
-    observer: &dyn EngineObserver,
-) -> Result<EngineResult, EngineError> {
-    // If the sink exposes an on-disk root, wipe its stale contents so
-    // pre-existing garbage (files from an aborted run, a checkpoint with
-    // the wrong plan_hash, etc.) does not survive into the new run.
-    if let Some(root) = resolve_checkpoint_root(config, sink) {
-        wipe_directory(&root).map_err(|e| EngineError::ResumeFailed(ResumeError::from(e)))?;
-    }
-
-    let cp = cp_for_sink(sink, plan, config, Vec::new(), Vec::new());
-    let skip = HashSet::new();
-    run_pyramid_with_cp(
-        source,
-        plan,
-        sink,
-        config,
-        cp.as_ref(),
-        &skip,
-        false,
-        observer,
-    )
-}
-
 /// Resolve the on-disk checkpoint root. Prefers the explicit
 /// [`EngineConfig::checkpoint_root`] when set; otherwise consults
 /// [`TileSink::checkpoint_root`]. Returns `None` when neither is available
@@ -769,52 +707,6 @@ pub(crate) fn resolve_checkpoint_root(cfg: &EngineConfig, sink: &dyn TileSink) -
     cfg.checkpoint_root
         .clone()
         .or_else(|| sink.checkpoint_root().map(|p| p.to_path_buf()))
-}
-
-/// Resume-from-checkpoint branch of [`generate_pyramid_resumable`].
-fn run_resume(
-    source: &Raster,
-    plan: &PyramidPlan,
-    sink: &dyn TileSink,
-    config: &EngineConfig,
-    observer: &dyn EngineObserver,
-) -> Result<EngineResult, EngineError> {
-    let expected_hash = compute_plan_hash(plan);
-
-    let (existing_completed, existing_levels) =
-        if let Some(root) = resolve_checkpoint_root(config, sink) {
-            // `JobCheckpoint::load` returns `Result<Option<_>, ResumeError>`:
-            // `?` surfaces real corruption as an engine error (via
-            // `EngineError::ResumeFailed`) rather than silently degrading
-            // to "no checkpoint". A missing file is still `Ok(None)`.
-            match JobCheckpoint::load(&root)? {
-                Some(meta) => {
-                    if meta.plan_hash != expected_hash {
-                        return Err(EngineError::PlanHashMismatch {
-                            expected: meta.plan_hash.clone(),
-                            got: expected_hash,
-                        });
-                    }
-                    (meta.completed_tiles, meta.levels_completed)
-                }
-                None => (Vec::new(), Vec::new()),
-            }
-        } else {
-            (Vec::new(), Vec::new())
-        };
-
-    let skip: HashSet<TileCoord> = existing_completed.iter().copied().collect();
-    let cp = cp_for_sink(sink, plan, config, existing_completed, existing_levels);
-    run_pyramid_with_cp(
-        source,
-        plan,
-        sink,
-        config,
-        cp.as_ref(),
-        &skip,
-        true,
-        observer,
-    )
 }
 
 /// Build a `CheckpointState` rooted at the sink's checkpoint directory, or
@@ -845,37 +737,19 @@ pub(crate) fn cp_for_sink(
     ))
 }
 
-/// Common pyramid-run body used by both `Overwrite` and `Resume`.
+/// Verify mode for the monolithic raster path: walks every tile in the
+/// plan, reads the on-disk bytes via `sink.checkpoint_root()` joined with
+/// the plan's tile path, and returns an error if any tile is missing or
+/// (when the manifest records checksums) if the bytes do not match the
+/// recorded digest.
 ///
-/// The `treat_skip_as_produced` flag keeps [`EngineResult::tiles_produced`]
-/// meaningful across both modes: a fresh Overwrite returns the total count,
-/// while Resume returns only the count of tiles written on *this* run
-/// (the tests use the difference to assert exactly how much rework happened).
-#[allow(clippy::too_many_arguments)]
-fn run_pyramid_with_cp(
-    source: &Raster,
-    plan: &PyramidPlan,
-    sink: &dyn TileSink,
-    config: &EngineConfig,
-    cp: Option<&CheckpointState>,
-    skip: &HashSet<TileCoord>,
-    _treat_skip_as_produced: bool,
-    observer: &dyn EngineObserver,
-) -> Result<EngineResult, EngineError> {
-    let skip_ref = if skip.is_empty() { None } else { Some(skip) };
-    run_pyramid(source, plan, sink, config, observer, skip_ref, cp)
-}
-
-/// Verify-mode branch: walks every tile in the plan, reads the on-disk bytes
-/// via `sink.checkpoint_root()` joined with the plan's tile path, and
-/// returns an error if any tile is missing or (when the manifest records
-/// checksums) if the bytes do not match the recorded digest.
-///
-/// Verify does NOT call `sink.write_tile`; the test suite asserts that
+/// Does NOT call `sink.write_tile`; the test suite asserts that
 /// `tiles_produced == 0` and that no files are mutated. Emits
 /// `LevelStarted` / `TileCompleted` / `LevelCompleted` / `Finished`
 /// events so progress observers see verify runs as first-class.
-fn run_verify(
+///
+/// Strip-source equivalents live in [`crate::stream_verify`].
+pub(crate) fn raster_verify(
     source: &Raster,
     plan: &PyramidPlan,
     sink: &dyn TileSink,
@@ -886,6 +760,20 @@ fn run_verify(
     let root_buf =
         resolve_checkpoint_root(config, sink).ok_or(EngineError::VerifyRequiresOnDiskSink)?;
     let root = root_buf.as_path();
+
+    // If a checkpoint exists, its `plan_hash` must match the plan we're
+    // verifying against — otherwise we'd walk every tile just to report a
+    // byte mismatch on the first one, which is strictly less useful than
+    // failing fast with the structural error.
+    if let Some(meta) = JobCheckpoint::load(root)? {
+        let expected = compute_plan_hash(plan);
+        if meta.plan_hash != expected {
+            return Err(EngineError::PlanHashMismatch {
+                expected: meta.plan_hash,
+                got: expected,
+            });
+        }
+    }
 
     // Try every known tile-file extension until we find one that matches.
     // The sink's active format isn't visible from this layer, so we probe
@@ -2213,13 +2101,17 @@ mod tests {
     }
 
     /// Observer should see LevelStarted / TileCompleted / LevelCompleted /
-    /// Finished events from the resumable path, not just the non-resumable
-    /// one. Runs all three ResumeModes against a CollectingObserver and
-    /// asserts each one drives at least the expected shape of events.
+    /// Finished events from every resume path, not just the non-resumable
+    /// one. Runs all three ResumeModes via `EngineBuilder::with_resume`
+    /// against a CollectingObserver and asserts each one drives at least
+    /// the expected shape of events.
     #[test]
     fn resumable_emits_observer_events() {
+        use std::sync::Arc;
+
         use crate::observe::CollectingObserver;
-        use crate::resume::ResumeMode;
+        use crate::resume::ResumePolicy;
+        use crate::{EngineBuilder, EngineKind};
         use tempfile::tempdir;
 
         let src = gradient_raster(128, 96);
@@ -2230,16 +2122,13 @@ mod tests {
             .with_format(crate::sink::TileFormat::Raw);
 
         // --- Overwrite --------------------------------------------------
-        let obs = CollectingObserver::new();
-        generate_pyramid_resumable(
-            &src,
-            &plan,
-            &sink,
-            &EngineConfig::default(),
-            ResumeMode::Overwrite,
-            &obs,
-        )
-        .unwrap();
+        let obs = Arc::new(CollectingObserver::new());
+        EngineBuilder::new(&src, plan.clone(), &sink)
+            .with_engine(EngineKind::Monolithic)
+            .with_resume(ResumePolicy::overwrite())
+            .with_observer_arc(obs.clone())
+            .run()
+            .unwrap();
         let events = obs.events();
         let tile_events = events
             .iter()
@@ -2257,16 +2146,13 @@ mod tests {
         assert_eq!(finished, 1, "Overwrite: finished event");
 
         // --- Resume (no-op since everything is already complete) --------
-        let obs = CollectingObserver::new();
-        generate_pyramid_resumable(
-            &src,
-            &plan,
-            &sink,
-            &EngineConfig::default(),
-            ResumeMode::Resume,
-            &obs,
-        )
-        .unwrap();
+        let obs = Arc::new(CollectingObserver::new());
+        EngineBuilder::new(&src, plan.clone(), &sink)
+            .with_engine(EngineKind::Monolithic)
+            .with_resume(ResumePolicy::resume())
+            .with_observer_arc(obs.clone())
+            .run()
+            .unwrap();
         // Resume with a full checkpoint short-circuits without per-tile
         // work, so we only require the engine to have produced *some*
         // observer activity (the Finished event at minimum).
@@ -2276,16 +2162,13 @@ mod tests {
         );
 
         // --- Verify -----------------------------------------------------
-        let obs = CollectingObserver::new();
-        generate_pyramid_resumable(
-            &src,
-            &plan,
-            &sink,
-            &EngineConfig::default(),
-            ResumeMode::Verify,
-            &obs,
-        )
-        .unwrap();
+        let obs = Arc::new(CollectingObserver::new());
+        EngineBuilder::new(&src, plan.clone(), &sink)
+            .with_engine(EngineKind::Monolithic)
+            .with_resume(ResumePolicy::verify())
+            .with_observer_arc(obs.clone())
+            .run()
+            .unwrap();
         let events = obs.events();
         let tile_events = events
             .iter()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -710,7 +710,7 @@ fn parse_tile_rel_path(rel: &str) -> Option<TileCoord> {
 ///   tile in the plan, read the on-disk bytes, and return an error if a
 ///   tile is missing or (when the manifest includes checksums) if its bytes
 ///   hash to something other than the recorded digest.
-pub fn generate_pyramid_resumable(
+pub(crate) fn generate_pyramid_resumable(
     source: &Raster,
     plan: &PyramidPlan,
     sink: &dyn TileSink,

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -32,7 +32,7 @@ use crate::extensions::Extensions;
 use crate::observe::{EngineObserver, NoopObserver};
 use crate::planner::PyramidPlan;
 use crate::raster::Raster;
-use crate::resume::ResumePolicy;
+use crate::resume::{ResumeMode, ResumePolicy};
 use crate::retry::{FailurePolicy, RetryPolicy};
 use crate::sink::TileSink;
 use crate::streaming::{
@@ -396,41 +396,116 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 
         let kind = resolve_engine_kind(engine_kind, &source);
 
-        // Resume path: dispatch to generate_pyramid_resumable when a
-        // ResumePolicy is set. Only Monolithic + Raster is supported today
-        // — streaming and map-reduce resume land in a follow-up.
+        // Resume path: route through the resumable engine (Monolithic) or
+        // wrap the sink in a resume-aware filter (Streaming / MapReduce).
+        // Verify mode still requires a Raster source — the verify loop
+        // regenerates every level via downscale_half, which needs the full
+        // source raster in memory.
         if let Some(policy) = resume {
-            if !matches!(kind, EngineKind::Monolithic) {
-                return Err(EngineError::IncompatibleSource {
-                    kind,
-                    reason: "ResumePolicy requires EngineKind::Monolithic (or Auto with a Raster source); streaming / map-reduce resume is not yet supported",
-                });
-            }
-            let raster = match source {
-                EngineSource::Raster(r) => r,
-                EngineSource::Strip(_) => {
-                    return Err(EngineError::IncompatibleSource {
-                        kind,
-                        reason: "ResumePolicy requires an in-memory Raster source",
-                    });
-                }
-            };
             // Thread checkpoint frequency and root from the ResumePolicy
-            // into the EngineConfig that generate_pyramid_resumable reads.
+            // into the EngineConfig that the inner path reads.
             if policy.checkpoint_every() > 0 {
                 engine_cfg = engine_cfg.with_checkpoint_every(policy.checkpoint_every());
             }
             if let Some(root) = policy.checkpoint_root() {
                 engine_cfg = engine_cfg.with_checkpoint_root(root.to_path_buf());
             }
-            let result = crate::engine::generate_pyramid_resumable(
-                raster,
-                &plan,
-                &sink,
-                &engine_cfg,
-                policy.mode(),
-                observer_ref,
-            )?;
+
+            // Monolithic + Raster — existing resumable engine handles wipe,
+            // skip-set load, checkpoint state, and verify.
+            if matches!(kind, EngineKind::Monolithic) {
+                let raster = match source {
+                    EngineSource::Raster(r) => r,
+                    EngineSource::Strip(_) => {
+                        return Err(EngineError::IncompatibleSource {
+                            kind,
+                            reason: "ResumePolicy requires an in-memory Raster source for the Monolithic engine",
+                        });
+                    }
+                };
+                let result = crate::engine::generate_pyramid_resumable(
+                    raster,
+                    &plan,
+                    &sink,
+                    &engine_cfg,
+                    policy.mode(),
+                    observer_ref,
+                )?;
+                return Ok((result, sink));
+            }
+
+            // Verify with a streaming engine requires regenerating every
+            // level via downscale_half — that needs the full raster, which
+            // is exactly what a strip source is built to avoid. Stream
+            // sources can't cheaply satisfy Verify, so we reject it
+            // explicitly and steer the caller to Monolithic.
+            if matches!(policy.mode(), ResumeMode::Verify) {
+                return Err(EngineError::IncompatibleSource {
+                    kind,
+                    reason: "ResumePolicy::verify() requires EngineKind::Monolithic (verify walks every level from the source raster); use Monolithic for Verify runs",
+                });
+            }
+
+            // Streaming / MapReduce + Overwrite or Resume.
+            // Pattern:
+            //   1. Optionally wipe the output (Overwrite) or load the
+            //      checkpoint (Resume) to get the skip set.
+            //   2. Construct a CheckpointState rooted at the sink.
+            //   3. Wrap the user sink in a resume-aware filter that
+            //      short-circuits write_tile for already-completed coords
+            //      and advances the checkpoint for every real write.
+            //   4. Run the streaming / map-reduce engine against the
+            //      wrapped sink.
+            //   5. Flush the checkpoint on success.
+            let (skip, cp) = prepare_resume_state(&sink, &plan, &engine_cfg, policy.mode())?;
+            let wrapped = resume::ResumeAwareSink {
+                inner: &sink,
+                skip: &skip,
+                cp: cp.as_ref(),
+            };
+            let result = match (kind, source) {
+                (EngineKind::Streaming, EngineSource::Raster(raster)) => {
+                    let strip = RasterStripSource::new(raster);
+                    let cfg =
+                        build_streaming_config(engine_cfg, memory_budget_bytes, budget_policy);
+                    generate_pyramid_streaming(&strip, &plan, &wrapped, &cfg, observer_ref)?
+                }
+                (EngineKind::Streaming, EngineSource::Strip(strip)) => {
+                    let cfg =
+                        build_streaming_config(engine_cfg, memory_budget_bytes, budget_policy);
+                    generate_pyramid_streaming(strip.as_ref(), &plan, &wrapped, &cfg, observer_ref)?
+                }
+                (EngineKind::MapReduce, EngineSource::Raster(raster)) => {
+                    let strip = RasterStripSource::new(raster);
+                    let cfg = build_mapreduce_config(
+                        memory_budget_bytes,
+                        concurrency,
+                        buffer_size,
+                        background_rgb,
+                        blank_strategy,
+                    );
+                    generate_pyramid_mapreduce(&strip, &plan, &wrapped, &cfg, observer_ref)?
+                }
+                (EngineKind::MapReduce, EngineSource::Strip(strip)) => {
+                    let cfg = build_mapreduce_config(
+                        memory_budget_bytes,
+                        concurrency,
+                        buffer_size,
+                        background_rgb,
+                        blank_strategy,
+                    );
+                    generate_pyramid_mapreduce(strip.as_ref(), &plan, &wrapped, &cfg, observer_ref)?
+                }
+                (EngineKind::Auto, _) => {
+                    unreachable!("Auto should have been resolved before match")
+                }
+                (EngineKind::Monolithic, _) => {
+                    unreachable!("Monolithic + resume handled in the branch above")
+                }
+            };
+            if let Some(cp) = cp.as_ref() {
+                cp.flush().map_err(EngineError::ResumeFailed)?;
+            }
             return Ok((result, sink));
         }
 
@@ -572,4 +647,139 @@ fn resolve_engine_kind(kind: EngineKind, source: &EngineSource<'_>) -> EngineKin
         (EngineKind::Auto, EngineSource::Strip(_)) => EngineKind::Streaming,
         (k, _) => k,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Resume support for streaming / map-reduce engines
+// ---------------------------------------------------------------------------
+
+/// Prepare the (skip_set, checkpoint_state) pair for a streaming or
+/// map-reduce resume run. Matches the Monolithic engine's Overwrite /
+/// Resume behaviour:
+///
+/// - [`ResumeMode::Overwrite`] — wipe the output root and start with an
+///   empty skip set and a fresh checkpoint state.
+/// - [`ResumeMode::Resume`] — load the existing checkpoint (if any) and
+///   build the skip set from its `completed_tiles`. Surfaces
+///   [`EngineError::PlanHashMismatch`] when the on-disk checkpoint was
+///   produced from a different plan.
+fn prepare_resume_state(
+    sink: &dyn TileSink,
+    plan: &PyramidPlan,
+    config: &EngineConfig,
+    mode: ResumeMode,
+) -> Result<
+    (
+        std::collections::HashSet<crate::planner::TileCoord>,
+        Option<crate::engine::CheckpointState>,
+    ),
+    EngineError,
+> {
+    match mode {
+        ResumeMode::Overwrite => {
+            if let Some(root) = crate::engine::resolve_checkpoint_root(config, sink) {
+                crate::engine::wipe_directory(&root)
+                    .map_err(|e| EngineError::ResumeFailed(crate::resume::ResumeError::from(e)))?;
+            }
+            let cp = crate::engine::cp_for_sink(sink, plan, config, Vec::new(), Vec::new());
+            Ok((std::collections::HashSet::new(), cp))
+        }
+        ResumeMode::Resume => {
+            let expected_hash = crate::resume::compute_plan_hash(plan);
+            let (completed, levels) =
+                if let Some(root) = crate::engine::resolve_checkpoint_root(config, sink) {
+                    match crate::resume::JobCheckpoint::load(&root)? {
+                        Some(meta) => {
+                            if meta.plan_hash != expected_hash {
+                                return Err(EngineError::PlanHashMismatch {
+                                    expected: meta.plan_hash.clone(),
+                                    got: expected_hash,
+                                });
+                            }
+                            (meta.completed_tiles, meta.levels_completed)
+                        }
+                        None => (Vec::new(), Vec::new()),
+                    }
+                } else {
+                    (Vec::new(), Vec::new())
+                };
+            let skip: std::collections::HashSet<crate::planner::TileCoord> =
+                completed.iter().copied().collect();
+            let cp = crate::engine::cp_for_sink(sink, plan, config, completed, levels);
+            Ok((skip, cp))
+        }
+        ResumeMode::Verify => unreachable!("Verify is rejected above for non-Monolithic engines"),
+    }
+}
+
+mod resume {
+    use std::collections::HashSet;
+    use std::path::Path;
+    use std::sync::atomic::AtomicU64;
+
+    use crate::engine::{CheckpointState, EngineConfig};
+    use crate::planner::TileCoord;
+    use crate::sink::{SinkError, Tile, TileSink};
+
+    /// Transparent wrapper that filters `write_tile` calls against a resume
+    /// skip set and advances an optional [`CheckpointState`] on every tile
+    /// that reaches the inner sink.
+    ///
+    /// Applied in front of the user-provided sink when the streaming or
+    /// map-reduce engines are asked to run in resume mode. Keeps those
+    /// engines themselves oblivious to resume semantics — the filtering
+    /// happens at the one natural bottleneck (every tile ultimately lands
+    /// in `write_tile`).
+    pub(super) struct ResumeAwareSink<'a, S: TileSink + ?Sized> {
+        pub(super) inner: &'a S,
+        pub(super) skip: &'a HashSet<TileCoord>,
+        pub(super) cp: Option<&'a CheckpointState>,
+    }
+
+    impl<'a, S: TileSink + ?Sized> TileSink for ResumeAwareSink<'a, S> {
+        fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+            if self.skip.contains(&tile.coord) {
+                return Ok(());
+            }
+            self.inner.write_tile(tile)?;
+            if let Some(cp) = self.cp {
+                cp.mark_tile_completed(tile.coord)
+                    .map_err(|e| SinkError::Other(format!("checkpoint: {e}")))?;
+            }
+            Ok(())
+        }
+
+        fn finish(&self) -> Result<(), SinkError> {
+            self.inner.finish()
+        }
+
+        fn record_engine_config(&self, config: &EngineConfig) {
+            self.inner.record_engine_config(config)
+        }
+
+        fn sink_retry_count(&self) -> u64 {
+            self.inner.sink_retry_count()
+        }
+
+        fn sink_skipped_due_to_failure(&self) -> u64 {
+            self.inner.sink_skipped_due_to_failure()
+        }
+
+        fn note_sink_skipped(&self) {
+            self.inner.note_sink_skipped()
+        }
+
+        fn checkpoint_root(&self) -> Option<&Path> {
+            self.inner.checkpoint_root()
+        }
+
+        fn init_level_count(&self, levels: usize) {
+            self.inner.init_level_count(levels)
+        }
+    }
+
+    // Silence "field never read" lints on the AtomicU64 placeholder if
+    // future refactors drop these fields.
+    #[allow(dead_code)]
+    fn _unused_marker(_: AtomicU64) {}
 }

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -1,0 +1,496 @@
+//! Unified fluent entry point for pyramid generation.
+//!
+//! [`EngineBuilder`] collapses the five free-function entry points
+//! ([`generate_pyramid`](crate::generate_pyramid),
+//! [`generate_pyramid_observed`](crate::generate_pyramid_observed),
+//! [`generate_pyramid_streaming`](crate::generate_pyramid_streaming),
+//! [`generate_pyramid_mapreduce`](crate::generate_pyramid_mapreduce),
+//! [`generate_pyramid_mapreduce_auto`](crate::generate_pyramid_mapreduce_auto))
+//! behind a single typed builder. Call
+//! [`EngineBuilder::new(source, plan, sink)`](EngineBuilder::new), chain any
+//! combination of `with_*` setters, then [`EngineBuilder::run`] or
+//! [`EngineBuilder::run_collect`].
+//!
+//! Routing to the underlying engine is driven by two inputs:
+//!
+//! 1. The [`EngineKind`] set via [`EngineBuilder::with_engine`]
+//!    (default: [`EngineKind::Auto`]).
+//! 2. Whether the source is an in-memory [`Raster`] or a
+//!    [`StripSource`](crate::streaming::StripSource).
+//!
+//! [`EngineKind::Monolithic`] refuses to run against a strip source and
+//! surfaces [`EngineError::IncompatibleSource`] instead of silently pulling
+//! the whole source into memory.
+
+use std::sync::Arc;
+
+use crate::dedupe::DedupeStrategy;
+use crate::engine::{
+    BlankTileStrategy, EngineConfig, EngineError, EngineResult, generate_pyramid_observed,
+};
+use crate::extensions::Extensions;
+use crate::observe::{EngineObserver, NoopObserver};
+use crate::planner::PyramidPlan;
+use crate::raster::Raster;
+use crate::resume::ResumePolicy;
+use crate::retry::{FailurePolicy, RetryPolicy};
+use crate::sink::TileSink;
+use crate::streaming::{
+    BudgetPolicy, RasterStripSource, StreamingConfig, StripSource, generate_pyramid_streaming,
+};
+use crate::streaming_mapreduce::{MapReduceConfig, generate_pyramid_mapreduce};
+
+// ---------------------------------------------------------------------------
+// EngineKind
+// ---------------------------------------------------------------------------
+
+/// Which underlying engine implementation [`EngineBuilder::run`] should
+/// dispatch to.
+///
+/// `#[non_exhaustive]` so future engine variants (e.g. `Gpu`, `Distributed`,
+/// `Remote`) can be added as minor-version additions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum EngineKind {
+    /// Pick an engine based on the source and memory budget. The default.
+    #[default]
+    Auto,
+    /// In-memory monolithic engine. Requires an [`EngineSource::Raster`]
+    /// source; a [`EngineSource::Strip`] source errors with
+    /// [`EngineError::IncompatibleSource`].
+    Monolithic,
+    /// Sequential streaming engine. Accepts either source kind; in-memory
+    /// rasters are wrapped in a [`RasterStripSource`] automatically.
+    Streaming,
+    /// Parallel map-reduce streaming engine. Accepts either source kind.
+    MapReduce,
+}
+
+// ---------------------------------------------------------------------------
+// EngineSource + IntoEngineSource
+// ---------------------------------------------------------------------------
+
+/// Input source for [`EngineBuilder`].
+///
+/// Callers typically construct this implicitly via
+/// [`EngineBuilder::new`]'s `impl IntoEngineSource<'a>` argument — passing a
+/// `&Raster` or any `T: StripSource` is enough.
+pub enum EngineSource<'a> {
+    /// In-memory raster, passed by reference.
+    Raster(&'a Raster),
+    /// Pull-based strip source, type-erased behind a trait object.
+    Strip(Box<dyn StripSource + 'a>),
+}
+
+impl<'a> std::fmt::Debug for EngineSource<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Raster(_) => f.debug_tuple("EngineSource::Raster").finish(),
+            Self::Strip(_) => f.debug_tuple("EngineSource::Strip").finish(),
+        }
+    }
+}
+
+/// Conversion into an [`EngineSource`]. Implemented for `&Raster` and for
+/// every `T: StripSource`, so [`EngineBuilder::new`] accepts either kind
+/// of source without explicit wrapping.
+pub trait IntoEngineSource<'a> {
+    fn into_engine_source(self) -> EngineSource<'a>;
+}
+
+impl<'a> IntoEngineSource<'a> for &'a Raster {
+    fn into_engine_source(self) -> EngineSource<'a> {
+        EngineSource::Raster(self)
+    }
+}
+
+impl<'a, T> IntoEngineSource<'a> for T
+where
+    T: StripSource + 'a,
+{
+    fn into_engine_source(self) -> EngineSource<'a> {
+        EngineSource::Strip(Box::new(self))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EngineBuilder
+// ---------------------------------------------------------------------------
+
+/// Fluent entry point for pyramid generation.
+///
+/// Generic over the sink type so `.run()` is monomorphic for single-sink
+/// callers; use `EngineBuilder<'a, Box<dyn TileSink>>` when different match
+/// arms need to return different concrete sinks.
+pub struct EngineBuilder<'a, S: TileSink> {
+    source: EngineSource<'a>,
+    plan: PyramidPlan,
+    sink: S,
+
+    engine_kind: EngineKind,
+    observer: Option<Arc<dyn EngineObserver>>,
+
+    // EngineConfig knobs
+    concurrency: Option<usize>,
+    buffer_size: Option<usize>,
+    background_rgb: Option<[u8; 3]>,
+    blank_strategy: Option<BlankTileStrategy>,
+    failure_policy: Option<FailurePolicy>,
+    dedupe: Option<DedupeStrategy>,
+
+    // Resume
+    resume: Option<ResumePolicy>,
+
+    // StreamingConfig knobs
+    memory_budget_bytes: Option<u64>,
+    budget_policy: Option<BudgetPolicy>,
+
+    // Extension hatch (Approach C)
+    extensions: Extensions,
+}
+
+impl<'a, S: TileSink> std::fmt::Debug for EngineBuilder<'a, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EngineBuilder")
+            .field("source", &self.source)
+            .field("engine_kind", &self.engine_kind)
+            .field("concurrency", &self.concurrency)
+            .field("buffer_size", &self.buffer_size)
+            .field("background_rgb", &self.background_rgb)
+            .field("blank_strategy", &self.blank_strategy)
+            .field("failure_policy", &self.failure_policy)
+            .field("dedupe", &self.dedupe)
+            .field("resume", &self.resume)
+            .field("memory_budget_bytes", &self.memory_budget_bytes)
+            .field("budget_policy", &self.budget_policy)
+            .field("extensions", &self.extensions)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a, S: TileSink> EngineBuilder<'a, S> {
+    /// Start a builder rooted at the given source, plan, and sink.
+    pub fn new(source: impl IntoEngineSource<'a>, plan: PyramidPlan, sink: S) -> Self {
+        Self {
+            source: source.into_engine_source(),
+            plan,
+            sink,
+            engine_kind: EngineKind::Auto,
+            observer: None,
+            concurrency: None,
+            buffer_size: None,
+            background_rgb: None,
+            blank_strategy: None,
+            failure_policy: None,
+            dedupe: None,
+            resume: None,
+            memory_budget_bytes: None,
+            budget_policy: None,
+            extensions: Extensions::new(),
+        }
+    }
+
+    // --- typed setters (Approach A) ---
+
+    /// Attach an observer receiving every [`EngineEvent`](crate::EngineEvent).
+    pub fn with_observer(mut self, observer: impl EngineObserver + 'static) -> Self {
+        self.observer = Some(Arc::new(observer));
+        self
+    }
+
+    /// Attach a pre-boxed observer. Useful when the observer is already
+    /// shared between callers or is `Arc<dyn EngineObserver>`-shaped at the
+    /// call site.
+    pub fn with_observer_arc(mut self, observer: Arc<dyn EngineObserver>) -> Self {
+        self.observer = Some(observer);
+        self
+    }
+
+    /// Select which engine implementation [`EngineBuilder::run`] will
+    /// dispatch to. Defaults to [`EngineKind::Auto`].
+    pub fn with_engine(mut self, kind: EngineKind) -> Self {
+        self.engine_kind = kind;
+        self
+    }
+
+    /// Set the [`FailurePolicy`] the engine consults when a tile write
+    /// terminally fails. Overrides any earlier [`EngineBuilder::with_retry`]
+    /// call.
+    pub fn with_failure_policy(mut self, policy: FailurePolicy) -> Self {
+        self.failure_policy = Some(policy);
+        self
+    }
+
+    /// Shorthand for `with_failure_policy(FailurePolicy::RetryThenFail(policy))`.
+    pub fn with_retry(self, policy: RetryPolicy) -> Self {
+        self.with_failure_policy(FailurePolicy::RetryThenFail(policy))
+    }
+
+    /// Control resume / verify behaviour. Only the engine's resumable path
+    /// consults this; see [`ResumePolicy`] for the mode selector and the
+    /// checkpoint-persistence knobs.
+    pub fn with_resume(mut self, policy: ResumePolicy) -> Self {
+        self.resume = Some(policy);
+        self
+    }
+
+    /// Select a content-addressed deduplication strategy. See
+    /// [`DedupeStrategy`] for variants.
+    pub fn with_dedupe(mut self, strategy: DedupeStrategy) -> Self {
+        self.dedupe = Some(strategy);
+        self
+    }
+
+    /// Control how blank (uniform-colour) tiles are handled.
+    pub fn with_blank_strategy(mut self, strategy: BlankTileStrategy) -> Self {
+        self.blank_strategy = Some(strategy);
+        self
+    }
+
+    /// Set the background RGB used to pad edge tiles.
+    pub fn with_background_rgb(mut self, rgb: [u8; 3]) -> Self {
+        self.background_rgb = Some(rgb);
+        self
+    }
+
+    /// Worker-thread concurrency (0 = single-threaded on the caller's thread).
+    pub fn with_concurrency(mut self, n: usize) -> Self {
+        self.concurrency = Some(n);
+        self
+    }
+
+    /// Capacity of the producer→sink bounded channel.
+    pub fn with_buffer_size(mut self, n: usize) -> Self {
+        self.buffer_size = Some(n);
+        self
+    }
+
+    /// Soft memory budget in bytes. Drives strip-height selection in the
+    /// streaming and map-reduce engines.
+    pub fn with_memory_budget(mut self, bytes: u64) -> Self {
+        self.memory_budget_bytes = Some(bytes);
+        self
+    }
+
+    /// Decide what happens when the requested budget is too tight for the
+    /// worst-case minimum aligned strip.
+    pub fn with_budget_policy(mut self, policy: BudgetPolicy) -> Self {
+        self.budget_policy = Some(policy);
+        self
+    }
+
+    // --- extension hatch (Approach C) ---
+
+    /// Attach a user-defined extension keyed by its runtime `TypeId`.
+    ///
+    /// libviprs itself reads zero extensions today; the hatch exists so
+    /// third-party consumers (metrics exporters, custom audit logs, bespoke
+    /// observer state) can thread context through the pipeline without a
+    /// semver bump.
+    pub fn with_extension<T: Send + Sync + 'static>(mut self, value: T) -> Self {
+        self.extensions.insert(value);
+        self
+    }
+
+    /// Borrow a previously-inserted extension by type.
+    pub fn extension<T: Send + Sync + 'static>(&self) -> Option<&T> {
+        self.extensions.get::<T>()
+    }
+
+    /// Borrow the full extension map — useful for custom observers that want
+    /// to read user-supplied context without hard-coding the extension key.
+    pub fn extensions(&self) -> &Extensions {
+        &self.extensions
+    }
+
+    // --- terminal run methods ---
+
+    /// Dispatch to the underlying engine and return the aggregate
+    /// [`EngineResult`].
+    ///
+    /// Consumes the builder; the sink is dropped after the run. Use
+    /// [`EngineBuilder::run_collect`] if you need the sink back afterwards
+    /// (for example to call `MemorySink::tiles()`).
+    pub fn run(self) -> Result<EngineResult, EngineError> {
+        let (result, _sink) = self.run_collect()?;
+        Ok(result)
+    }
+
+    /// Dispatch to the underlying engine and return both the result and the
+    /// owned sink.
+    pub fn run_collect(self) -> Result<(EngineResult, S), EngineError> {
+        let EngineBuilder {
+            source,
+            plan,
+            sink,
+            engine_kind,
+            observer,
+            concurrency,
+            buffer_size,
+            background_rgb,
+            blank_strategy,
+            failure_policy,
+            dedupe,
+            resume: _resume, // not wired into the existing free fns yet
+            memory_budget_bytes,
+            budget_policy,
+            extensions: _extensions, // libviprs itself reads zero extensions
+        } = self;
+
+        // Build the EngineConfig once; the three engines accept slight
+        // variations of it but all share the same underlying knob list.
+        let engine_cfg = build_engine_config(
+            concurrency,
+            buffer_size,
+            background_rgb,
+            blank_strategy,
+            failure_policy,
+            dedupe,
+        );
+
+        let observer_ref: &dyn EngineObserver = match &observer {
+            Some(arc) => arc.as_ref(),
+            None => &NoopObserver,
+        };
+
+        let kind = resolve_engine_kind(engine_kind, &source);
+
+        let result = match (kind, source) {
+            (EngineKind::Monolithic, EngineSource::Raster(raster)) => {
+                generate_pyramid_observed(raster, &plan, &sink, &engine_cfg, observer_ref)?
+            }
+            (EngineKind::Monolithic, EngineSource::Strip(_)) => {
+                return Err(EngineError::IncompatibleSource {
+                    kind: EngineKind::Monolithic,
+                    reason: "Monolithic engine requires an in-memory Raster source",
+                });
+            }
+            (EngineKind::Streaming, EngineSource::Raster(raster)) => {
+                let source = RasterStripSource::new(raster);
+                let cfg = build_streaming_config(engine_cfg, memory_budget_bytes, budget_policy);
+                generate_pyramid_streaming(&source, &plan, &sink, &cfg, observer_ref)?
+            }
+            (EngineKind::Streaming, EngineSource::Strip(source)) => {
+                let cfg = build_streaming_config(engine_cfg, memory_budget_bytes, budget_policy);
+                generate_pyramid_streaming(source.as_ref(), &plan, &sink, &cfg, observer_ref)?
+            }
+            (EngineKind::MapReduce, EngineSource::Raster(raster)) => {
+                let source = RasterStripSource::new(raster);
+                let cfg = build_mapreduce_config(
+                    memory_budget_bytes,
+                    concurrency,
+                    buffer_size,
+                    background_rgb,
+                    blank_strategy,
+                );
+                generate_pyramid_mapreduce(&source, &plan, &sink, &cfg, observer_ref)?
+            }
+            (EngineKind::MapReduce, EngineSource::Strip(source)) => {
+                let cfg = build_mapreduce_config(
+                    memory_budget_bytes,
+                    concurrency,
+                    buffer_size,
+                    background_rgb,
+                    blank_strategy,
+                );
+                generate_pyramid_mapreduce(source.as_ref(), &plan, &sink, &cfg, observer_ref)?
+            }
+            (EngineKind::Auto, _) => {
+                // `resolve_engine_kind` already flattened Auto to a concrete
+                // kind; reaching this arm means we missed a case above.
+                unreachable!("Auto should have been resolved before match")
+            }
+        };
+
+        Ok((result, sink))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn build_engine_config(
+    concurrency: Option<usize>,
+    buffer_size: Option<usize>,
+    background_rgb: Option<[u8; 3]>,
+    blank_strategy: Option<BlankTileStrategy>,
+    failure_policy: Option<FailurePolicy>,
+    dedupe: Option<DedupeStrategy>,
+) -> EngineConfig {
+    let mut cfg = EngineConfig::default();
+    if let Some(n) = concurrency {
+        cfg = cfg.with_concurrency(n);
+    }
+    if let Some(n) = buffer_size {
+        cfg = cfg.with_buffer_size(n);
+    }
+    if let Some(rgb) = background_rgb {
+        cfg.background_rgb = rgb;
+    }
+    if let Some(bts) = blank_strategy {
+        cfg = cfg.with_blank_tile_strategy(bts);
+    }
+    if let Some(fp) = failure_policy {
+        cfg = cfg.with_failure_policy(fp);
+    }
+    if let Some(ds) = dedupe {
+        cfg = cfg.with_dedupe_strategy(ds);
+    }
+    cfg
+}
+
+fn build_streaming_config(
+    engine: EngineConfig,
+    memory_budget_bytes: Option<u64>,
+    budget_policy: Option<BudgetPolicy>,
+) -> StreamingConfig {
+    let defaults = StreamingConfig::default();
+    StreamingConfig {
+        engine,
+        memory_budget_bytes: memory_budget_bytes.unwrap_or(defaults.memory_budget_bytes),
+        budget_policy: budget_policy.unwrap_or(defaults.budget_policy),
+    }
+}
+
+fn build_mapreduce_config(
+    memory_budget_bytes: Option<u64>,
+    concurrency: Option<usize>,
+    buffer_size: Option<usize>,
+    background_rgb: Option<[u8; 3]>,
+    blank_strategy: Option<BlankTileStrategy>,
+) -> MapReduceConfig {
+    let mut cfg = MapReduceConfig::default();
+    if let Some(b) = memory_budget_bytes {
+        cfg.memory_budget_bytes = b;
+    }
+    if let Some(n) = concurrency {
+        cfg.tile_concurrency = n;
+    }
+    if let Some(n) = buffer_size {
+        cfg.buffer_size = n;
+    }
+    if let Some(rgb) = background_rgb {
+        cfg.background_rgb = rgb;
+    }
+    if let Some(bts) = blank_strategy {
+        cfg.blank_tile_strategy = bts;
+    }
+    cfg
+}
+
+/// Flatten [`EngineKind::Auto`] to a concrete variant based on the source.
+///
+/// * `Raster` → [`EngineKind::Monolithic`] (fastest when the raster fits in
+///   memory; the free-function `generate_pyramid_auto` would already have
+///   made this choice under its own budget heuristic).
+/// * `Strip`  → [`EngineKind::Streaming`].
+///
+/// Non-`Auto` kinds pass through unchanged.
+fn resolve_engine_kind(kind: EngineKind, source: &EngineSource<'_>) -> EngineKind {
+    match (kind, source) {
+        (EngineKind::Auto, EngineSource::Raster(_)) => EngineKind::Monolithic,
+        (EngineKind::Auto, EngineSource::Strip(_)) => EngineKind::Streaming,
+        (k, _) => k,
+    }
+}

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -213,6 +213,25 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
         self
     }
 
+    /// Apply every field of an existing [`EngineConfig`] in one call.
+    ///
+    /// Convenience for callers that already have a fully-constructed
+    /// [`EngineConfig`] — typically because they're migrating from the
+    /// old `generate_pyramid_observed(source, plan, sink, &config, obs)`
+    /// free function. Individual `.with_*` setters called after
+    /// `with_config` take precedence.
+    pub fn with_config(mut self, config: EngineConfig) -> Self {
+        self.concurrency = Some(config.concurrency);
+        self.buffer_size = Some(config.buffer_size);
+        self.background_rgb = Some(config.background_rgb);
+        self.blank_strategy = Some(config.blank_tile_strategy);
+        self.failure_policy = Some(config.failure_policy);
+        if let Some(ds) = config.dedupe_strategy {
+            self.dedupe = Some(ds);
+        }
+        self
+    }
+
     /// Set the [`FailurePolicy`] the engine consults when a tile write
     /// terminally fails. Overrides any earlier [`EngineBuilder::with_retry`]
     /// call.

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -396,14 +396,19 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 
         let kind = resolve_engine_kind(engine_kind, &source);
 
-        // Resume path: route through the resumable engine (Monolithic) or
-        // wrap the sink in a resume-aware filter (Streaming / MapReduce).
-        // Verify mode still requires a Raster source — the verify loop
-        // regenerates every level via downscale_half, which needs the full
-        // source raster in memory.
+        // Unified resume path: every engine kind now flows through the
+        // same (skip, cp) + ResumeAwareSink pipeline. Verify is a
+        // read-only sibling that delegates to dedicated verify helpers
+        // (raster_verify or verify_from_strip_source) and never touches
+        // the checkpoint.
+        //
+        // Invariants preserved:
+        //   * Monolithic + Strip is rejected with IncompatibleSource.
+        //   * policy.checkpoint_every() / policy.checkpoint_root() are
+        //     threaded into engine_cfg before prepare_resume_state runs.
+        //   * cp.flush() runs on every non-Verify success; Verify is
+        //     read-only and has no checkpoint to persist.
         if let Some(policy) = resume {
-            // Thread checkpoint frequency and root from the ResumePolicy
-            // into the EngineConfig that the inner path reads.
             if policy.checkpoint_every() > 0 {
                 engine_cfg = engine_cfg.with_checkpoint_every(policy.checkpoint_every());
             }
@@ -411,59 +416,65 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                 engine_cfg = engine_cfg.with_checkpoint_root(root.to_path_buf());
             }
 
-            // Monolithic + Raster — existing resumable engine handles wipe,
-            // skip-set load, checkpoint state, and verify.
-            if matches!(kind, EngineKind::Monolithic) {
-                let raster = match source {
-                    EngineSource::Raster(r) => r,
-                    EngineSource::Strip(_) => {
-                        return Err(EngineError::IncompatibleSource {
-                            kind,
-                            reason: "ResumePolicy requires an in-memory Raster source for the Monolithic engine",
-                        });
-                    }
-                };
-                let result = crate::engine::generate_pyramid_resumable(
-                    raster,
-                    &plan,
-                    &sink,
-                    &engine_cfg,
-                    policy.mode(),
-                    observer_ref,
-                )?;
-                return Ok((result, sink));
-            }
-
-            // Verify with a streaming engine requires regenerating every
-            // level via downscale_half — that needs the full raster, which
-            // is exactly what a strip source is built to avoid. Stream
-            // sources can't cheaply satisfy Verify, so we reject it
-            // explicitly and steer the caller to Monolithic.
-            if matches!(policy.mode(), ResumeMode::Verify) {
+            if matches!(kind, EngineKind::Monolithic) && matches!(source, EngineSource::Strip(_)) {
                 return Err(EngineError::IncompatibleSource {
-                    kind,
-                    reason: "ResumePolicy::verify() requires EngineKind::Monolithic (verify walks every level from the source raster); use Monolithic for Verify runs",
+                    kind: EngineKind::Monolithic,
+                    reason: "Monolithic engine requires an in-memory Raster source",
                 });
             }
 
-            // Streaming / MapReduce + Overwrite or Resume.
-            // Pattern:
-            //   1. Optionally wipe the output (Overwrite) or load the
-            //      checkpoint (Resume) to get the skip set.
-            //   2. Construct a CheckpointState rooted at the sink.
-            //   3. Wrap the user sink in a resume-aware filter that
-            //      short-circuits write_tile for already-completed coords
-            //      and advances the checkpoint for every real write.
-            //   4. Run the streaming / map-reduce engine against the
-            //      wrapped sink.
-            //   5. Flush the checkpoint on success.
+            // Verify: read-only, no skip set, no checkpoint. Route by
+            // engine kind to the matching verify helper.
+            if matches!(policy.mode(), ResumeMode::Verify) {
+                let result = match (kind, source) {
+                    (EngineKind::Monolithic, EngineSource::Raster(raster)) => {
+                        crate::verify::raster_verify(
+                            raster,
+                            &plan,
+                            &sink,
+                            &engine_cfg,
+                            observer_ref,
+                        )?
+                    }
+                    (EngineKind::Streaming, EngineSource::Raster(raster))
+                    | (EngineKind::MapReduce, EngineSource::Raster(raster)) => {
+                        let strip = RasterStripSource::new(raster);
+                        crate::verify::verify_from_strip_source(
+                            &strip,
+                            &plan,
+                            &sink,
+                            &engine_cfg,
+                            observer_ref,
+                        )?
+                    }
+                    (EngineKind::Streaming, EngineSource::Strip(strip))
+                    | (EngineKind::MapReduce, EngineSource::Strip(strip)) => {
+                        crate::verify::verify_from_strip_source(
+                            strip.as_ref(),
+                            &plan,
+                            &sink,
+                            &engine_cfg,
+                            observer_ref,
+                        )?
+                    }
+                    (EngineKind::Monolithic, EngineSource::Strip(_)) => {
+                        unreachable!("Monolithic + Strip rejected above")
+                    }
+                    (EngineKind::Auto, _) => {
+                        unreachable!("Auto should have been resolved before match")
+                    }
+                };
+                return Ok((result, sink));
+            }
+
+            // Overwrite / Resume: shared (skip, cp) setup + ResumeAwareSink.
             let (skip, cp) = prepare_resume_state(&sink, &plan, &engine_cfg, policy.mode())?;
-            let wrapped = resume::ResumeAwareSink {
-                inner: &sink,
-                skip: &skip,
-                cp: cp.as_ref(),
-            };
-            let result = match (kind, source) {
+            let wrapped = resume::ResumeAwareSink::new(&sink, &skip, cp.as_ref());
+
+            let mut result = match (kind, source) {
+                (EngineKind::Monolithic, EngineSource::Raster(raster)) => {
+                    generate_pyramid_observed(raster, &plan, &wrapped, &engine_cfg, observer_ref)?
+                }
                 (EngineKind::Streaming, EngineSource::Raster(raster)) => {
                     let strip = RasterStripSource::new(raster);
                     let cfg =
@@ -496,13 +507,25 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                     );
                     generate_pyramid_mapreduce(strip.as_ref(), &plan, &wrapped, &cfg, observer_ref)?
                 }
+                (EngineKind::Monolithic, EngineSource::Strip(_)) => {
+                    unreachable!("Monolithic + Strip rejected above")
+                }
                 (EngineKind::Auto, _) => {
                     unreachable!("Auto should have been resolved before match")
                 }
-                (EngineKind::Monolithic, _) => {
-                    unreachable!("Monolithic + resume handled in the branch above")
-                }
             };
+
+            // Adjust tiles_produced down by the number of tiles the
+            // resume wrapper short-circuited. This restores the
+            // pre-unification contract that `tiles_produced` reports
+            // "tiles actually written this run" rather than "tiles the
+            // engine visited" — the difference matters for Resume runs
+            // where most or all tiles skip the write path.
+            let skipped = wrapped.skipped_count();
+            if skipped > 0 {
+                result.tiles_produced = result.tiles_produced.saturating_sub(skipped);
+            }
+
             if let Some(cp) = cp.as_ref() {
                 cp.flush().map_err(EngineError::ResumeFailed)?;
             }
@@ -715,7 +738,7 @@ fn prepare_resume_state(
 mod resume {
     use std::collections::HashSet;
     use std::path::Path;
-    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use crate::engine::{CheckpointState, EngineConfig};
     use crate::planner::TileCoord;
@@ -734,11 +757,36 @@ mod resume {
         pub(super) inner: &'a S,
         pub(super) skip: &'a HashSet<TileCoord>,
         pub(super) cp: Option<&'a CheckpointState>,
+        /// Running count of skipped writes, used after `.run()` to adjust
+        /// [`crate::engine::EngineResult::tiles_produced`] down so that
+        /// callers see "tiles actually written this run" rather than
+        /// "tiles the engine visited".
+        pub(super) skipped: AtomicU64,
+    }
+
+    impl<'a, S: TileSink + ?Sized> ResumeAwareSink<'a, S> {
+        pub(super) fn new(
+            inner: &'a S,
+            skip: &'a HashSet<TileCoord>,
+            cp: Option<&'a CheckpointState>,
+        ) -> Self {
+            Self {
+                inner,
+                skip,
+                cp,
+                skipped: AtomicU64::new(0),
+            }
+        }
+
+        pub(super) fn skipped_count(&self) -> u64 {
+            self.skipped.load(Ordering::Relaxed)
+        }
     }
 
     impl<'a, S: TileSink + ?Sized> TileSink for ResumeAwareSink<'a, S> {
         fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
             if self.skip.contains(&tile.coord) {
+                self.skipped.fetch_add(1, Ordering::Relaxed);
                 return Ok(());
             }
             self.inner.write_tile(tile)?;

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -220,6 +220,12 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
     /// old `generate_pyramid_observed(source, plan, sink, &config, obs)`
     /// free function. Individual `.with_*` setters called after
     /// `with_config` take precedence.
+    ///
+    /// Also threads the config's `checkpoint_every` and `checkpoint_root`
+    /// into a default [`ResumePolicy::overwrite`] if no explicit policy has
+    /// been attached yet — matching the behaviour of the old
+    /// `generate_pyramid_resumable` path where those knobs lived directly
+    /// on the `EngineConfig`.
     pub fn with_config(mut self, config: EngineConfig) -> Self {
         self.concurrency = Some(config.concurrency);
         self.buffer_size = Some(config.buffer_size);
@@ -228,6 +234,22 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
         self.failure_policy = Some(config.failure_policy);
         if let Some(ds) = config.dedupe_strategy {
             self.dedupe = Some(ds);
+        }
+        // Carry the checkpoint knobs into an existing ResumePolicy (if set)
+        // so migrations from `generate_pyramid_resumable(.., &cfg, mode)`
+        // don't silently lose the cadence / root that used to live on the
+        // config.
+        if config.checkpoint_every != 0 || config.checkpoint_root.is_some() {
+            let mut policy = self.resume.unwrap_or_else(ResumePolicy::overwrite);
+            if config.checkpoint_every != 0 && policy.checkpoint_every() == 0 {
+                policy = policy.with_checkpoint_every(config.checkpoint_every);
+            }
+            if policy.checkpoint_root().is_none() {
+                if let Some(root) = config.checkpoint_root {
+                    policy = policy.with_checkpoint_root(root);
+                }
+            }
+            self.resume = Some(policy);
         }
         self
     }
@@ -350,7 +372,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             blank_strategy,
             failure_policy,
             dedupe,
-            resume: _resume, // not wired into the existing free fns yet
+            resume,
             memory_budget_bytes,
             budget_policy,
             extensions: _extensions, // libviprs itself reads zero extensions
@@ -358,7 +380,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 
         // Build the EngineConfig once; the three engines accept slight
         // variations of it but all share the same underlying knob list.
-        let engine_cfg = build_engine_config(
+        let mut engine_cfg = build_engine_config(
             concurrency,
             buffer_size,
             background_rgb,
@@ -373,6 +395,43 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
         };
 
         let kind = resolve_engine_kind(engine_kind, &source);
+
+        // Resume path: dispatch to generate_pyramid_resumable when a
+        // ResumePolicy is set. Only Monolithic + Raster is supported today
+        // — streaming and map-reduce resume land in a follow-up.
+        if let Some(policy) = resume {
+            if !matches!(kind, EngineKind::Monolithic) {
+                return Err(EngineError::IncompatibleSource {
+                    kind,
+                    reason: "ResumePolicy requires EngineKind::Monolithic (or Auto with a Raster source); streaming / map-reduce resume is not yet supported",
+                });
+            }
+            let raster = match source {
+                EngineSource::Raster(r) => r,
+                EngineSource::Strip(_) => {
+                    return Err(EngineError::IncompatibleSource {
+                        kind,
+                        reason: "ResumePolicy requires an in-memory Raster source",
+                    });
+                }
+            };
+            // Thread checkpoint frequency and root from the ResumePolicy
+            // into the EngineConfig that generate_pyramid_resumable reads.
+            if policy.checkpoint_every() > 0 {
+                engine_cfg = engine_cfg.with_checkpoint_every(policy.checkpoint_every());
+            }
+            if let Some(root) = policy.checkpoint_root() {
+                engine_cfg = engine_cfg.with_checkpoint_root(root.to_path_buf());
+            }
+            let result = crate::engine::generate_pyramid_resumable(
+                raster,
+                &plan,
+                &sink,
+                &engine_cfg,
+                policy.mode(),
+            )?;
+            return Ok((result, sink));
+        }
 
         let result = match (kind, source) {
             (EngineKind::Monolithic, EngineSource::Raster(raster)) => {

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -429,6 +429,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                 &sink,
                 &engine_cfg,
                 policy.mode(),
+                observer_ref,
             )?;
             return Ok((result, sink));
         }

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,0 +1,175 @@
+//! Typed extension map for pipeline-level context that does not fit one of
+//! the first-class builder slots ([`TileSink`](crate::sink::TileSink),
+//! [`EngineObserver`](crate::observe::EngineObserver),
+//! [`StripSource`](crate::streaming::StripSource)).
+//!
+//! The shape mirrors [`http::Extensions`]: a `TypeId`-keyed map of
+//! `Box<dyn Any + Send + Sync>`. One slot per `TypeId`; re-inserting a type
+//! overwrites the previous value. Values must be `Send + Sync + 'static` so
+//! the map itself is trivially `Send + Sync`.
+//!
+//! libviprs itself reads **zero** extensions as of this release — the hatch
+//! is deliberately inert. It exists so third-party crates can stash shared
+//! context (metrics recorders, tracing spans, custom config blobs) through
+//! [`EngineBuilder::with_extension`](crate::EngineBuilder::with_extension)
+//! and retrieve it from a custom `EngineObserver` or the rest of the
+//! pipeline without a semver bump to libviprs. When libviprs grows a
+//! feature that needs cross-cutting context (e.g. an optional `metrics`
+//! integration), that feature's code becomes the first internal reader.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use libviprs::extensions::Extensions;
+//!
+//! struct MyContext { counter: std::sync::atomic::AtomicU64 }
+//!
+//! let mut ext = Extensions::new();
+//! ext.insert(Arc::new(MyContext { counter: 0.into() }));
+//!
+//! let pulled: &Arc<MyContext> = ext.get().unwrap();
+//! ```
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+type BoxedAny = Box<dyn Any + Send + Sync>;
+
+/// Typed map of `Send + Sync + 'static` values keyed by [`TypeId`].
+///
+/// One slot per type; [`Extensions::insert`] returns the previous value if
+/// one was present. The internal [`HashMap`] is lazily allocated so an
+/// [`EngineBuilder`](crate::EngineBuilder) that never sets an extension
+/// pays no heap cost.
+#[derive(Default)]
+pub struct Extensions {
+    map: Option<HashMap<TypeId, BoxedAny>>,
+}
+
+impl std::fmt::Debug for Extensions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Extensions")
+            .field("len", &self.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Extensions {
+    /// Construct an empty extension map. No allocation until the first
+    /// [`Extensions::insert`] call.
+    pub fn new() -> Self {
+        Self { map: None }
+    }
+
+    /// Insert `value`, returning the previous value for the same `T` if one
+    /// was present.
+    pub fn insert<T: Send + Sync + 'static>(&mut self, value: T) -> Option<T> {
+        let map = self.map.get_or_insert_with(HashMap::new);
+        map.insert(TypeId::of::<T>(), Box::new(value))
+            .and_then(|boxed| boxed.downcast::<T>().ok().map(|b| *b))
+    }
+
+    /// Retrieve a shared reference to the stored value of type `T`, if any.
+    pub fn get<T: Send + Sync + 'static>(&self) -> Option<&T> {
+        self.map
+            .as_ref()?
+            .get(&TypeId::of::<T>())
+            .and_then(|b| b.downcast_ref::<T>())
+    }
+
+    /// Retrieve a unique reference to the stored value of type `T`, if any.
+    pub fn get_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
+        self.map
+            .as_mut()?
+            .get_mut(&TypeId::of::<T>())
+            .and_then(|b| b.downcast_mut::<T>())
+    }
+
+    /// Remove and return the stored value of type `T`, if any.
+    pub fn remove<T: Send + Sync + 'static>(&mut self) -> Option<T> {
+        self.map
+            .as_mut()?
+            .remove(&TypeId::of::<T>())
+            .and_then(|boxed| boxed.downcast::<T>().ok().map(|b| *b))
+    }
+
+    /// Number of stored extensions.
+    pub fn len(&self) -> usize {
+        self.map.as_ref().map_or(0, |m| m.len())
+    }
+
+    /// Whether the map currently holds zero extensions.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Drop every stored extension.
+    pub fn clear(&mut self) {
+        if let Some(m) = self.map.as_mut() {
+            m.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct Marker(&'static str);
+
+    #[test]
+    fn roundtrip() {
+        let mut ext = Extensions::new();
+        assert!(ext.is_empty());
+        ext.insert(Marker("hi"));
+        assert_eq!(ext.len(), 1);
+        assert_eq!(ext.get::<Marker>(), Some(&Marker("hi")));
+    }
+
+    #[test]
+    fn overwrites_same_type() {
+        let mut ext = Extensions::new();
+        assert_eq!(ext.insert(Marker("first")), None);
+        assert_eq!(ext.insert(Marker("second")), Some(Marker("first")));
+        assert_eq!(ext.get::<Marker>(), Some(&Marker("second")));
+    }
+
+    #[test]
+    fn different_types_coexist() {
+        #[derive(Debug, PartialEq)]
+        struct Alpha(u32);
+        #[derive(Debug, PartialEq)]
+        struct Beta(String);
+
+        let mut ext = Extensions::new();
+        ext.insert(Alpha(1));
+        ext.insert(Beta("b".into()));
+        assert_eq!(ext.get::<Alpha>(), Some(&Alpha(1)));
+        assert_eq!(ext.get::<Beta>(), Some(&Beta("b".into())));
+        assert_eq!(ext.len(), 2);
+    }
+
+    #[test]
+    fn remove_returns_ownership() {
+        let mut ext = Extensions::new();
+        ext.insert(Marker("x"));
+        assert_eq!(ext.remove::<Marker>(), Some(Marker("x")));
+        assert!(ext.get::<Marker>().is_none());
+    }
+
+    #[test]
+    fn get_mut_is_mutable() {
+        let mut ext = Extensions::new();
+        ext.insert(vec![1u32, 2, 3]);
+        ext.get_mut::<Vec<u32>>().unwrap().push(4);
+        assert_eq!(ext.get::<Vec<u32>>().unwrap(), &vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn send_sync_bound_holds() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Extensions>();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@
 pub mod checksum;
 pub mod dedupe;
 pub mod engine;
+pub mod engine_builder;
+pub mod extensions;
 pub mod geo;
 #[cfg(loom)]
 mod loom_tests;
@@ -60,6 +62,7 @@ pub use engine::{
     BlankTileStrategy, EngineConfig, EngineError, EngineResult, StageDurations, generate_pyramid,
     generate_pyramid_observed, generate_pyramid_resumable, is_blank_tile,
 };
+pub use engine_builder::{EngineBuilder, EngineKind, EngineSource, IntoEngineSource};
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};
 pub use manifest::{
     ChecksumAlgo, Checksums, GenerationSettings, LevelMetadata, Manifest, ManifestBuilder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,7 @@ pub mod streaming_mapreduce;
 pub use checksum::{ChecksumMode, VerifyError, VerifyReport};
 pub use dedupe::{DedupeDecision, DedupeIndex, DedupeStrategy, LinkResult};
 pub use engine::{
-    BlankTileStrategy, EngineConfig, EngineError, EngineResult, StageDurations,
-    generate_pyramid_resumable, is_blank_tile,
+    BlankTileStrategy, EngineConfig, EngineError, EngineResult, StageDurations, is_blank_tile,
 };
 pub use engine_builder::{EngineBuilder, EngineKind, EngineSource, IntoEngineSource};
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub use planner::{
     Layout, LevelPlan, PlannerError, PyramidPlan, PyramidPlanner, TileCoord, TileRect,
 };
 pub use raster::{Raster, RasterError, RegionView};
-pub use resume::{JobCheckpoint, JobMetadata, ResumeError, ResumeMode};
+pub use resume::{JobCheckpoint, JobMetadata, ResumeError, ResumeMode, ResumePolicy};
 pub use retry::{FailurePolicy, RetryPolicy, RetryingSink};
 pub use sink::{
     BLANK_TILE_MARKER, CollectedTile, FsSink, MemorySink, SinkError, Tile, TileFormat, TileSink,
@@ -82,7 +82,7 @@ pub use sink::{
 #[cfg(feature = "s3")]
 pub use sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 #[cfg(feature = "packfile")]
-pub use sink_packfile::{PackfileFormat, PackfileSink};
+pub use sink_packfile::{PackfileFormat, PackfileSink, PackfileSinkBuilder};
 pub use source::{SourceError, decode_bytes, decode_file, generate_test_raster};
 #[cfg(feature = "pdfium")]
 pub use streaming::PdfiumStripSource;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,8 @@ pub mod streaming_mapreduce;
 pub use checksum::{ChecksumMode, VerifyError, VerifyReport};
 pub use dedupe::{DedupeDecision, DedupeIndex, DedupeStrategy, LinkResult};
 pub use engine::{
-    BlankTileStrategy, EngineConfig, EngineError, EngineResult, StageDurations, generate_pyramid,
-    generate_pyramid_observed, generate_pyramid_resumable, is_blank_tile,
+    BlankTileStrategy, EngineConfig, EngineError, EngineResult, StageDurations,
+    generate_pyramid_resumable, is_blank_tile,
 };
 pub use engine_builder::{EngineBuilder, EngineKind, EngineSource, IntoEngineSource};
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};
@@ -91,8 +91,6 @@ pub use source::{SourceError, decode_bytes, decode_file, generate_test_raster};
 pub use streaming::PdfiumStripSource;
 pub use streaming::{
     BudgetPolicy, RasterStripSource, StreamingConfig, StripSource, compute_strip_height,
-    estimate_streaming_memory, generate_pyramid_auto, generate_pyramid_streaming,
+    estimate_streaming_memory,
 };
-pub use streaming_mapreduce::{
-    MapReduceConfig, generate_pyramid_mapreduce, generate_pyramid_mapreduce_auto,
-};
+pub use streaming_mapreduce::MapReduceConfig;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,10 @@ pub mod sink_object_store;
 #[cfg(feature = "packfile")]
 pub mod sink_packfile;
 pub mod source;
+pub mod stream_verify;
 pub mod streaming;
 pub mod streaming_mapreduce;
+pub mod verify;
 
 // Curated crate-root surface: types and high-level entry points only.
 // Leaf helpers, constants, and free functions stay behind their module path

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -421,7 +421,14 @@ fn cmyk_to_rgb_raster(cmyk_data: &[u8], width: u32, height: u32) -> Result<Raste
     Raster::new(width, height, PixelFormat::Rgb8, rgb).map_err(PdfError::Raster)
 }
 
-/// Get page dimensions in points from MediaBox.
+/// Get page dimensions in points, in the *displayed* orientation.
+///
+/// Reads `/MediaBox` and applies the effective `/Rotate` from the page
+/// dictionary (inheriting through the `/Parent` chain per PDF 1.7
+/// §7.7.3.3). For `/Rotate 90` or `270`, width and height are swapped so
+/// the returned `(w, h)` matches what viewers and the pdfium form-data
+/// render path report. `/Rotate 0` and `180` preserve the MediaBox
+/// orientation. Missing `/Rotate` behaves as `0`.
 fn get_page_dimensions(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> (f64, f64) {
     let obj = match doc.get_object(page_id) {
         Ok(o) => o,
@@ -439,11 +446,69 @@ fn get_page_dimensions(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> (f64,
             let y0 = obj_to_f64(&media_box[1]).unwrap_or(0.0);
             let x1 = obj_to_f64(&media_box[2]).unwrap_or(0.0);
             let y1 = obj_to_f64(&media_box[3]).unwrap_or(0.0);
-            return ((x1 - x0).abs(), (y1 - y0).abs());
+            let w = (x1 - x0).abs();
+            let h = (y1 - y0).abs();
+            return apply_rotate_to_dims(w, h, resolve_rotate(doc, page_id));
         }
     }
 
     (0.0, 0.0)
+}
+
+/// Swap `(w, h)` when `rotate` is `90` or `270` (mod 360). Returns
+/// `(w, h)` unchanged for `0`, `180`, or any non-multiple-of-90 value.
+fn apply_rotate_to_dims(w: f64, h: f64, rotate: i64) -> (f64, f64) {
+    // PDF spec: /Rotate must be a multiple of 90. `rem_euclid` normalises
+    // negative or out-of-range values (seen in malformed PDFs) into
+    // `[0, 360)` before the swap decision.
+    let normalised = rotate.rem_euclid(360);
+    if normalised == 90 || normalised == 270 {
+        (h, w)
+    } else {
+        (w, h)
+    }
+}
+
+/// Resolve the effective `/Rotate` value for a page.
+///
+/// Walks the `/Parent` chain per PDF 1.7 §7.7.3.3: the page's own dict
+/// first, then each ancestor `Pages` node, returning the first numeric
+/// `/Rotate` encountered. Returns `0` if none is found or the traversal
+/// hits a malformed node / self-referential loop.
+fn resolve_rotate(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> i64 {
+    let mut current = page_id;
+    // Cap the walk defensively — page trees more than a few dozen levels
+    // deep are pathological, and this stops an adversarial self-referential
+    // `/Parent` from spinning forever even if the ID-equality guard below
+    // misses it (e.g. alternating pairs of ids).
+    for _ in 0..64 {
+        let Ok(obj) = doc.get_object(current) else {
+            return 0;
+        };
+        let Ok(dict) = obj.as_dict() else {
+            return 0;
+        };
+        if let Ok(rotate_obj) = dict.get(b"Rotate") {
+            if let Ok(resolved) = resolve_object(doc, rotate_obj) {
+                if let Some(v) = obj_to_f64(resolved) {
+                    return v as i64;
+                }
+            }
+        }
+        // `/Parent` is an indirect reference to the parent Pages node.
+        // Pull the object id straight from the Reference — don't call
+        // `resolve_object`, which would hand back the dict itself and
+        // lose the id we need to walk upward.
+        let parent_id = match dict.get(b"Parent") {
+            Ok(lopdf::Object::Reference(id)) => *id,
+            _ => return 0,
+        };
+        if parent_id == current {
+            return 0;
+        }
+        current = parent_id;
+    }
+    0
 }
 
 /// Check whether a page has any Image XObjects.
@@ -765,5 +830,132 @@ mod tests {
     fn obj_to_f64_other() {
         let obj = lopdf::Object::Boolean(true);
         assert_eq!(obj_to_f64(&obj), None);
+    }
+
+    // -----------------------------------------------------------------
+    // /Rotate handling (issue #50)
+    //
+    // These tests pin the contract that `get_page_dimensions` returns
+    // display-oriented dimensions: a landscape MediaBox with /Rotate 90
+    // is reported as portrait, /Rotate 0 and /Rotate 180 preserve the
+    // raw MediaBox orientation, and /Rotate is inheritable through the
+    // Pages tree. Each test builds a minimal in-memory PDF via lopdf
+    // so the contract is exercised end-to-end through the same parser
+    // path `pdf_info` uses at runtime.
+    // -----------------------------------------------------------------
+
+    /// Build a minimal 1-page document with the given MediaBox +
+    /// `page_rotate` on the leaf page and `pages_rotate` on the parent
+    /// Pages node. `None` for either means the key is absent.
+    fn build_rotated_doc(
+        media_box: [f64; 4],
+        page_rotate: Option<i64>,
+        pages_rotate: Option<i64>,
+    ) -> (lopdf::Document, lopdf::ObjectId) {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+        let content = Stream::new(dictionary! {}, b"q 0 g 0 0 10 10 re f Q".to_vec());
+        let content_id = doc.add_object(content);
+
+        let mut page_dict = dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "MediaBox" => vec![
+                media_box[0].into(),
+                media_box[1].into(),
+                media_box[2].into(),
+                media_box[3].into(),
+            ],
+            "Contents" => content_id,
+            "Resources" => dictionary! {},
+        };
+        if let Some(r) = page_rotate {
+            page_dict.set("Rotate", Object::Integer(r));
+        }
+        let page_id = doc.add_object(page_dict);
+
+        let mut pages_dict = dictionary! {
+            "Type" => "Pages",
+            "Kids" => vec![page_id.into()],
+            "Count" => 1i64,
+        };
+        if let Some(r) = pages_rotate {
+            pages_dict.set("Rotate", Object::Integer(r));
+        }
+        doc.objects.insert(pages_id, Object::Dictionary(pages_dict));
+
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        doc.trailer.set("Root", catalog_id);
+        (doc, page_id)
+    }
+
+    #[test]
+    fn get_page_dimensions_no_rotate_is_identity() {
+        let (doc, page_id) = build_rotated_doc([0.0, 0.0, 1000.0, 500.0], None, None);
+        assert_eq!(get_page_dimensions(&doc, page_id), (1000.0, 500.0));
+    }
+
+    #[test]
+    fn get_page_dimensions_rotate_zero_is_identity() {
+        let (doc, page_id) = build_rotated_doc([0.0, 0.0, 1000.0, 500.0], Some(0), None);
+        assert_eq!(get_page_dimensions(&doc, page_id), (1000.0, 500.0));
+    }
+
+    #[test]
+    fn get_page_dimensions_rotate_90_swaps() {
+        let (doc, page_id) = build_rotated_doc([0.0, 0.0, 1000.0, 500.0], Some(90), None);
+        assert_eq!(get_page_dimensions(&doc, page_id), (500.0, 1000.0));
+    }
+
+    #[test]
+    fn get_page_dimensions_rotate_180_preserves() {
+        let (doc, page_id) = build_rotated_doc([0.0, 0.0, 1000.0, 500.0], Some(180), None);
+        assert_eq!(get_page_dimensions(&doc, page_id), (1000.0, 500.0));
+    }
+
+    #[test]
+    fn get_page_dimensions_rotate_270_swaps() {
+        let (doc, page_id) = build_rotated_doc([0.0, 0.0, 1000.0, 500.0], Some(270), None);
+        assert_eq!(get_page_dimensions(&doc, page_id), (500.0, 1000.0));
+    }
+
+    #[test]
+    fn get_page_dimensions_negative_rotate_normalises() {
+        // /Rotate -90 is equivalent to 270 under rem_euclid normalisation.
+        let (doc, page_id) = build_rotated_doc([0.0, 0.0, 1000.0, 500.0], Some(-90), None);
+        assert_eq!(get_page_dimensions(&doc, page_id), (500.0, 1000.0));
+    }
+
+    #[test]
+    fn get_page_dimensions_rotate_inherited_from_parent_pages() {
+        // /Rotate on the parent Pages node, absent on the page itself.
+        // PDF 1.7 §7.7.3.3 mandates inheritance; the page must pick up
+        // the parent's rotation.
+        let (doc, page_id) = build_rotated_doc([0.0, 0.0, 1000.0, 500.0], None, Some(90));
+        assert_eq!(get_page_dimensions(&doc, page_id), (500.0, 1000.0));
+    }
+
+    #[test]
+    fn get_page_dimensions_page_rotate_overrides_parent() {
+        // When both the page and the parent Pages node declare /Rotate,
+        // the page's value wins — the walk stops at the first /Rotate it
+        // encounters.
+        let (doc, page_id) = build_rotated_doc([0.0, 0.0, 1000.0, 500.0], Some(0), Some(90));
+        assert_eq!(get_page_dimensions(&doc, page_id), (1000.0, 500.0));
+    }
+
+    #[test]
+    fn apply_rotate_to_dims_multiples() {
+        assert_eq!(apply_rotate_to_dims(1000.0, 500.0, 0), (1000.0, 500.0));
+        assert_eq!(apply_rotate_to_dims(1000.0, 500.0, 90), (500.0, 1000.0));
+        assert_eq!(apply_rotate_to_dims(1000.0, 500.0, 180), (1000.0, 500.0));
+        assert_eq!(apply_rotate_to_dims(1000.0, 500.0, 270), (500.0, 1000.0));
+        assert_eq!(apply_rotate_to_dims(1000.0, 500.0, 360), (1000.0, 500.0));
+        assert_eq!(apply_rotate_to_dims(1000.0, 500.0, -90), (500.0, 1000.0));
     }
 }

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -84,6 +84,98 @@ pub enum ResumeMode {
     Verify,
 }
 
+/// Fluent builder bundling a [`ResumeMode`] with its checkpoint-persistence
+/// knobs.
+///
+/// `ResumePolicy` is the user-facing type threaded through `EngineBuilder`.
+/// Three mutually-exclusive factories anchor the mode:
+///
+/// * [`ResumePolicy::overwrite`] — fresh run; any existing checkpoint is
+///   wiped. Matches [`ResumeMode::Overwrite`] and is the `Default`.
+/// * [`ResumePolicy::resume`] — skip tiles already recorded in the on-disk
+///   checkpoint. Matches [`ResumeMode::Resume`].
+/// * [`ResumePolicy::verify`] — read-only audit of existing tiles. Matches
+///   [`ResumeMode::Verify`].
+///
+/// After picking a factory, chain `.with_checkpoint_every(n)` to flush the
+/// checkpoint file every `n` completed tiles (default `0` = never) and
+/// `.with_checkpoint_root(path)` to place the checkpoint somewhere other
+/// than the sink's base directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResumePolicy {
+    mode: ResumeMode,
+    checkpoint_every: u64,
+    checkpoint_root: Option<PathBuf>,
+}
+
+impl Default for ResumePolicy {
+    fn default() -> Self {
+        Self {
+            mode: ResumeMode::Overwrite,
+            checkpoint_every: 0,
+            checkpoint_root: None,
+        }
+    }
+}
+
+impl ResumePolicy {
+    /// Start a fresh run. Equivalent to [`ResumeMode::Overwrite`].
+    pub fn overwrite() -> Self {
+        Self {
+            mode: ResumeMode::Overwrite,
+            ..Self::default()
+        }
+    }
+
+    /// Continue an interrupted run from the on-disk checkpoint. Equivalent
+    /// to [`ResumeMode::Resume`].
+    pub fn resume() -> Self {
+        Self {
+            mode: ResumeMode::Resume,
+            ..Self::default()
+        }
+    }
+
+    /// Audit an existing output directory against the plan without writing
+    /// anything. Equivalent to [`ResumeMode::Verify`].
+    pub fn verify() -> Self {
+        Self {
+            mode: ResumeMode::Verify,
+            ..Self::default()
+        }
+    }
+
+    /// Flush the checkpoint file every `n` completed tiles. `0` (the
+    /// default) defers the checkpoint write until the end of the run.
+    pub fn with_checkpoint_every(mut self, n: u64) -> Self {
+        self.checkpoint_every = n;
+        self
+    }
+
+    /// Override the checkpoint directory. When unset, the engine falls back
+    /// to the sink's `checkpoint_root()` (typically the output base dir).
+    pub fn with_checkpoint_root(mut self, path: impl Into<PathBuf>) -> Self {
+        self.checkpoint_root = Some(path.into());
+        self
+    }
+
+    /// The resume mode this policy lowers to.
+    pub fn mode(&self) -> ResumeMode {
+        self.mode
+    }
+
+    /// The configured checkpoint frequency (`0` means "only at the end").
+    pub fn checkpoint_every(&self) -> u64 {
+        self.checkpoint_every
+    }
+
+    /// The configured checkpoint root, if one was set via
+    /// [`ResumePolicy::with_checkpoint_root`].
+    pub fn checkpoint_root(&self) -> Option<&Path> {
+        self.checkpoint_root.as_deref()
+    }
+}
+
 /// On-disk checkpoint describing the state of a pyramid generation job.
 ///
 /// Produced and consumed by [`JobCheckpoint::save`] / [`JobCheckpoint::load`].

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -45,9 +45,8 @@ use thiserror::Error;
 
 use crate::planner::{Layout, PyramidPlan, TileCoord};
 
-// Re-export the engine entry point from `libviprs::resume::*` so tests can
-// grab it from the same module that owns the checkpoint types.
-pub use crate::engine::generate_pyramid_resumable;
+// `generate_pyramid_resumable` is now the exclusive purview of
+// `EngineBuilder::with_resume` — no crate-external entry point.
 
 /// Current on-disk schema version for [`JobMetadata`].
 ///

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -125,6 +125,23 @@ impl RetryPolicy {
         }
     }
 
+    /// Construct a policy that never retries (shorthand for `max_retries = 0`).
+    ///
+    /// Use this when you want [`FailurePolicy::FailFast`]-style behaviour but
+    /// still want to feed a `RetryPolicy` value through an API that requires
+    /// one (e.g. a `match` arm returning `RetryPolicy` from every branch).
+    pub fn fail_fast() -> Self {
+        Self {
+            max_retries: 0,
+            ..Self::default()
+        }
+    }
+
+    /// Short-form alias for [`RetryPolicy::with_max_retries`].
+    pub fn with_max(self, n: u32) -> Self {
+        self.with_max_retries(n)
+    }
+
     pub fn with_max_retries(mut self, n: u32) -> Self {
         self.max_retries = n;
         self

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -76,6 +76,11 @@ pub enum SinkError {
         expected: String,
         got: String,
     },
+    /// A required field was not set on a sink builder before `build()` was
+    /// called. The payload is the fully-qualified field name, e.g.
+    /// `"PackfileSinkBuilder::plan"`.
+    #[error("required builder field not set: {0}")]
+    MissingField(&'static str),
 }
 
 /// Single-byte marker written in place of blank tiles when using
@@ -535,6 +540,22 @@ impl FsSink {
     /// `.libviprs-job.json` checkpoint alongside the pyramid.
     pub fn with_resume(mut self, enabled: bool) -> Self {
         self.resume_enabled = enabled;
+        self
+    }
+
+    /// Override the tile encoding format after construction.
+    ///
+    /// Lets callers configure the format through the builder chain rather
+    /// than via the `new` constructor's positional argument, matching the
+    /// per-component builder convention used elsewhere in the crate:
+    ///
+    /// ```ignore
+    /// FsSink::new(dir, plan, TileFormat::Png)
+    ///     .with_format(TileFormat::Jpeg { quality: 85 })
+    ///     .with_dedupe(DedupeStrategy::Blanks);
+    /// ```
+    pub fn with_format(mut self, format: TileFormat) -> Self {
+        self.format = format;
         self
     }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -533,32 +533,7 @@ impl FsSink {
     /// FsSink::new(dir, plan).with_format(TileFormat::Jpeg { quality: 85 });
     /// ```
     pub fn new(base_dir: impl Into<PathBuf>, plan: PyramidPlan) -> Self {
-        Self::new_with_format_inner(base_dir, plan, TileFormat::Png)
-    }
-
-    /// Deprecated three-argument constructor that takes the tile format as a
-    /// positional parameter.
-    ///
-    /// Retained as a migration alias; new code should prefer
-    /// [`FsSink::new`] followed by [`FsSink::with_format`] when a non-PNG
-    /// format is needed.
-    #[deprecated(
-        since = "0.3.0",
-        note = "use FsSink::new(dir, plan).with_format(format) instead"
-    )]
-    pub fn new_with_format(
-        base_dir: impl Into<PathBuf>,
-        plan: PyramidPlan,
-        format: TileFormat,
-    ) -> Self {
-        Self::new_with_format_inner(base_dir, plan, format)
-    }
-
-    fn new_with_format_inner(
-        base_dir: impl Into<PathBuf>,
-        plan: PyramidPlan,
-        format: TileFormat,
-    ) -> Self {
+        let format = TileFormat::Png;
         let base_dir = base_dir.into();
         // Pre-size the per-level atomic counter vector so that the hot
         // write path can index by `level as usize` without any lock or

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -172,6 +172,48 @@ pub trait TileSink: Send + Sync {
     fn init_level_count(&self, _levels: usize) {}
 }
 
+/// Forwarding impl so `Box<dyn TileSink>` (and `Box<T>` where `T: TileSink`)
+/// satisfies [`TileSink`] itself.
+///
+/// Required so callers can unify match arms that return different concrete
+/// sink types under `Box<dyn TileSink>` and feed the boxed form to
+/// [`EngineBuilder::new`](crate::EngineBuilder::new):
+///
+/// ```ignore
+/// let sink: Box<dyn TileSink> = match mode {
+///     "mem" => Box::new(MemorySink::new()),
+///     "fs"  => Box::new(FsSink::new(dir, plan)),
+///     _ => unreachable!(),
+/// };
+/// EngineBuilder::new(&src, plan, sink).run()?;
+/// ```
+impl<T: TileSink + ?Sized> TileSink for Box<T> {
+    fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+        (**self).write_tile(tile)
+    }
+    fn finish(&self) -> Result<(), SinkError> {
+        (**self).finish()
+    }
+    fn record_engine_config(&self, config: &crate::engine::EngineConfig) {
+        (**self).record_engine_config(config)
+    }
+    fn sink_retry_count(&self) -> u64 {
+        (**self).sink_retry_count()
+    }
+    fn sink_skipped_due_to_failure(&self) -> u64 {
+        (**self).sink_skipped_due_to_failure()
+    }
+    fn note_sink_skipped(&self) {
+        (**self).note_sink_skipped()
+    }
+    fn checkpoint_root(&self) -> Option<&Path> {
+        (**self).checkpoint_root()
+    }
+    fn init_level_count(&self, levels: usize) {
+        (**self).init_level_count(levels)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // MemorySink
 // ---------------------------------------------------------------------------

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -214,6 +214,45 @@ impl<T: TileSink + ?Sized> TileSink for Box<T> {
     }
 }
 
+/// Forwarding impl so `&T` satisfies [`TileSink`] wherever `T` does.
+///
+/// Parallels the [`Box<T>`] impl above. Lets callers feed the
+/// [`EngineBuilder`](crate::EngineBuilder) a borrowed sink when they need
+/// to keep ownership (e.g. the CLI, which uses the same sink for both the
+/// builder path and the resumable free function):
+///
+/// ```ignore
+/// let sink = FsSink::new(dir, plan);
+/// EngineBuilder::new(&raster, plan.clone(), &sink).run()?;
+/// // `sink` still usable here.
+/// ```
+impl<T: TileSink + ?Sized> TileSink for &T {
+    fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+        (*self).write_tile(tile)
+    }
+    fn finish(&self) -> Result<(), SinkError> {
+        (*self).finish()
+    }
+    fn record_engine_config(&self, config: &crate::engine::EngineConfig) {
+        (*self).record_engine_config(config)
+    }
+    fn sink_retry_count(&self) -> u64 {
+        (*self).sink_retry_count()
+    }
+    fn sink_skipped_due_to_failure(&self) -> u64 {
+        (*self).sink_skipped_due_to_failure()
+    }
+    fn note_sink_skipped(&self) {
+        (*self).note_sink_skipped()
+    }
+    fn checkpoint_root(&self) -> Option<&Path> {
+        (*self).checkpoint_root()
+    }
+    fn init_level_count(&self, levels: usize) {
+        (*self).init_level_count(levels)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // MemorySink
 // ---------------------------------------------------------------------------

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -444,8 +444,40 @@ impl std::fmt::Debug for FsSink {
 
 impl FsSink {
     /// Creates a new filesystem sink rooted at `base_dir` with the given
-    /// pyramid plan and tile encoding format.
-    pub fn new(base_dir: impl Into<PathBuf>, plan: PyramidPlan, format: TileFormat) -> Self {
+    /// pyramid plan. The tile encoding format defaults to
+    /// [`TileFormat::Png`]; override it via [`FsSink::with_format`] when
+    /// writing JPEG or Raw tiles:
+    ///
+    /// ```ignore
+    /// FsSink::new(dir, plan).with_format(TileFormat::Jpeg { quality: 85 });
+    /// ```
+    pub fn new(base_dir: impl Into<PathBuf>, plan: PyramidPlan) -> Self {
+        Self::new_with_format_inner(base_dir, plan, TileFormat::Png)
+    }
+
+    /// Deprecated three-argument constructor that takes the tile format as a
+    /// positional parameter.
+    ///
+    /// Retained as a migration alias; new code should prefer
+    /// [`FsSink::new`] followed by [`FsSink::with_format`] when a non-PNG
+    /// format is needed.
+    #[deprecated(
+        since = "0.3.0",
+        note = "use FsSink::new(dir, plan).with_format(format) instead"
+    )]
+    pub fn new_with_format(
+        base_dir: impl Into<PathBuf>,
+        plan: PyramidPlan,
+        format: TileFormat,
+    ) -> Self {
+        Self::new_with_format_inner(base_dir, plan, format)
+    }
+
+    fn new_with_format_inner(
+        base_dir: impl Into<PathBuf>,
+        plan: PyramidPlan,
+        format: TileFormat,
+    ) -> Self {
         let base_dir = base_dir.into();
         // Pre-size the per-level atomic counter vector so that the hot
         // write path can index by `level as usize` without any lock or
@@ -545,12 +577,12 @@ impl FsSink {
 
     /// Override the tile encoding format after construction.
     ///
-    /// Lets callers configure the format through the builder chain rather
-    /// than via the `new` constructor's positional argument, matching the
-    /// per-component builder convention used elsewhere in the crate:
+    /// Overrides the tile encoding format set by [`FsSink::new`] (which
+    /// defaults to [`TileFormat::Png`]). Chain with the other `with_*`
+    /// methods to configure the full sink in builder style:
     ///
     /// ```ignore
-    /// FsSink::new(dir, plan, TileFormat::Png)
+    /// FsSink::new(dir, plan)
     ///     .with_format(TileFormat::Jpeg { quality: 85 })
     ///     .with_dedupe(DedupeStrategy::Blanks);
     /// ```
@@ -1362,11 +1394,8 @@ mod tests {
         #[cfg(not(miri))]
         {
             let dir = tempfile::tempdir().unwrap();
-            let sink = FsSink::new(
-                dir.path().join("output_files"),
-                plan.clone(),
-                TileFormat::Raw,
-            );
+            let sink = FsSink::new(dir.path().join("output_files"), plan.clone())
+                .with_format(TileFormat::Raw);
             let tile = Tile {
                 coord: TileCoord::new(top.level, 0, 0),
                 raster,
@@ -1412,7 +1441,8 @@ mod tests {
         #[cfg(not(miri))]
         {
             let dir = tempfile::tempdir().unwrap();
-            let sink = FsSink::new(dir.path().join("tiles"), plan.clone(), TileFormat::Raw);
+            let sink =
+                FsSink::new(dir.path().join("tiles"), plan.clone()).with_format(TileFormat::Raw);
 
             for col in 0..top.cols {
                 for row in 0..top.rows {
@@ -1459,7 +1489,7 @@ mod tests {
         #[cfg(not(miri))]
         {
             let dir = tempfile::tempdir().unwrap();
-            let sink = FsSink::new(dir.path().join("output_files"), plan, TileFormat::Png);
+            let sink = FsSink::new(dir.path().join("output_files"), plan);
             sink.finish().unwrap();
 
             let dzi_path = dir.path().join("output_files.dzi");
@@ -1494,7 +1524,7 @@ mod tests {
         #[cfg(not(miri))]
         {
             let dir = tempfile::tempdir().unwrap();
-            let sink = FsSink::new(dir.path().join("tiles"), plan, TileFormat::Raw);
+            let sink = FsSink::new(dir.path().join("tiles"), plan).with_format(TileFormat::Raw);
             sink.finish().unwrap();
 
             let dzi_path = dir.path().join("tiles.dzi");
@@ -1536,7 +1566,8 @@ mod tests {
         #[cfg(not(miri))]
         {
             let dir = tempfile::tempdir().unwrap();
-            let sink = FsSink::new(dir.path().join("tiles"), plan.clone(), TileFormat::Raw);
+            let sink =
+                FsSink::new(dir.path().join("tiles"), plan.clone()).with_format(TileFormat::Raw);
 
             let rect = plan.tile_rect(TileCoord::new(top.level, 1, 0)).unwrap();
             let tile = Tile {
@@ -1578,7 +1609,7 @@ mod tests {
             let plan = planner.plan();
             let top_level = plan.levels.last().unwrap().level;
 
-            let sink = FsSink::new(dir.path().join("out"), plan, TileFormat::Png);
+            let sink = FsSink::new(dir.path().join("out"), plan);
             let tile = Tile {
                 coord: TileCoord::new(top_level, 0, 0),
                 raster,
@@ -1619,11 +1650,8 @@ mod tests {
             let plan = planner.plan();
             let top_level = plan.levels.last().unwrap().level;
 
-            let sink = FsSink::new(
-                dir.path().join("out"),
-                plan,
-                TileFormat::Jpeg { quality: 85 },
-            );
+            let sink = FsSink::new(dir.path().join("out"), plan)
+                .with_format(TileFormat::Jpeg { quality: 85 });
             let tile = Tile {
                 coord: TileCoord::new(top_level, 0, 0),
                 raster,
@@ -1667,8 +1695,10 @@ mod tests {
 
             let dir1 = tempfile::tempdir().unwrap();
             let dir2 = tempfile::tempdir().unwrap();
-            let sink1 = FsSink::new(dir1.path().join("out"), plan.clone(), TileFormat::Raw);
-            let sink2 = FsSink::new(dir2.path().join("out"), plan.clone(), TileFormat::Raw);
+            let sink1 =
+                FsSink::new(dir1.path().join("out"), plan.clone()).with_format(TileFormat::Raw);
+            let sink2 =
+                FsSink::new(dir2.path().join("out"), plan.clone()).with_format(TileFormat::Raw);
 
             let tile = Tile {
                 coord: TileCoord::new(top.level, 0, 0),

--- a/src/sink_packfile.rs
+++ b/src/sink_packfile.rs
@@ -101,6 +101,29 @@ impl std::fmt::Debug for PackfileSink {
 }
 
 impl PackfileSink {
+    /// Start a fluent builder rooted at `path`.
+    ///
+    /// Call [`PackfileSinkBuilder::plan`] (required), then any combination of
+    /// [`PackfileSinkBuilder::format`] (default: [`PackfileFormat::Tar`])
+    /// and [`PackfileSinkBuilder::tile_format`] (default:
+    /// [`TileFormat::Png`]), then [`PackfileSinkBuilder::build`]:
+    ///
+    /// ```ignore
+    /// PackfileSink::builder("out.zip")
+    ///     .plan(plan)
+    ///     .format(PackfileFormat::Zip)
+    ///     .tile_format(TileFormat::Jpeg { quality: 85 })
+    ///     .build()?;
+    /// ```
+    pub fn builder(path: impl Into<PathBuf>) -> PackfileSinkBuilder {
+        PackfileSinkBuilder {
+            out_path: path.into(),
+            format: PackfileFormat::Tar,
+            tile_format: TileFormat::Png,
+            plan: None,
+        }
+    }
+
     /// Create a new packfile sink, opening `path` for writing and wrapping it
     /// in the requested archive format.
     ///
@@ -256,6 +279,64 @@ impl PackfileSink {
             width = self.plan.image_width,
             height = self.plan.image_height,
         )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PackfileSinkBuilder
+// ---------------------------------------------------------------------------
+
+/// Fluent builder for [`PackfileSink`].
+///
+/// Produced by [`PackfileSink::builder`]. The `plan` field is required —
+/// calling [`PackfileSinkBuilder::build`] without one returns
+/// [`SinkError::MissingField`]. The archive and tile formats default to
+/// [`PackfileFormat::Tar`] and [`TileFormat::Png`] respectively so the
+/// minimum-viable call is:
+///
+/// ```ignore
+/// PackfileSink::builder("out.tar").plan(plan).build()?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct PackfileSinkBuilder {
+    out_path: PathBuf,
+    format: PackfileFormat,
+    tile_format: TileFormat,
+    plan: Option<PyramidPlan>,
+}
+
+impl PackfileSinkBuilder {
+    /// Set the archive container format. Defaults to [`PackfileFormat::Tar`].
+    pub fn format(mut self, format: PackfileFormat) -> Self {
+        self.format = format;
+        self
+    }
+
+    /// Set the per-tile encoding format. Defaults to [`TileFormat::Png`].
+    pub fn tile_format(mut self, tile_format: TileFormat) -> Self {
+        self.tile_format = tile_format;
+        self
+    }
+
+    /// Attach the pyramid plan. Required — the archive needs the plan to
+    /// compute tile paths and emit companion manifests.
+    pub fn plan(mut self, plan: PyramidPlan) -> Self {
+        self.plan = Some(plan);
+        self
+    }
+
+    /// Finalise the configuration and open the archive for writing.
+    ///
+    /// # Errors
+    ///
+    /// * [`SinkError::MissingField`] if [`PackfileSinkBuilder::plan`] was
+    ///   never called.
+    /// * [`SinkError::Io`] if the output file cannot be created.
+    pub fn build(self) -> Result<PackfileSink, SinkError> {
+        let plan = self
+            .plan
+            .ok_or(SinkError::MissingField("PackfileSinkBuilder::plan"))?;
+        PackfileSink::new(self.out_path, self.format, plan, self.tile_format)
     }
 }
 

--- a/src/stream_verify.rs
+++ b/src/stream_verify.rs
@@ -1,0 +1,589 @@
+//! Strip-based verify implementation.
+//!
+//! This module mirrors the byte-exact verify path in
+//! [`crate::engine::run_verify`](crate::engine) without requiring the full
+//! source raster to live in memory up front. The caller supplies a
+//! [`StripSource`](crate::streaming::StripSource); the verify walker pulls
+//! the top pyramid level strip-by-strip, assembles it into a
+//! `canvas_width × canvas_height` raster, and then replays the monolithic
+//! engine's level-by-level downscale / tile-extract / tile-compare loop.
+//!
+//! The *only* memory cost above that of the monolithic verify is the top
+//! level itself — and that's an unavoidable cost of byte-exact verification
+//! against on-disk tiles, because the lower levels must be produced by the
+//! same downscale chain the engine used at generation time. What we avoid
+//! is materialising the full source image ahead of time, which for large
+//! PDFs or tiled TIFFs would otherwise dominate peak memory.
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use crate::engine::{EngineConfig, EngineError, EngineResult, StageDurations};
+use crate::observe::{EngineEvent, EngineObserver};
+use crate::planner::{PyramidPlan, TileCoord};
+use crate::raster::Raster;
+use crate::resize;
+use crate::sink::{SinkError, TileSink};
+use crate::streaming::{StripSource, obtain_canvas_strip};
+
+/// Candidate tile file extensions probed when looking for a tile on disk.
+///
+/// The sink's active format is not visible from this layer (the `TileSink`
+/// trait object doesn't expose it), so we probe the extensions produced by
+/// every [`TileFormat`](crate::sink::TileFormat) variant before declaring a
+/// tile missing. This matches the behaviour of `engine::run_verify`.
+const CANDIDATE_EXTS: [&str; 4] = ["raw", "png", "jpeg", "jpg"];
+
+/// Verify an on-disk pyramid against a streaming source.
+///
+/// Walks every tile listed in `plan`, reads the corresponding file from the
+/// checkpoint root (resolved via [`EngineConfig::checkpoint_root`] or the
+/// sink's own root), and confirms it matches what the engine would produce
+/// if it re-rendered the pyramid from `source`.
+///
+/// This is the streaming analogue of the byte-exact verify loop in
+/// `engine::run_verify`. Behaviour is identical in every respect *except*
+/// that the top-level raster is assembled on demand from
+/// [`StripSource::render_strip`] calls rather than copied from a pre-loaded
+/// [`Raster`]. Lower levels are produced by the same
+/// [`resize::downscale_half`] chain the monolithic engine uses, guaranteeing
+/// pixel-exact parity.
+///
+/// # Verification strategy per extension
+///
+/// * `raw` — byte-exact comparison against the regenerated tile. Any
+///   mismatch (truncation, flipped byte, padding drift) is reported as
+///   [`EngineError::ChecksumMismatch`].
+/// * `png` / `jpeg` / `jpg` — existence check only. Encoded tiles cannot be
+///   re-encoded bit-identically from fresh pixel data (encoder-state
+///   nondeterminism), so deeper verification is deferred to the
+///   manifest-checksum branch.
+///
+/// # Manifest checksums
+///
+/// If a `manifest.json` sits next to or inside the checkpoint root and
+/// includes a `checksums.per_tile` table, every listed tile is re-hashed
+/// with the manifest's declared algorithm and compared against the
+/// recorded digest. A mismatch returns [`EngineError::ChecksumMismatch`].
+///
+/// # Events
+///
+/// Emits the same progression events as `run_verify`:
+/// [`LevelStarted`](EngineEvent::LevelStarted) →
+/// [`TileCompleted`](EngineEvent::TileCompleted) per tile →
+/// [`LevelCompleted`](EngineEvent::LevelCompleted) per level →
+/// [`Finished`](EngineEvent::Finished) once. Strip accumulation does *not*
+/// emit [`StripRendered`](EngineEvent::StripRendered) — verify runs are
+/// observationally equivalent to the monolithic path.
+///
+/// # Errors
+///
+/// * [`EngineError::VerifyRequiresOnDiskSink`] — neither
+///   [`EngineConfig::checkpoint_root`] nor [`TileSink::checkpoint_root`]
+///   yields a readable directory.
+/// * [`EngineError::Sink`] wrapping [`SinkError::Other`] — a tile listed in
+///   the plan is missing from disk.
+/// * [`EngineError::Sink`] wrapping [`SinkError::Io`] — reading a tile
+///   file's bytes failed.
+/// * [`EngineError::ChecksumMismatch`] — the on-disk bytes differ from the
+///   regenerated tile (raw) or from the manifest digest (any format).
+/// * [`EngineError::Raster`] — the downscale chain or tile extraction
+///   failed structurally (e.g. invalid extracted region).
+///
+/// # Returned `EngineResult`
+///
+/// Matches `run_verify`: `tiles_produced = 0`, `levels_processed =
+/// plan.levels.len()`, `duration = started.elapsed()`, every other counter
+/// zero. Verify never writes to the sink and never retries, so the
+/// write-side counters have no meaningful value to report.
+pub(crate) fn verify_from_strip_source(
+    source: &dyn StripSource,
+    plan: &PyramidPlan,
+    sink: &dyn TileSink,
+    config: &EngineConfig,
+    observer: &dyn EngineObserver,
+) -> Result<EngineResult, EngineError> {
+    let started = Instant::now();
+    let root_buf = resolve_root(config, sink).ok_or(EngineError::VerifyRequiresOnDiskSink)?;
+    let root = root_buf.as_path();
+    let bg = config.background_rgb;
+
+    // Fast-fail when the on-disk checkpoint was produced from a different
+    // plan. Mirrors the Monolithic raster_verify path so verify errors on
+    // plan divergence surface structurally instead of as per-tile byte
+    // mismatches.
+    if let Some(meta) = crate::resume::JobCheckpoint::load(root)? {
+        let expected = crate::resume::compute_plan_hash(plan);
+        if meta.plan_hash != expected {
+            return Err(EngineError::PlanHashMismatch {
+                expected: meta.plan_hash,
+                got: expected,
+            });
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 1: existence pass.
+    //
+    // Walk every plan tile and confirm *some* candidate extension resolves
+    // to an on-disk file. This mirrors the first loop in `run_verify` and
+    // gives fast feedback when the output directory is clearly wrong
+    // (e.g. pointed at a stale run) before we spend time re-rendering.
+    // ------------------------------------------------------------------
+    for coord in plan.tile_coords() {
+        if find_tile_on_disk(root, plan, coord).is_none() {
+            return Err(EngineError::Sink(SinkError::Other(format!(
+                "Verify: missing tile for coord {coord:?}"
+            ))));
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 2: manifest-checksum branch.
+    //
+    // Copy of `run_verify`'s manifest handling: if a manifest.json is
+    // present and records per-tile checksums, re-hash the on-disk bytes
+    // and fail on the first mismatch.
+    // ------------------------------------------------------------------
+    if let Some(manifest) = read_manifest(root) {
+        if let Some(checksums) = manifest.get("checksums") {
+            let algo_str = checksums.get("algo").and_then(|v| v.as_str());
+            let per_tile = checksums.get("per_tile").and_then(|v| v.as_object());
+            if let (Some(algo_str), Some(per_tile)) = (algo_str, per_tile) {
+                let algo = match algo_str {
+                    "blake3" => Some(crate::manifest::ChecksumAlgo::Blake3),
+                    "sha256" => Some(crate::manifest::ChecksumAlgo::Sha256),
+                    _ => None,
+                };
+                if let Some(algo) = algo {
+                    for (rel, expected) in per_tile {
+                        let Some(expected_s) = expected.as_str() else {
+                            continue;
+                        };
+                        let abs = root.join(rel);
+                        let bytes = match std::fs::read(&abs) {
+                            Ok(b) => b,
+                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                            Err(e) => return Err(EngineError::Sink(SinkError::Io(e))),
+                        };
+                        let got = crate::checksum::hash_tile(&bytes, algo);
+                        if !got.eq_ignore_ascii_case(expected_s) {
+                            return Err(EngineError::ChecksumMismatch {
+                                tile: parse_tile_rel_path(rel)
+                                    .unwrap_or_else(|| TileCoord::new(0, 0, 0)),
+                                expected: expected_s.to_string(),
+                                got,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 3: assemble the top-level raster from `source` strips.
+    //
+    // `obtain_canvas_strip` already encapsulates every layout concern
+    // (Google padding, centring, DeepZoom/Xyz raw rows), so we defer to
+    // it instead of re-implementing the centre-blit that `embed_in_canvas`
+    // performs in the monolithic path. The helper returns canvas-space
+    // strips, which makes the concatenated buffer byte-identical to
+    // `embed_in_canvas(source, plan, bg)` even when centring is active.
+    // ------------------------------------------------------------------
+    let top_level_idx = plan.levels.len() - 1;
+    let top = &plan.levels[top_level_idx];
+    let format = source.format();
+    let bpp = format.bytes_per_pixel();
+
+    let cw = plan.canvas_width;
+    let ch = plan.canvas_height;
+    let dst_stride = cw as usize * bpp;
+    let mut canvas = vec![0u8; dst_stride * ch as usize];
+
+    // Strip height: `obtain_canvas_strip` contract only requires that
+    // strips be requested in increasing Y with monotonically incrementing
+    // heights. The exact height is a performance knob, not a correctness
+    // one — a single strip per `2 × tile_size` rows keeps peak auxiliary
+    // memory bounded to that same size, independent of canvas height.
+    let strip_h = (2 * plan.tile_size).min(ch).max(1);
+    let mut y: u32 = 0;
+    while y < ch {
+        let sh = strip_h.min(ch - y);
+        let strip = obtain_canvas_strip(source, plan, y, sh, config)?;
+        // `obtain_canvas_strip` guarantees the returned raster has width
+        // `canvas_width` for Google / centred layouts. For DeepZoom/Xyz
+        // the strip width equals the source width, which also equals
+        // `canvas_width` in those layouts (no canvas padding is applied).
+        debug_assert_eq!(strip.width(), cw);
+        debug_assert_eq!(strip.format(), format);
+        let strip_rows = strip.height() as usize;
+        let src_row_bytes = strip.width() as usize * bpp;
+        let src_stride = strip.stride();
+        let data = strip.data();
+        for row in 0..strip_rows {
+            let src_start = row * src_stride;
+            let dst_start = (y as usize + row) * dst_stride;
+            canvas[dst_start..dst_start + src_row_bytes]
+                .copy_from_slice(&data[src_start..src_start + src_row_bytes]);
+        }
+        y += sh;
+    }
+
+    let mut current = Raster::new(cw, ch, format, canvas)?;
+
+    // Sanity check: the assembled raster must match the top plan level's
+    // recorded dimensions, otherwise the downstream downscale chain will
+    // diverge from what the engine wrote. For every layout libviprs
+    // supports this is identity; guard it defensively.
+    debug_assert_eq!(current.width(), top.width);
+    debug_assert_eq!(current.height(), top.height);
+
+    // ------------------------------------------------------------------
+    // Phase 4: byte-exact verification, level-by-level, top to bottom.
+    //
+    // This is a direct transcription of `run_verify`'s second loop. The
+    // downscale cadence, tile ordering, and event emission order are all
+    // preserved; only the top-level source changes (strip-assembled
+    // rather than `embed_in_canvas`-produced).
+    // ------------------------------------------------------------------
+    for level_idx in (0..plan.levels.len()).rev() {
+        let level = &plan.levels[level_idx];
+        if level_idx < top_level_idx {
+            current = resize::downscale_half(&current)?;
+        }
+
+        observer.on_event(EngineEvent::LevelStarted {
+            level: level.level,
+            width: level.width,
+            height: level.height,
+            tile_count: level.tile_count(),
+        });
+
+        for row in 0..level.rows {
+            for col in 0..level.cols {
+                let coord = TileCoord::new(level_idx as u32, col, row);
+                observer.on_event(EngineEvent::TileCompleted { coord });
+
+                // `extract_tile_from_strip` with `strip_canvas_y = 0`
+                // applied to a full-level raster is byte-equivalent to the
+                // private `engine::extract_tile`: same rect projection,
+                // same edge padding, same Google vs. DeepZoom branching.
+                let expected =
+                    crate::streaming::extract_tile_from_strip(&current, plan, coord, 0, bg)?;
+                let expected_bytes = expected.data();
+
+                let (abs, ext) = match find_tile_on_disk(root, plan, coord) {
+                    Some(found) => found,
+                    None => {
+                        return Err(EngineError::Sink(SinkError::Other(format!(
+                            "Verify: missing tile for coord {coord:?}"
+                        ))));
+                    }
+                };
+
+                let on_disk =
+                    std::fs::read(&abs).map_err(|e| EngineError::Sink(SinkError::Io(e)))?;
+
+                if ext == "raw" && on_disk != expected_bytes {
+                    return Err(EngineError::ChecksumMismatch {
+                        tile: coord,
+                        expected: format!("{} bytes (raw)", expected_bytes.len()),
+                        got: format!(
+                            "{} bytes on disk differ from regenerated tile",
+                            on_disk.len()
+                        ),
+                    });
+                }
+                // Encoded formats (png/jpeg) fall through: existence
+                // check already passed, and fresh re-encoding is not
+                // byte-stable, so we don't compare pixel data here.
+            }
+        }
+
+        observer.on_event(EngineEvent::LevelCompleted {
+            level: level.level,
+            tiles_produced: level.tile_count(),
+        });
+    }
+
+    observer.on_event(EngineEvent::Finished {
+        total_tiles: plan.total_tile_count(),
+        levels: plan.levels.len() as u32,
+    });
+
+    Ok(EngineResult {
+        tiles_produced: 0,
+        tiles_skipped: 0,
+        levels_processed: plan.levels.len() as u32,
+        peak_memory_bytes: 0,
+        bytes_read: 0,
+        bytes_written: 0,
+        retry_count: 0,
+        queue_pressure_peak: 0,
+        duration: started.elapsed(),
+        stage_durations: StageDurations::default(),
+        skipped_due_to_failure: 0,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+//
+// These reproduce logic that `engine.rs` keeps private. They are intentionally
+// kept file-local so this module can be built without touching the engine.
+// ---------------------------------------------------------------------------
+
+/// Locate a tile on disk by probing the candidate extensions.
+///
+/// Returns `Some((absolute_path, extension))` for the first candidate that
+/// exists as a regular file, or `None` if none match.
+fn find_tile_on_disk(
+    root: &std::path::Path,
+    plan: &PyramidPlan,
+    coord: TileCoord,
+) -> Option<(PathBuf, &'static str)> {
+    for ext in &CANDIDATE_EXTS {
+        if let Some(rel) = plan.tile_path(coord, ext) {
+            let abs = root.join(&rel);
+            if abs.is_file() {
+                return Some((abs, *ext));
+            }
+        }
+    }
+    None
+}
+
+/// Resolve the on-disk checkpoint root, preferring the config override.
+///
+/// Duplicates `engine::resolve_checkpoint_root`, which is `pub(crate)` in
+/// the engine module but imported here via its full path instead of
+/// re-export to keep the module graph explicit.
+fn resolve_root(cfg: &EngineConfig, sink: &dyn TileSink) -> Option<PathBuf> {
+    crate::engine::resolve_checkpoint_root(cfg, sink)
+}
+
+/// Parse a relative tile path (as stored in `manifest.json`) back into a
+/// [`TileCoord`].
+///
+/// Accepts both DeepZoom-style paths (`"<level>/<col>_<row>.<ext>"`) and
+/// XYZ/Google-style paths (`"<level>/<col>/<row>.<ext>"`). Windows path
+/// separators are normalised. Returns `None` for any other shape.
+fn parse_tile_rel_path(rel: &str) -> Option<TileCoord> {
+    let normalized = rel.replace('\\', "/");
+    let no_ext = normalized
+        .rsplit_once('.')
+        .map(|(s, _)| s)
+        .unwrap_or(&normalized);
+    let parts: Vec<&str> = no_ext.split('/').collect();
+    match parts.as_slice() {
+        [level, last] => {
+            let level: u32 = level.parse().ok()?;
+            let (col, row) = last.split_once('_')?;
+            let col: u32 = col.parse().ok()?;
+            let row: u32 = row.parse().ok()?;
+            Some(TileCoord::new(level, col, row))
+        }
+        [level, col, row] => {
+            let level: u32 = level.parse().ok()?;
+            let col: u32 = col.parse().ok()?;
+            let row: u32 = row.parse().ok()?;
+            Some(TileCoord::new(level, col, row))
+        }
+        _ => None,
+    }
+}
+
+/// Read the manifest JSON next to the checkpoint root.
+///
+/// Probes the sibling `<root>.manifest.json` first, then `<root>/manifest.json`
+/// inside. Returns `None` if no file is found or if the contents don't parse
+/// as JSON — a missing or corrupt manifest is not a verify error on its own;
+/// it just means the checksum branch is skipped.
+fn read_manifest(root: &std::path::Path) -> Option<serde_json::Value> {
+    if let (Some(parent), Some(stem)) = (root.parent(), root.file_name()) {
+        let mut name = stem.to_os_string();
+        name.push(".manifest.json");
+        let sibling = parent.join(name);
+        if let Ok(bytes) = std::fs::read(&sibling) {
+            if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&bytes) {
+                return Some(v);
+            }
+        }
+    }
+    let inside = root.join("manifest.json");
+    if let Ok(bytes) = std::fs::read(&inside) {
+        return serde_json::from_slice::<serde_json::Value>(&bytes).ok();
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observe::NoopObserver;
+    use crate::pixel::PixelFormat;
+    use crate::planner::{Layout, PyramidPlanner};
+    use crate::sink::{FsSink, TileFormat};
+    use crate::streaming::RasterStripSource;
+
+    /// Build a deterministic RGB gradient raster of size `w × h`.
+    ///
+    /// Using a gradient (rather than a solid fill) ensures that
+    /// `downscale_half` produces distinct bytes at every level, so a
+    /// corruption test that flips a single byte cannot be masked by
+    /// blank-tile placeholders or incidentally-matching background fill.
+    fn gradient(w: u32, h: u32) -> Raster {
+        let bpp = PixelFormat::Rgb8.bytes_per_pixel();
+        let mut data = vec![0u8; w as usize * h as usize * bpp];
+        for y in 0..h {
+            for x in 0..w {
+                let off = (y as usize * w as usize + x as usize) * bpp;
+                data[off] = (x % 256) as u8;
+                data[off + 1] = (y % 256) as u8;
+                data[off + 2] = ((x.wrapping_add(y)) % 256) as u8;
+            }
+        }
+        Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    /// Generate a raw-format pyramid into a temp dir and return the
+    /// pieces a verify test needs: the sink, the plan, and the source.
+    fn build_raw_pyramid(
+        dir: &std::path::Path,
+        w: u32,
+        h: u32,
+        tile_size: u32,
+    ) -> (FsSink, PyramidPlan, Raster) {
+        let src = gradient(w, h);
+        let plan = PyramidPlanner::new(w, h, tile_size, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+        let sink = FsSink::new(dir, plan.clone()).with_format(TileFormat::Raw);
+        crate::engine::generate_pyramid_observed(
+            &src,
+            &plan,
+            &sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .unwrap();
+        (sink, plan, src)
+    }
+
+    /// Happy path: an intact raw pyramid verifies cleanly via the stream
+    /// path, reports zero tiles produced, and flags every level as
+    /// processed.
+    #[test]
+    fn stream_verify_happy_path_raw() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("tiles");
+        let (sink, plan, src) = build_raw_pyramid(&out, 256, 256, 128);
+        let strip_src = RasterStripSource::new(&src);
+
+        let res = verify_from_strip_source(
+            &strip_src,
+            &plan,
+            &sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .expect("verify should succeed on an untouched pyramid");
+
+        assert_eq!(res.tiles_produced, 0, "verify must not write tiles");
+        assert_eq!(res.levels_processed, plan.levels.len() as u32);
+    }
+
+    /// Missing-tile path: deleting a single on-disk tile must surface as
+    /// a `SinkError::Other` wrapped in `EngineError::Sink`, matching the
+    /// contract of `engine::run_verify`.
+    #[test]
+    fn stream_verify_reports_missing_tile() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("tiles");
+        let (sink, plan, src) = build_raw_pyramid(&out, 256, 256, 128);
+
+        // Pick any tile from the plan — the first one iterated — and
+        // delete every candidate-extension file that matches it on disk.
+        let victim = plan
+            .tile_coords()
+            .next()
+            .expect("plan has at least one tile");
+        for ext in &CANDIDATE_EXTS {
+            if let Some(rel) = plan.tile_path(victim, ext) {
+                let abs = out.join(&rel);
+                let _ = std::fs::remove_file(abs);
+            }
+        }
+
+        let strip_src = RasterStripSource::new(&src);
+        let err = verify_from_strip_source(
+            &strip_src,
+            &plan,
+            &sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .expect_err("verify should fail when a tile is missing");
+
+        match err {
+            EngineError::Sink(SinkError::Other(msg)) => {
+                assert!(
+                    msg.starts_with("Verify: missing tile"),
+                    "unexpected missing-tile message: {msg}"
+                );
+            }
+            other => panic!("expected SinkError::Other for missing tile, got {other:?}"),
+        }
+    }
+
+    /// Byte-corruption path: flipping a byte in one raw tile must be
+    /// detected as `EngineError::ChecksumMismatch` with the offending
+    /// `TileCoord` populated.
+    #[test]
+    fn stream_verify_detects_raw_corruption() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("tiles");
+        let (sink, plan, src) = build_raw_pyramid(&out, 256, 256, 128);
+
+        // Corrupt the first raw tile we can find — pick a tile at the
+        // bottom (level 0) so we traverse multiple downscale iterations
+        // before reaching it, exercising the full verify loop.
+        let mut corrupted: Option<TileCoord> = None;
+        'outer: for coord in plan.tile_coords() {
+            if let Some(rel) = plan.tile_path(coord, "raw") {
+                let abs = out.join(&rel);
+                if let Ok(mut bytes) = std::fs::read(&abs) {
+                    if !bytes.is_empty() {
+                        bytes[0] ^= 0xFF;
+                        std::fs::write(&abs, &bytes).unwrap();
+                        corrupted = Some(coord);
+                        break 'outer;
+                    }
+                }
+            }
+        }
+        let corrupted = corrupted.expect("pyramid should contain at least one raw tile");
+
+        let strip_src = RasterStripSource::new(&src);
+        let err = verify_from_strip_source(
+            &strip_src,
+            &plan,
+            &sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .expect_err("verify should fail on byte-corrupted raw tile");
+
+        match err {
+            EngineError::ChecksumMismatch { tile, .. } => {
+                assert_eq!(tile, corrupted, "mismatch reported on wrong tile");
+            }
+            other => panic!("expected ChecksumMismatch, got {other:?}"),
+        }
+    }
+}

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -641,7 +641,7 @@ pub fn estimate_streaming_memory(
 ///
 /// Propagates errors from the source, sink, raster operations, and the
 /// 2×2 downscale filter.
-pub fn generate_pyramid_streaming(
+pub(crate) fn generate_pyramid_streaming(
     source: &dyn StripSource,
     plan: &PyramidPlan,
     sink: &dyn TileSink,
@@ -943,34 +943,6 @@ pub fn generate_pyramid_streaming(
         stage_durations: crate::engine::StageDurations::default(),
         skipped_due_to_failure: 0,
     })
-}
-
-/// Auto-selecting entry point that chooses between monolithic and streaming.
-///
-/// Compares the estimated peak memory of the monolithic engine against the
-/// configured budget. If the monolithic path fits, it delegates to
-/// [`generate_pyramid_observed`](crate::engine::generate_pyramid_observed)
-/// for maximum throughput. Otherwise, wraps the source raster in a
-/// [`RasterStripSource`] and calls [`generate_pyramid_streaming`].
-///
-/// This is the recommended entry point when the caller has an in-memory
-/// [`Raster`] and wants automatic memory management without committing
-/// to a specific engine implementation.
-pub fn generate_pyramid_auto(
-    source: &Raster,
-    plan: &PyramidPlan,
-    sink: &dyn TileSink,
-    config: &StreamingConfig,
-    observer: &dyn EngineObserver,
-) -> Result<EngineResult, EngineError> {
-    let mono_peak = plan.estimate_peak_memory_for_format(source.format());
-
-    if mono_peak <= config.memory_budget_bytes {
-        crate::engine::generate_pyramid_observed(source, plan, sink, &config.engine, observer)
-    } else {
-        let strip_source = RasterStripSource::new(source);
-        generate_pyramid_streaming(&strip_source, plan, sink, config, observer)
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1627,7 +1599,14 @@ mod tests {
 
         // Monolithic
         let ref_sink = MemorySink::new();
-        crate::engine::generate_pyramid(&src, &plan, &ref_sink, &EngineConfig::default()).unwrap();
+        crate::engine::generate_pyramid_observed(
+            &src,
+            &plan,
+            &ref_sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .unwrap();
         let mut ref_tiles = ref_sink.tiles();
         ref_tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
 
@@ -1638,7 +1617,14 @@ mod tests {
             engine: EngineConfig::default(),
             budget_policy: BudgetPolicy::Error,
         };
-        generate_pyramid_auto(&src, &plan, &sink, &config, &NoopObserver).unwrap();
+        generate_pyramid_streaming(
+            &RasterStripSource::new(&src),
+            &plan,
+            &sink,
+            &config,
+            &NoopObserver,
+        )
+        .unwrap();
         let mut tiles = sink.tiles();
         tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
 
@@ -1705,7 +1691,14 @@ mod tests {
         let plan = planner.plan();
 
         let ref_sink = MemorySink::new();
-        crate::engine::generate_pyramid(&src, &plan, &ref_sink, &EngineConfig::default()).unwrap();
+        crate::engine::generate_pyramid_observed(
+            &src,
+            &plan,
+            &ref_sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .unwrap();
         let mut ref_tiles = ref_sink.tiles();
         ref_tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
 
@@ -1715,7 +1708,14 @@ mod tests {
             engine: EngineConfig::default(),
             budget_policy: BudgetPolicy::Error,
         };
-        generate_pyramid_auto(&src, &plan, &sink, &config, &NoopObserver).unwrap();
+        generate_pyramid_streaming(
+            &RasterStripSource::new(&src),
+            &plan,
+            &sink,
+            &config,
+            &NoopObserver,
+        )
+        .unwrap();
         let mut tiles = sink.tiles();
         tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
 
@@ -1741,7 +1741,14 @@ mod tests {
             engine: EngineConfig::default(),
             budget_policy: BudgetPolicy::Error,
         };
-        let result = generate_pyramid_auto(&src, &plan, &sink, &config, &NoopObserver).unwrap();
+        let result = generate_pyramid_streaming(
+            &RasterStripSource::new(&src),
+            &plan,
+            &sink,
+            &config,
+            &NoopObserver,
+        )
+        .unwrap();
 
         assert_eq!(result.tiles_produced, plan.total_tile_count());
     }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -182,36 +182,31 @@ impl<'a> StripSource for RasterStripSource<'a> {
 // PdfiumStripSource — true source-side PDF strip streaming
 // ---------------------------------------------------------------------------
 
-/// [`StripSource`] backed by pdfium with per-strip matrix rendering.
+/// [`StripSource`] backed by pdfium.
 ///
-/// Each [`render_strip`](StripSource::render_strip) call dispatches to
-/// `FPDF_RenderPageBitmapWithMatrix`, allocating only a `canvas_width ×
-/// strip_h × 4` bitmap (BGRA → RGBA conversion in place). No full-page raster
-/// is ever materialised on the source side, so peak source memory is
-/// `O(canvas_width × max_strip_h)` instead of the page area.
+/// At construction time, the full display-oriented page is rendered once via
+/// [`render_page_pdfium`](crate::pdf::render_page_pdfium). Each
+/// [`render_strip`](StripSource::render_strip) call then slices the cached
+/// raster — O(1) per strip, no additional pdfium calls. Dimensions are
+/// taken directly from the rendered raster so
+/// [`StripSource::width`]/[`StripSource::height`] match the output byte-for-byte.
 ///
-/// Dimensions are queried from pdfium at construction time and cached, so
-/// callers cannot mis-predict them — closing libviprs#41's panic surface.
-///
-/// Pdfium is not thread-safe; the inner mutex serialises strip renders.
+/// This currently trades source-side memory (`O(canvas_w × canvas_h)`) for
+/// correctness: pdfium's matrix render path does not auto-apply the page's
+/// intrinsic `/Rotate`, and hand-composed rotation matrices produced
+/// 180°-off output for `/Rotate 90/270` pages in practice. The form-data
+/// render path that `render_page_pdfium` uses does rotate automatically, so
+/// we fall back to full-page render + slice. See
+/// [`render_strip_inner`](Self::render_strip_inner) for details.
 #[cfg(feature = "pdfium")]
 pub struct PdfiumStripSource {
-    inner: std::sync::Mutex<PdfiumInner>,
     width: u32,
     height: u32,
-    /// Display width in PDF points (post-/Rotate). Used to compose the
-    /// rotation-aware matrix in [`render_strip_inner`].
-    disp_w_pts: f32,
-    /// Display height in PDF points (post-/Rotate).
-    disp_h_pts: f32,
     dpi: u32,
-}
-
-#[cfg(feature = "pdfium")]
-struct PdfiumInner {
-    pdfium: &'static pdfium_render::prelude::Pdfium,
-    path: std::path::PathBuf,
-    page: usize,
+    /// Full display-oriented raster, rendered at construction time and
+    /// sliced per-strip. See [`render_strip_inner`] for why we cache the
+    /// full page instead of rendering strip-by-strip.
+    full_raster: Raster,
 }
 
 #[cfg(feature = "pdfium")]
@@ -229,10 +224,9 @@ impl std::fmt::Debug for PdfiumStripSource {
 impl PdfiumStripSource {
     /// Open a PDF page as a strip source at the given DPI.
     ///
-    /// Probes pdfium for the rotation-aware page dimensions and stores them
-    /// for [`width`](StripSource::width)/[`height`](StripSource::height).
-    /// No raster is rendered yet — strips are produced on demand by
-    /// [`render_strip`](StripSource::render_strip).
+    /// Renders the full display-oriented page via pdfium and caches it.
+    /// Subsequent [`render_strip`](StripSource::render_strip) calls slice
+    /// the cached raster.
     ///
     /// # Arguments
     ///
@@ -245,15 +239,21 @@ impl PdfiumStripSource {
         dpi: u32,
     ) -> Result<Self, crate::pdf::PdfError> {
         let path = path.into();
-        let pdfium = crate::pdf::init_pdfium()?;
-        let (width, height, disp_w_pts, disp_h_pts) = probe_page_dims(pdfium, &path, page, dpi)?;
+        // Render eagerly and use the actual raster dimensions. Pdfium's
+        // `set_target_width`/`set_maximum_height` path rounds a few pixels
+        // differently than our `probe_page_dims` truncation at higher DPIs;
+        // using the cached raster's real width/height keeps
+        // `StripSource::width`/`height` in lockstep with what `render_strip`
+        // will hand back. See `render_strip_inner` for why we render the
+        // full page in the first place.
+        let full = crate::pdf::render_page_pdfium(&path, page, dpi)?;
+        let width = full.width();
+        let height = full.height();
         Ok(Self {
-            inner: std::sync::Mutex::new(PdfiumInner { pdfium, path, page }),
             width,
             height,
-            disp_w_pts,
-            disp_h_pts,
             dpi,
+            full_raster: full,
         })
     }
 
@@ -300,15 +300,14 @@ impl PdfiumStripSource {
                 budget_bytes,
             )?,
         };
-        let (width, height, disp_w_pts, disp_h_pts) =
-            probe_page_dims(pdfium, &path, page, resolved_dpi)?;
+        let full = crate::pdf::render_page_pdfium(&path, page, resolved_dpi)?;
+        let width = full.width();
+        let height = full.height();
         Ok(Self {
-            inner: std::sync::Mutex::new(PdfiumInner { pdfium, path, page }),
             width,
             height,
-            disp_w_pts,
-            disp_h_pts,
             dpi: resolved_dpi,
+            full_raster: full,
         })
     }
 
@@ -323,90 +322,25 @@ impl PdfiumStripSource {
         y_offset: u32,
         height: u32,
     ) -> Result<Raster, crate::pdf::PdfError> {
-        use pdfium_render::prelude::*;
-
-        let inner = self.inner.lock().unwrap();
-        let document = inner
-            .pdfium
-            .load_pdf_from_file(&inner.path, None)
-            .map_err(|e| crate::pdf::PdfError::Pdfium(e.to_string()))?;
-        let pages = document.pages();
-        let total = pages.len();
-        if inner.page == 0 || inner.page > total as usize {
-            return Err(crate::pdf::PdfError::PageOutOfRange {
-                page: inner.page,
-                total: total as usize,
-            });
-        }
-        let pdf_page = pages
-            .get(inner.page as u16 - 1)
-            .map_err(|e| crate::pdf::PdfError::Pdfium(e.to_string()))?;
-
+        // Pdfium's matrix-based render path (FPDF_RenderPageBitmapWithMatrix)
+        // does not auto-apply the page's intrinsic /Rotate — hand-composed
+        // rotation matrices produced 180°-off output for /Rotate 90/270
+        // pages across every variant we tried. Rather than chase pdfium's
+        // matrix conventions, we render the full display-oriented raster
+        // once via `render_page_pdfium` (the form-data path that pdfium
+        // does rotate automatically) and slice strips out of the cached
+        // buffer. This trades peak memory for correctness; a future
+        // iteration can switch back to a true single-strip render once
+        // pdfium's matrix convention is pinned down.
         let strip_h = height.min(self.height.saturating_sub(y_offset));
         if strip_h == 0 {
-            // Above the page — return a fully transparent strip so callers
-            // get a uniform shape regardless of position.
             let data = vec![0u8; self.width as usize * height as usize * 4];
             return Raster::new(self.width, height, PixelFormat::Rgba8, data)
                 .map_err(crate::pdf::PdfError::from);
         }
 
-        // FPDF_RenderPageBitmapWithMatrix does NOT honor the page's intrinsic
-        // /Rotate; we have to compose the rotation prefix ourselves. Without
-        // this, /Rotate 90/180/270 pages render in their un-rotated user-space
-        // orientation, mangled into a rotation-aware-sized bitmap.
-        let rotation = pdf_page
-            .rotation()
-            .map_err(|e| crate::pdf::PdfError::Pdfium(e.to_string()))?;
-
-        // Matrix maps PDF user-space points → strip bitmap pixels (top-left
-        // origin). For each rotation case we derived (a,b,c,d,e,f) so that
-        //   (sx, sy) = (a*x_u + c*y_u + e, b*x_u + d*y_u + f)
-        // places the page content correctly into the (display-oriented) strip.
-        // disp_w_pts/disp_h_pts are post-rotation page dims; the strip's row 0
-        // is full-page row `y_offset`, so f always carries `- y_offset`.
-        //
-        // Per-rotation derivation (W_u, H_u = un-rotated user-space dims;
-        // display dims swap for 90/270):
-        //   /Rotate 0:   display = user                  → (s, 0, 0, -s, 0, H*s - yo)
-        //   /Rotate 90:  display.x = y_u, .y = W_u - x_u → (0, s, s, 0, 0, -yo)
-        //   /Rotate 180: display = (W_u-x_u, H_u-y_u)    → (-s, 0, 0, s, W*s, -yo)
-        //   /Rotate 270: display.x = H_u - y_u, .y = x_u → (0, -s, -s, 0, W_d*s, H_d*s - yo)
-        let s = self.dpi as f32 / 72.0;
-        let disp_w_px = self.disp_w_pts * s;
-        let disp_h_px = self.disp_h_pts * s;
-        let yo = y_offset as f32;
-        let (a, b, c, d, e, f) = match rotation {
-            PdfPageRenderRotation::None => (s, 0.0, 0.0, -s, 0.0, disp_h_px - yo),
-            PdfPageRenderRotation::Degrees90 => (0.0, s, s, 0.0, 0.0, -yo),
-            PdfPageRenderRotation::Degrees180 => (-s, 0.0, 0.0, s, disp_w_px, -yo),
-            PdfPageRenderRotation::Degrees270 => (0.0, -s, -s, 0.0, disp_w_px, disp_h_px - yo),
-        };
-
-        let bindings = inner.pdfium.bindings();
-        let mut bitmap = PdfBitmap::empty(
-            self.width as Pixels,
-            strip_h as Pixels,
-            PdfBitmapFormat::BGRA,
-            bindings,
-        )
-        .map_err(|e| crate::pdf::PdfError::Pdfium(e.to_string()))?;
-
-        let config = PdfRenderConfig::new()
-            .set_fixed_size(self.width as Pixels, strip_h as Pixels)
-            .render_form_data(false)
-            .transform(a, b, c, d, e, f)
-            .map_err(|e| crate::pdf::PdfError::Pdfium(e.to_string()))?;
-
-        pdf_page
-            .render_into_bitmap_with_config(&mut bitmap, &config)
-            .map_err(|e| crate::pdf::PdfError::Pdfium(e.to_string()))?;
-
-        // pdfium-render's as_rgba_bytes() handles BGRA → RGBA per the
-        // bitmap's actual format; safer than swapping bytes manually.
-        let data = bitmap.as_rgba_bytes();
-
-        Raster::new(self.width, strip_h, PixelFormat::Rgba8, data)
+        self.full_raster
+            .extract(0, y_offset, self.width, strip_h)
             .map_err(crate::pdf::PdfError::from)
     }
 }

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -36,8 +36,10 @@ use crate::planner::{Layout, PyramidPlan, TileCoord};
 use crate::raster::Raster;
 use crate::resize;
 use crate::sink::{Tile, TileSink};
+#[cfg(test)]
+use crate::streaming::RasterStripSource;
 use crate::streaming::{
-    RasterStripSource, StripSource, compute_strip_height, emit_full_level_tiles, emit_strip_tiles,
+    StripSource, compute_strip_height, emit_full_level_tiles, emit_strip_tiles,
     fill_background_rows, find_monolithic_threshold, obtain_canvas_strip, propagate_down,
 };
 
@@ -274,7 +276,7 @@ fn emit_strip_tiles_parallel(
 /// Produces byte-identical output to the sequential streaming engine and
 /// the monolithic engine. The reduce phase uses the same `propagate_down`
 /// logic and monolithic flush.
-pub fn generate_pyramid_mapreduce(
+pub(crate) fn generate_pyramid_mapreduce(
     source: &dyn StripSource,
     plan: &PyramidPlan,
     sink: &dyn TileSink,
@@ -567,25 +569,6 @@ pub fn generate_pyramid_mapreduce(
     })
 }
 
-/// Auto-selecting entry point: monolithic if budget allows, MapReduce otherwise.
-pub fn generate_pyramid_mapreduce_auto(
-    source: &Raster,
-    plan: &PyramidPlan,
-    sink: &dyn TileSink,
-    config: &MapReduceConfig,
-    observer: &dyn EngineObserver,
-) -> Result<EngineResult, EngineError> {
-    let mono_peak = plan.estimate_peak_memory_for_format(source.format());
-
-    if mono_peak <= config.memory_budget_bytes {
-        let engine_cfg = config.engine_config();
-        crate::engine::generate_pyramid_observed(source, plan, sink, &engine_cfg, observer)
-    } else {
-        let strip_source = RasterStripSource::new(source);
-        generate_pyramid_mapreduce(&strip_source, plan, sink, config, observer)
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
@@ -644,7 +627,14 @@ mod tests {
         let plan = planner.plan();
 
         let ref_sink = MemorySink::new();
-        crate::engine::generate_pyramid(&src, &plan, &ref_sink, &EngineConfig::default()).unwrap();
+        crate::engine::generate_pyramid_observed(
+            &src,
+            &plan,
+            &ref_sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .unwrap();
         let mut ref_tiles = ref_sink.tiles();
         ref_tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
 
@@ -675,8 +665,14 @@ mod tests {
             ..MapReduceConfig::default()
         };
         let sink = MemorySink::new();
-        let result =
-            generate_pyramid_mapreduce_auto(&src, &plan, &sink, &config, &NoopObserver).unwrap();
+        let result = generate_pyramid_mapreduce(
+            &RasterStripSource::new(&src),
+            &plan,
+            &sink,
+            &config,
+            &NoopObserver,
+        )
+        .unwrap();
         assert_eq!(result.tiles_produced, plan.total_tile_count());
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,0 +1,18 @@
+//! Verify-mode entry points.
+//!
+//! Two flavours share one namespace so `EngineBuilder` can route verify
+//! runs by source kind without the rest of the crate hard-coding which
+//! helper to call:
+//!
+//! * [`raster_verify`] — walks every level via `downscale_half` against
+//!   the full in-memory source raster. Used when the caller has a
+//!   `&Raster` and picks `EngineKind::Monolithic`.
+//! * [`verify_from_strip_source`](crate::stream_verify::verify_from_strip_source)
+//!   — strip-driven verify for pull-based sources or when the caller
+//!   explicitly picks `EngineKind::Streaming` / `EngineKind::MapReduce`.
+//!
+//! Both emit the same `LevelStarted` / `TileCompleted` / `LevelCompleted`
+//! / `Finished` event stream so observers see verify runs as first-class.
+
+pub(crate) use crate::engine::raster_verify;
+pub(crate) use crate::stream_verify::verify_from_strip_source;


### PR DESCRIPTION
## v0.3.0 — builder_v1 API sweep + /Rotate correctness

Pre-1.0 API consolidation: the free `generate_pyramid_*` entry points and `FsSink::new_with_format` are gone. Every pyramid run now flows through a single `EngineBuilder` with typed per-component builders. Resume and verify are unified across every engine kind (Monolithic, Streaming, MapReduce). Also fixes `pdf_info` for rotated PDFs (#50).

### Breaking changes

- **`generate_pyramid_*` free functions deleted** in favour of `EngineBuilder`. `generate_pyramid`, `generate_pyramid_observed`, `generate_pyramid_streaming`, `generate_pyramid_auto`, `generate_pyramid_mapreduce`, `generate_pyramid_mapreduce_auto`, and `generate_pyramid_resumable` are all removed from the public API. Migration: `EngineBuilder::new(source, plan, sink).with_engine(...).run()`.
- **`FsSink::new` is 2-arg now.** The tile format moves to a builder chain: `FsSink::new(dir, plan).with_format(TileFormat::Jpeg { quality: 85 })`. The 3-arg `FsSink::new_with_format` deprecated alias is also removed.
- **`ResumePolicy` routes through `EngineBuilder::with_resume`** across every engine kind. `generate_pyramid_resumable` is now `pub(crate)` and only reachable through the builder.

### Features

- **`EngineBuilder<'a, S: TileSink>`** — fluent single entry point, generic over sink for monomorphic `.run()`. Setters for engine kind, failure/retry policies, resume policy, dedupe, blank-tile strategy, memory budget + budget policy, concurrency, buffer size, observers (by value or `Arc`), and an extension hatch for downstream context.
- **`EngineKind`** — `#[non_exhaustive]` enum: `Auto` (default), `Monolithic`, `Streaming`, `MapReduce`. `Auto` resolves by source kind.
- **`EngineSource<'a>` + `IntoEngineSource<'a>`** — implicit conversion for `&Raster` and any `T: StripSource`.
- **`Extensions`** — `TypeId`-keyed `Send + Sync + 'static` map (http::Extensions shape) for third-party pipeline context.
- **`stream_verify` / `verify` modules** — Streaming and MapReduce engines now support `ResumeMode::Verify` via strip-driven verification (previously `IncompatibleSource`).
- **`PackfileSinkBuilder`** — `PackfileSink::builder(path).plan(...).format(...).tile_format(...).build()` replaces the four-argument positional ctor.
- **`FsSink::with_format(fmt)`** — tile format overrideable through the builder chain.
- **`RetryPolicy::fail_fast()`** / **`::with_max(n)`** — shorthand constructors.
- **`EngineError::IncompatibleSource { kind, reason }`** — typed error for engine × source mismatches.
- **Blanket `impl TileSink for &T` and `for Box<T>`** — `EngineBuilder::new` accepts borrowed or boxed sinks without caller wrapping.
- **`EngineObserver` threaded through the resumable path** — resume runs emit the same event stream as non-resume runs.
- **`ResumePolicy` extended to Streaming and MapReduce engines** — every engine × source combination now supports Overwrite / Resume / Verify uniformly.

### Fixes

- **`pdf_info` honors `/Rotate`** (#53, closes #50) — `get_page_dimensions` now returns display-oriented dimensions, applying the effective `/Rotate` (inherited through the `/Parent` Pages tree per PDF 1.7 §7.7.3.3) and swapping width/height for 90/270 rotations. Negative values and malformed page trees handled safely (`rem_euclid` normalisation, 64-step walk cap, self-reference guard). 9 new unit tests pin the contract.
- **`PdfiumStripSource` strip rendering correctness** — the matrix render path produced 180°-off output for `/Rotate 90/270` pages. Interim fix: render the full display-oriented page once via the form-data render path and slice strips. True windowed-render via the libviprs `pdfium-render` fork is staged for a follow-up release.

### Chore

- Bump version to `0.3.0`.

### Paired PRs

- libviprs-cli (sibling release PR) — routes CLI through `EngineBuilder`.
- libviprs-tests (sibling release PR) — migrates all tests off free fns; adds 63 new tests covering stream-verify + resume matrix.