### PR TITLE
docs: add CHANGELOG.md and MIGRATION.md for 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+All notable changes to libviprs are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] — 2026-04-25
+
+The headline change in 0.3.0 is `EngineBuilder`: the five free-function entry
+points (`generate_pyramid`, `generate_pyramid_observed`,
+`generate_pyramid_streaming`, `generate_pyramid_mapreduce`,
+`generate_pyramid_mapreduce_auto`) and `generate_pyramid_resumable` are gone,
+replaced by a single typed builder that routes to the monolithic, streaming,
+or map-reduce engines. `FsSink` also moved to a 2-arg constructor plus a
+`with_format` builder.
+
+See [MIGRATION.md](./MIGRATION.md) for before/after snippets for the most
+common 0.2.0 call sites.
+
+### Added
+
+- `EngineBuilder` and `EngineKind` (`Auto`, `Monolithic`, `Streaming`,
+  `MapReduce`) — single typed entry point that routes to every engine.
+- `EngineSource` enum and `IntoEngineSource` trait so `EngineBuilder::new`
+  accepts either `&Raster` or any `T: StripSource` directly.
+- `extensions` module and `EngineBuilder::with_extension::<T>(value)` typed
+  extension bag.
+- `EngineError::IncompatibleSource` for engines that cannot accept the source
+  kind they were handed (e.g. `Monolithic` with a strip source).
+- `ResumePolicy` (factories `overwrite()`, `resume()`, `verify()`, plus
+  `with_checkpoint_every` / `with_checkpoint_root`) wired through the builder
+  via `with_resume(...)`. Honored by every engine — Monolithic, Streaming, and
+  MapReduce.
+- `RetryPolicy::fail_fast()` and `RetryPolicy::with_max(n)` convenience
+  constructors; `FailurePolicy` and `RetryPolicy` are first-class on the
+  builder via `with_retry(...)` / `with_failure_policy(...)`.
+- `DedupeStrategy` exposed on the builder via `with_dedupe(...)` and on
+  `FsSink` via `.with_dedupe(...)`.
+- Full lifecycle `EngineEvent` variants: `SourceLoadStarted`, `SourceLoaded`,
+  `PlanCreated`, `LevelStarted`, `LevelCompleted`, `StripRendered`,
+  `BatchStarted`, `BatchCompleted`, `Finished`, `PipelineComplete` (alongside
+  the existing `TileCompleted`).
+- `EngineObserver` is threaded through every engine via
+  `EngineBuilder::with_observer(...)` and `with_observer_arc(...)`.
+- `PackfileSink::builder(path)` + `PackfileSinkBuilder` fluent form
+  (`.plan(...).format(...).tile_format(...).build()`); `SinkError::MissingField`
+  variant surfaced when a required field is omitted.
+- `FsSink::with_format(TileFormat)` builder method.
+- `stream_verify` module — verify pyramid output against the source.
+- `pixel::PixelFormat` is now public and re-exported at the crate root (used by
+  `EngineEvent::SourceLoaded`).
+- Blanket `impl TileSink for &T` so `&FsSink` and friends work where a
+  `TileSink` is required.
+- `pdfium-static` cargo feature (pulls in `pdfium` plus
+  `pdfium-render/static`) for statically linking libpdfium.
+
+### Changed (breaking)
+
+- `FsSink::new` is now 2-arg: `FsSink::new(dir, plan)`. Format is set via
+  `.with_format(TileFormat)`; default remains `TileFormat::Png`.
+- `EngineBuilder::with_config(EngineConfig)` is the supported way to override
+  the full `EngineConfig`; the old per-call `&EngineConfig` argument is no
+  longer accepted by free functions because the free functions no longer
+  exist.
+
+### Removed (breaking)
+
+- Free functions `generate_pyramid`, `generate_pyramid_observed`,
+  `generate_pyramid_streaming`, `generate_pyramid_mapreduce`,
+  `generate_pyramid_mapreduce_auto` — use `EngineBuilder` with the
+  appropriate `EngineKind`.
+- `generate_pyramid_resumable` — absorbed into
+  `EngineBuilder::with_resume(ResumePolicy::resume())`. The internal helper
+  is now `pub(crate)`.
+- `FsSink::new_with_format(...)` — kept as a deprecated alias of
+  `FsSink::new(...).with_format(...)`; will be removed in a future release.
+
+### Fixed
+
+- `pdf_info` honors `/Rotate` when computing page dimensions.
+- `PdfiumStripSource` now renders the full page once, then slices strips,
+  fixing inconsistencies at strip boundaries on rotated pages.
+- `RetryPolicy` backoff rounds nanoseconds to avoid floating-point truncation.
+- Phase-3 filesystem tests are gated under Miri via
+  `#[cfg_attr(miri, ignore)]`.
+
+### Internal
+
+- Build patches `pdfium-render` against the `libviprs/pdfium-render` fork.
+- Version bumped to 0.3.0.
+
+## [0.2.0] — 2025
+
+Phase-3 hardening: manifest v1, sinks, resume, retry, dedupe, tracing.
+
+[0.3.0]: https://github.com/libviprs/libviprs/releases/tag/v0.3.0
+[0.2.0]: https://github.com/libviprs/libviprs/releases/tag/v0.2.0

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,145 @@
+# Migrating from libviprs 0.2.0 to 0.3.0
+
+0.3.0 collapses every pyramid entry point into a single `EngineBuilder` and
+flips `FsSink::new` to a 2-arg constructor plus a `with_format` builder. This
+guide covers the call sites you are most likely to update.
+
+## `FsSink`
+
+The third format argument is gone. Set the format via the builder; default is
+`TileFormat::Png`.
+
+```rust
+// 0.2.0
+let sink = FsSink::new("out", plan.clone(), TileFormat::Png);
+
+// 0.3.0
+let sink = FsSink::new("out", plan.clone()).with_format(TileFormat::Png);
+```
+
+`FsSink::new_with_format(...)` still compiles as a deprecated alias of
+`FsSink::new(...).with_format(...)`.
+
+## Free `generate_pyramid_*` functions → `EngineBuilder`
+
+All five free functions plus `generate_pyramid_resumable` are removed. Replace
+each call with `EngineBuilder::new(source, plan, sink)` and pick the engine
+via `with_engine(EngineKind::...)` (omit it for `Auto`).
+
+### Monolithic (in-memory)
+
+```rust
+// 0.2.0
+let result = generate_pyramid(&raster, &plan, &sink, &config)?;
+
+// 0.3.0
+let result = EngineBuilder::new(&raster, plan, sink)
+    .with_config(config)
+    .run()?;
+```
+
+### Observed monolithic
+
+```rust
+// 0.2.0
+let result = generate_pyramid_observed(&raster, &plan, &sink, &config, &observer)?;
+
+// 0.3.0
+let result = EngineBuilder::new(&raster, plan, sink)
+    .with_config(config)
+    .with_observer(observer)
+    .run()?;
+```
+
+### Streaming
+
+```rust
+// 0.2.0
+let result = generate_pyramid_streaming(&strip_src, &plan, &sink, &cfg, &observer)?;
+
+// 0.3.0
+let result = EngineBuilder::new(strip_src, plan, sink)
+    .with_engine(EngineKind::Streaming)
+    .with_memory_budget(cfg.memory_budget_bytes)
+    .with_budget_policy(cfg.budget_policy)
+    .with_observer(observer)
+    .run()?;
+```
+
+### MapReduce (and the `_auto` variant)
+
+```rust
+// 0.2.0
+let result = generate_pyramid_mapreduce(&strip_src, &plan, &sink, &cfg, &observer)?;
+// or
+let result = generate_pyramid_mapreduce_auto(&strip_src, &plan, &sink, &cfg, &observer)?;
+
+// 0.3.0
+let result = EngineBuilder::new(strip_src, plan, sink)
+    .with_engine(EngineKind::MapReduce)
+    .with_observer(observer)
+    .run()?;
+```
+
+`EngineKind::Auto` (the default) picks Monolithic, Streaming, or MapReduce
+based on the source kind and memory budget.
+
+### Resumable
+
+`generate_pyramid_resumable` is absorbed into `EngineBuilder` and works for
+every engine, not just the monolithic path.
+
+```rust
+// 0.2.0
+let result = generate_pyramid_resumable(
+    &raster, &plan, &sink, &config, &observer, checkpoint_root,
+)?;
+
+// 0.3.0
+let result = EngineBuilder::new(&raster, plan, sink)
+    .with_config(config)
+    .with_observer(observer)
+    .with_resume(
+        ResumePolicy::resume()
+            .with_checkpoint_root(checkpoint_root)
+            .with_checkpoint_every(64),
+    )
+    .run()?;
+```
+
+`ResumePolicy::overwrite()`, `::resume()`, and `::verify()` anchor the mode;
+`with_checkpoint_every` and `with_checkpoint_root` tune persistence.
+`Default` is `Overwrite`.
+
+## Observers / events
+
+`EngineEvent` now covers the full pipeline lifecycle:
+
+- `SourceLoadStarted { source_description }`
+- `SourceLoaded { width, height, format: PixelFormat, size_bytes }`
+- `PlanCreated { levels, total_tiles, canvas_width, canvas_height }`
+- `LevelStarted { level, width, height, tile_count }`
+- `TileCompleted { coord }`
+- `LevelCompleted { level, tiles_produced }`
+- `StripRendered { strip_index, total_strips }` (Streaming)
+- `BatchStarted { batch_index, strips_in_batch, total_batches }` (MapReduce)
+- `BatchCompleted { batch_index, tiles_produced }` (MapReduce)
+- `Finished { total_tiles, levels }`
+- `PipelineComplete`
+
+`EngineBuilder::with_observer(impl EngineObserver + 'static)` and
+`with_observer_arc(Arc<dyn EngineObserver>)` feed every engine — Monolithic,
+Streaming, and MapReduce — so a single observer implementation works against
+all of them. `PixelFormat` is now public and re-exported at the crate root.
+
+## Cargo features
+
+| Feature | Default | Purpose |
+|---|---|---|
+| `pdfium` | off | Vector PDF rendering, `PdfiumStripSource`, `render_page_pdfium*` |
+| `pdfium-static` | off | New in 0.3.0 — pulls in `pdfium` plus `pdfium-render/static` for static linking of libpdfium |
+| `s3` | off | Gates `ObjectStoreSink` against a user-injected `ObjectStore` |
+| `tracing` | off | Structured spans/events |
+| `packfile` | off | `PackfileSink` (write tiles into a tar/zip), now with `PackfileSinkBuilder` |
+
+`default = []` — no features enabled by default. MSRV is 1.85, edition 2024.


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` (Keep-a-Changelog) for the 0.3.0 release covering the `EngineBuilder` rollout, the `FsSink` 2-arg shape change, removed free `generate_pyramid_*` functions, `ResumePolicy`/`RetryPolicy`/`DedupeStrategy`, the new `EngineEvent` lifecycle variants, and the `pdfium-static` cargo feature.
- Add `MIGRATION.md` with copy-pasteable 0.2.0 -> 0.3.0 before/after snippets for `FsSink::new`, every removed free function (monolithic, observed, streaming, mapreduce, mapreduce-auto, resumable), the expanded `EngineEvent` set, and the cargo feature table.

Both files are new; no existing files are modified. Bullets are cross-checked against `git log v0.2.0..HEAD`, `Cargo.toml` (version 0.3.0), and `src/lib.rs` re-exports.

## Test plan

- [ ] `CHANGELOG.md` renders cleanly on the GitHub release page.
- [ ] `MIGRATION.md` snippets `cargo check` against libviprs 0.3.0 in a downstream project.
- [ ] No broken links between `CHANGELOG.md` and `MIGRATION.md`.