### PR TITLE
test: gate filesystem-touching tests under Miri isolation

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2106,6 +2106,7 @@ mod tests {
     /// against a CollectingObserver and asserts each one drives at least
     /// the expected shape of events.
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn resumable_emits_observer_events() {
         use std::sync::Arc;
 

--- a/src/stream_verify.rs
+++ b/src/stream_verify.rs
@@ -479,6 +479,7 @@ mod tests {
     /// path, reports zero tiles produced, and flags every level as
     /// processed.
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn stream_verify_happy_path_raw() {
         let tmp = tempfile::tempdir().unwrap();
         let out = tmp.path().join("tiles");
@@ -502,6 +503,7 @@ mod tests {
     /// a `SinkError::Other` wrapped in `EngineError::Sink`, matching the
     /// contract of `engine::run_verify`.
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn stream_verify_reports_missing_tile() {
         let tmp = tempfile::tempdir().unwrap();
         let out = tmp.path().join("tiles");
@@ -545,6 +547,7 @@ mod tests {
     /// detected as `EngineError::ChecksumMismatch` with the offending
     /// `TileCoord` populated.
     #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn stream_verify_detects_raw_corruption() {
         let tmp = tempfile::tempdir().unwrap();
         let out = tmp.path().join("tiles");


### PR DESCRIPTION
## Summary
- The Miri job in \`merge-gate.yml\` fails on tests that call \`mkdir(2)\` via \`tempfile::tempdir()\` because Miri's isolation mode blocks filesystem syscalls.
- Match the existing convention (\`resume.rs\`, \`sink_packfile.rs\`, \`dedupe.rs\`, \`source.rs\`) by adding \`#[cfg_attr(miri, ignore)]\` to the four offenders:
  - \`engine::resumable_emits_observer_events\`
  - \`stream_verify::stream_verify_happy_path_raw\`
  - \`stream_verify::stream_verify_reports_missing_tile\`
  - \`stream_verify::stream_verify_detects_raw_corruption\`

Native test runs are unchanged.

## Test plan
- [x] Pre-push test suite passed locally (Docker, arm64) — full sibling \`libviprs-tests\` suite green
- [ ] Miri job in \`merge-gate.yml\` passes on CI
- [ ] Native CI tests still green

## Note
The pre-push hook also surfaced a flaky \`phase3_resume::checkpoint_written_periodically\` assertion in \`libviprs-tests\` (mtime-coalescing under Docker-on-macOS); fixed independently in libviprs/libviprs-tests#39.