### PR TITLE
docs: cross-reference interactive CLI documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,23 @@ A pure-Rust, thread-safe image pyramiding engine. Inspired by [libvips](https://
 
 Takes blueprint PDFs and images, extracts raster data, optionally geo-references it, and generates tile pyramids (DeepZoom, XYZ, Google Maps) suitable for web-based viewers.
 
+**Try it interactively:** the [CLI docs page](https://libviprs.org/cli/) lets you tick flags and copy a complete Rust program — start from the [pyramid base setup](https://libviprs.org/cli/#pyramid-base-setup) and toggle features in the [generator panel](https://libviprs.org/cli/#cli-generator).
+
 ## Features
 
 - **PDF extraction** — extract embedded raster images from scanned blueprint PDFs via lopdf (pure Rust, no C dependencies)
-- **PDF rendering** — render vector PDFs (AutoCAD exports, text, paths) via PDFium, with optional memory-budgeted rendering (optional `pdfium` feature)
+- **PDF rendering** — render vector PDFs (AutoCAD exports, text, paths) via PDFium, with optional [memory-budgeted rendering](https://libviprs.org/cli/#flag-memory-budget) (optional `pdfium` feature)
 - **Image decoding** — JPEG, PNG, TIFF via the `image` crate
-- **Tile pyramid generation** — three engines (Monolithic, Streaming, MapReduce) routed through `EngineBuilder` / `EngineKind` (`Auto` by default), with backpressure and configurable tile size and overlap
+- **Tile pyramid generation** — three engines (Monolithic, Streaming, MapReduce) routed through `EngineBuilder` / `EngineKind` (`Auto` by default), with backpressure and configurable tile size and overlap (see [`--parallel`](https://libviprs.org/cli/#flag-parallel))
 - **Layout formats** — DeepZoom (`.dzi` + directory tree), XYZ (`z/x/y`), and Google Maps (`z/y/x`, power-of-2 grids)
 - **Centre support** — centre image within the tile grid with even background padding on all sides
 - **Tile encoding** — PNG, JPEG (configurable quality), or raw pixel output
 - **Blank tile optimization** — configurable `BlankTileStrategy` to either emit full tiles or write 1-byte placeholders (`BLANK_TILE_MARKER`) for uniform-color regions, reducing disk usage for sparse images
 - **Edge tile background** — configurable background color (`background_rgb`) for padding partial tiles at image edges (defaults to white)
-- **Geo-referencing** — affine transform mapping pixel coordinates to geographic coordinates, GCP support
-- **Observability** — progress events, per-level callbacks, peak memory tracking
+- **Geo-referencing** — affine transform mapping pixel coordinates to geographic coordinates, GCP support ([`--geo-reference`](https://libviprs.org/cli/#flag-geo-reference))
+- **Restart-safe runs** — checkpoint and [resume](https://libviprs.org/cli/#flag-resume) interrupted jobs, with content-addressed [tile dedupe](https://libviprs.org/cli/#flag-dedupe) and per-tile [checksums](https://libviprs.org/cli/#flag-checksums)
+- **Sinks** — filesystem, [packfile](https://libviprs.org/cli/#flag-packfile) (tar/zip), and [S3-compatible](https://libviprs.org/cli/#flag-s3) object stores
+- **Observability** — progress events, per-level callbacks, peak memory tracking, optional structured [tracing](https://libviprs.org/cli/#flag-tracing)
 
 ## Usage
 
@@ -64,6 +68,8 @@ println!(
     result.tiles_produced, result.levels_processed, result.tiles_skipped,
 );
 ```
+
+> See [interactive example](https://libviprs.org/cli/#cli-generator) — tick flags on the CLI docs page to generate a tailored version of this snippet.
 
 ## Modules
 

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -45,6 +45,13 @@ fn checksum_algo_from_manifest_str(s: &str) -> Option<ChecksumAlgo> {
 // ---------------------------------------------------------------------------
 
 /// How a sink should treat checksums.
+///
+/// The CLI surfaces this via
+/// [`--manifest-emit-checksums`](https://libviprs.org/cli/#flag-manifest-emit-checksums)
+/// (and, when verification is requested,
+/// [`--verify`](https://libviprs.org/cli/#flag-verify)).
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-manifest-emit-checksums)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum ChecksumMode {
     /// Do not compute or emit any per-tile checksums.
@@ -85,6 +92,11 @@ pub fn hash_tile(bytes: &[u8], algo: ChecksumAlgo) -> String {
 // ---------------------------------------------------------------------------
 
 /// Summary of what [`verify_output`] found.
+///
+/// Produced by the CLI's [`--verify`](https://libviprs.org/cli/#flag-verify)
+/// post-hoc check.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-verify)
 #[derive(Debug, Clone, Default)]
 pub struct VerifyReport {
     /// Total number of tile entries considered (== size of the manifest's
@@ -99,6 +111,10 @@ pub struct VerifyReport {
 }
 
 /// Errors produced by [`verify_output`].
+///
+/// Surfaced by the CLI's [`--verify`](https://libviprs.org/cli/#flag-verify) flag.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-verify)
 #[derive(Debug, Error)]
 pub enum VerifyError {
     #[error("manifest.json not found (checked {sibling} and {inside})")]

--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -40,6 +40,12 @@ use crate::manifest::ChecksumAlgo;
 // ---------------------------------------------------------------------------
 
 /// Selects how tiles are content-addressed prior to being written to disk.
+///
+/// CLI users pick a strategy via
+/// [`--dedupe-blanks`](https://libviprs.org/cli/#flag-dedupe-blanks) (blanks-only)
+/// or [`--dedupe-all`](https://libviprs.org/cli/#flag-dedupe-all) (every tile).
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-dedupe-blanks)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum DedupeStrategy {
@@ -48,9 +54,13 @@ pub enum DedupeStrategy {
     None,
     /// Only blank (uniform-colour) tiles are deduplicated. Non-blank tiles
     /// are written individually.
+    ///
+    /// CLI: [`--dedupe-blanks`](https://libviprs.org/cli/#flag-dedupe-blanks).
     Blanks,
     /// Every tile is content-addressed; identical tiles share a single
     /// physical file regardless of whether they're blank.
+    ///
+    /// CLI: [`--dedupe-all`](https://libviprs.org/cli/#flag-dedupe-all).
     All {
         /// Hash algorithm used to derive the shared-key filename.
         algo: ChecksumAlgo,
@@ -62,6 +72,11 @@ pub enum DedupeStrategy {
 // ---------------------------------------------------------------------------
 
 /// Outcome of a [`DedupeIndex::record`] call.
+///
+/// Drives the on-disk layout produced by the CLI's
+/// [`--dedupe-blanks`](https://libviprs.org/cli/#flag-dedupe-blanks) flag.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-dedupe-blanks)
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DedupeDecision {
@@ -139,6 +154,11 @@ struct DedupeState {
 /// In-memory mapping from content-hash to shared-key. One instance per
 /// generation run; not persisted across restarts (resume-mode sinks rebuild
 /// the index by walking `_shared/`).
+///
+/// Constructed under the hood when the CLI runs with
+/// [`--dedupe-blanks`](https://libviprs.org/cli/#flag-dedupe-blanks).
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-dedupe-blanks)
 #[non_exhaustive]
 pub struct DedupeIndex {
     strategy: DedupeStrategy,
@@ -301,6 +321,11 @@ impl DedupeIndex {
 
 /// Outcome of [`materialize_reference`]: which strategy was ultimately used
 /// to point `tile_path` at `shared_path`.
+///
+/// Reflects the link/placeholder fallback chain triggered by
+/// [`--dedupe-blanks`](https://libviprs.org/cli/#flag-dedupe-blanks).
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-dedupe-blanks)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum LinkResult {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -115,6 +115,9 @@ pub enum BlankTileStrategy {
 /// for filesystem-backed usage and the
 /// [CLI pyramid command](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 /// for command-line construction of this config.
+///
+/// **See also:** the [interactive CLI generator](https://libviprs.org/cli/#cli-generator)
+/// composes a runnable program from these same knobs.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct EngineConfig {
@@ -160,6 +163,8 @@ impl EngineConfig {
     ///
     /// `0` (the default) means single-threaded execution on the calling thread.
     /// Any positive value spawns that many workers per pyramid level.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-concurrency).
     pub fn with_concurrency(mut self, n: usize) -> Self {
         self.concurrency = n;
         self
@@ -170,6 +175,8 @@ impl EngineConfig {
     /// A smaller buffer limits memory usage but may cause producers to block
     /// more frequently. A larger buffer smooths out sink latency at the cost
     /// of higher peak memory.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-buffer-size).
     pub fn with_buffer_size(mut self, n: usize) -> Self {
         self.buffer_size = n;
         self
@@ -178,6 +185,9 @@ impl EngineConfig {
     /// Sets the strategy for handling blank (uniform-color) tiles.
     ///
     /// See [`BlankTileStrategy`] for the available options.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-skip-blank)
+    /// (and the related [`--blank-tolerance`](https://libviprs.org/cli/#flag-blank-tolerance) flag).
     pub fn with_blank_tile_strategy(mut self, strategy: BlankTileStrategy) -> Self {
         self.blank_tile_strategy = strategy;
         self
@@ -190,6 +200,8 @@ impl EngineConfig {
     /// (`FailFast` / `RetryThenFail`) or is accounted into
     /// [`EngineResult::skipped_due_to_failure`] and the run continues
     /// (`RetryThenSkip`).
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-failure-policy).
     pub fn with_failure_policy(mut self, policy: FailurePolicy) -> Self {
         self.failure_policy = policy;
         self
@@ -209,6 +221,9 @@ impl EngineConfig {
     /// In the Phase 2b stub this records the strategy on the config but does
     /// not yet drive engine-level deduplication (sinks that accept a
     /// [`DedupeStrategy`] continue to apply their own per-sink dedupe).
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-dedupe-blanks)
+    /// (and the related [`--dedupe-all`](https://libviprs.org/cli/#flag-dedupe-all) flag).
     pub fn with_dedupe_strategy(mut self, strategy: crate::dedupe::DedupeStrategy) -> Self {
         self.dedupe_strategy = Some(strategy);
         self

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -49,6 +49,8 @@ use crate::streaming_mapreduce::{MapReduceConfig, generate_pyramid_mapreduce};
 ///
 /// `#[non_exhaustive]` so future engine variants (e.g. `Gpu`, `Distributed`,
 /// `Remote`) can be added as minor-version additions.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-parallel).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum EngineKind {
@@ -122,6 +124,9 @@ where
 /// Generic over the sink type so `.run()` is monomorphic for single-sink
 /// callers; use `EngineBuilder<'a, Box<dyn TileSink>>` when different match
 /// arms need to return different concrete sinks.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#pyramid)
+/// for an end-to-end runnable program built from these setters.
 pub struct EngineBuilder<'a, S: TileSink> {
     source: EngineSource<'a>,
     plan: PyramidPlan,
@@ -208,6 +213,8 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 
     /// Select which engine implementation [`EngineBuilder::run`] will
     /// dispatch to. Defaults to [`EngineKind::Auto`].
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-parallel).
     pub fn with_engine(mut self, kind: EngineKind) -> Self {
         self.engine_kind = kind;
         self
@@ -257,12 +264,16 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
     /// Set the [`FailurePolicy`] the engine consults when a tile write
     /// terminally fails. Overrides any earlier [`EngineBuilder::with_retry`]
     /// call.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-retry-max).
     pub fn with_failure_policy(mut self, policy: FailurePolicy) -> Self {
         self.failure_policy = Some(policy);
         self
     }
 
     /// Shorthand for `with_failure_policy(FailurePolicy::RetryThenFail(policy))`.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-retry-max).
     pub fn with_retry(self, policy: RetryPolicy) -> Self {
         self.with_failure_policy(FailurePolicy::RetryThenFail(policy))
     }
@@ -270,6 +281,10 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
     /// Control resume / verify behaviour. Only the engine's resumable path
     /// consults this; see [`ResumePolicy`] for the mode selector and the
     /// checkpoint-persistence knobs.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume),
+    /// plus the related [`--overwrite`](https://libviprs.org/cli/#flag-overwrite)
+    /// and [`--verify`](https://libviprs.org/cli/#flag-verify) flags.
     pub fn with_resume(mut self, policy: ResumePolicy) -> Self {
         self.resume = Some(policy);
         self
@@ -277,12 +292,16 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 
     /// Select a content-addressed deduplication strategy. See
     /// [`DedupeStrategy`] for variants.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-dedupe-blanks).
     pub fn with_dedupe(mut self, strategy: DedupeStrategy) -> Self {
         self.dedupe = Some(strategy);
         self
     }
 
     /// Control how blank (uniform-colour) tiles are handled.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-skip-blank).
     pub fn with_blank_strategy(mut self, strategy: BlankTileStrategy) -> Self {
         self.blank_strategy = Some(strategy);
         self
@@ -295,12 +314,16 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
     }
 
     /// Worker-thread concurrency (0 = single-threaded on the caller's thread).
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-concurrency).
     pub fn with_concurrency(mut self, n: usize) -> Self {
         self.concurrency = Some(n);
         self
     }
 
     /// Capacity of the producer→sink bounded channel.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-buffer-size).
     pub fn with_buffer_size(mut self, n: usize) -> Self {
         self.buffer_size = Some(n);
         self
@@ -308,6 +331,8 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 
     /// Soft memory budget in bytes. Drives strip-height selection in the
     /// streaming and map-reduce engines.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-memory-budget).
     pub fn with_memory_budget(mut self, bytes: u64) -> Self {
         self.memory_budget_bytes = Some(bytes);
         self
@@ -315,6 +340,8 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 
     /// Decide what happens when the requested budget is too tight for the
     /// worst-case minimum aligned strip.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-memory-budget).
     pub fn with_budget_policy(mut self, policy: BudgetPolicy) -> Self {
         self.budget_policy = Some(policy);
         self

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -42,6 +42,8 @@ type BoxedAny = Box<dyn Any + Send + Sync>;
 /// one was present. The internal [`HashMap`] is lazily allocated so an
 /// [`EngineBuilder`](crate::EngineBuilder) that never sets an extension
 /// pays no heap cost.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#pyramid)
 #[derive(Default)]
 pub struct Extensions {
     map: Option<HashMap<TypeId, BoxedAny>>,

--- a/src/geo.rs
+++ b/src/geo.rs
@@ -24,6 +24,8 @@
 ///
 /// - [pdf_to_georeferenced_pyramid_memory](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_to_pyramid.rs)
 ///   constructs `PixelCoord` values when verifying geo bounds for tile centers.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-geo-origin)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PixelCoord {
     pub x: f64,
@@ -47,6 +49,8 @@ pub struct PixelCoord {
 ///   creates `GeoCoord` origins to geo-reference a PDF-extracted raster.
 /// - [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 ///   parses `--geo-origin` flag values into `GeoCoord`.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-geo-origin)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GeoCoord {
     pub x: f64,
@@ -71,6 +75,9 @@ pub struct GeoCoord {
 ///   centers fall within the expected geographic bounds.
 /// - [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 ///   builds a `GeoTransform` from the `--geo-origin` and `--geo-scale` flags.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-geo-origin)
+/// (and [`--geo-scale`](https://libviprs.org/cli/#flag-geo-scale))
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GeoTransform {
     pub a: f64,
@@ -316,6 +323,8 @@ impl GeoTransform {
 /// - [pdf_to_georeferenced_pyramid_memory](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_to_pyramid.rs)
 ///   obtains a `GeoBounds` via `image_bounds` and asserts that interior
 ///   tile centres are contained within it.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-geo-origin)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GeoBounds {
     pub min: GeoCoord,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,9 @@
 //! for comprehensive integration tests, and
 //! [libviprs-cli](https://github.com/libviprs/libviprs-cli) for a command-line
 //! tool demonstrating every public API.
+//!
+//! **See also:** the [interactive CLI documentation](https://libviprs.org/cli/)
+//! bundles every public knob into runnable examples.
 
 pub mod checksum;
 pub mod dedupe;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -69,6 +69,11 @@ pub type BlankReferences = BTreeMap<String, String>;
 ///
 /// Serializes as a lowercase string (`"blake3"` / `"sha256"`) so the
 /// manifest.json is human-readable and stable across releases.
+///
+/// Selected from the CLI via [`--checksum-algo`](https://libviprs.org/cli/#flag-checksum-algo),
+/// which accepts `blake3` (default) or `sha256`.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-checksum-algo)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ChecksumAlgo {
@@ -485,6 +490,11 @@ impl ManifestV1 {
 /// [`Manifest::V1`]. Unknown versions produce a deserialization error, which
 /// is the intentional contrast with the forward-compatible "unknown inner
 /// fields are ignored" policy on [`ManifestV1`].
+///
+/// Manifest emission is enabled from the CLI via
+/// [`--manifest-emit-checksums`](https://libviprs.org/cli/#flag-manifest-emit-checksums).
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-manifest-emit-checksums)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "schema_version")]
 pub enum Manifest {
@@ -552,6 +562,9 @@ impl Manifest {
 /// The builder is cheap to construct and clone, carries no references, and is
 /// consumed by `FsSink::with_manifest(...)` to configure the manifest emitter.
 ///
+/// The CLI exposes the equivalent toggle as
+/// [`--manifest-emit-checksums`](https://libviprs.org/cli/#flag-manifest-emit-checksums).
+///
 /// # Example
 ///
 /// ```ignore
@@ -560,6 +573,8 @@ impl Manifest {
 ///     .with_checksums(ChecksumAlgo::Blake3)
 ///     .with_dedupe(true);
 /// ```
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-manifest-emit-checksums)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManifestBuilder {
     checksums: Option<ChecksumAlgo>,

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -19,6 +19,8 @@ use crate::planner::TileCoord;
 /// - [level_started_before_tile_completed](https://github.com/libviprs/libviprs-tests/blob/main/tests/observability.rs)
 ///   verifies the ordering invariant between `LevelStarted` and
 ///   `TileCompleted` events.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-trace-level)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EngineEvent {
     // -- Pipeline-level events (emitted by callers for full-pipeline observability) --
@@ -119,6 +121,8 @@ pub enum EngineEvent {
 ///   and inspect all events emitted during a test pyramid build.
 /// - [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 ///   implements this trait to print live progress to stderr.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-trace-level)
 pub trait EngineObserver: Send + Sync {
     fn on_event(&self, event: EngineEvent);
 }
@@ -149,6 +153,8 @@ impl EngineObserver for NoopObserver {
 ///   then inspect the captured events.
 /// - [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 ///   wraps a `CollectingObserver` for its `--verbose` mode.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-trace-level)
 #[derive(Debug)]
 pub struct CollectingObserver {
     events: std::sync::Mutex<Vec<EngineEvent>>,
@@ -197,6 +203,8 @@ impl EngineObserver for CollectingObserver {
 /// - [peak_memory_bounded_for_medium_image](https://github.com/libviprs/libviprs-tests/blob/main/tests/observability.rs)
 ///   attaches a `MemoryTracker` to an engine run and asserts the peak stays
 ///   below an expected ceiling.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-trace-level)
 #[derive(Debug, Clone)]
 pub struct MemoryTracker {
     current: Arc<AtomicU64>,

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -16,6 +16,8 @@ use crate::source;
 ///
 /// See [pdf_ops tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_ops.rs)
 /// for error handling patterns.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-render)
 #[derive(Debug, Error)]
 pub enum PdfError {
     #[error("I/O error: {0}")]
@@ -54,6 +56,8 @@ pub enum PdfError {
 ///
 /// See [pdf_ops tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_ops.rs)
 /// and the [CLI info command](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs).
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#info)
 #[derive(Debug, Clone)]
 pub struct PdfInfo {
     pub page_count: usize,
@@ -70,6 +74,8 @@ pub struct PdfInfo {
 /// # Examples
 ///
 /// See [pdf_ops tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_ops.rs).
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#info)
 #[derive(Debug, Clone)]
 pub struct PdfPageInfo {
     pub page_number: usize,
@@ -93,6 +99,8 @@ pub struct PdfPageInfo {
 ///
 /// See [pdf_ops tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_ops.rs)
 /// and the [CLI info command](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs).
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#info)
 pub fn pdf_info(path: &Path) -> Result<PdfInfo, PdfError> {
     let doc = lopdf::Document::load(path).map_err(|e| PdfError::Parse(e.to_string()))?;
     let pages_map = doc.get_pages();
@@ -129,6 +137,10 @@ pub fn pdf_info(path: &Path) -> Result<PdfInfo, PdfError> {
 /// See [pdf_ops tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_ops.rs),
 /// [pdf_to_pyramid tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_to_pyramid.rs),
 /// and the [CLI pyramid command](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs).
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-page) (the
+/// `--page` flag selects which page to extract; the [full pyramid flow](https://libviprs.org/cli/#pyramid)
+/// uses this when the page has embedded images).
 pub fn extract_page_image(path: &Path, page: usize) -> Result<Raster, PdfError> {
     let doc = lopdf::Document::load(path).map_err(|e| PdfError::Parse(e.to_string()))?;
     let pages_map = doc.get_pages();
@@ -663,6 +675,8 @@ pub(crate) fn render_at_size(
 /// This handles vector content (AutoCAD exports, text, paths) that cannot be
 /// extracted as embedded images. Requires the `pdfium` feature and a PDFium
 /// library available at runtime.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-render)
 #[cfg(feature = "pdfium")]
 pub fn render_page_pdfium(path: &Path, page: usize, dpi: u32) -> Result<Raster, PdfError> {
     let pdfium = init_pdfium()?;
@@ -690,6 +704,8 @@ pub fn render_page_pdfium(path: &Path, page: usize, dpi: u32) -> Result<Raster, 
 }
 
 /// Result of a budget-constrained render, including the DPI that was used.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-render)
 #[cfg(feature = "pdfium")]
 #[derive(Debug)]
 pub struct BudgetRenderResult {
@@ -718,6 +734,8 @@ pub struct BudgetRenderResult {
 ///   the output fits.
 ///
 /// Returns the raster along with the actual DPI used and whether it was capped.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-render)
 #[cfg(feature = "pdfium")]
 pub fn render_page_pdfium_budgeted(
     path: &Path,

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -21,6 +21,9 @@
 ///
 /// * [pdf_to_pyramid tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_to_pyramid.rs)
 /// * [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-format)
+/// (pyramid overview at [`#pyramid`](https://libviprs.org/cli/#pyramid))
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PixelFormat {
     /// Single-channel 8-bit grayscale.

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -38,6 +38,8 @@ pub enum PlannerError {
 /// # Example usage
 ///
 /// * [pyramid_fs_sink tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pyramid_fs_sink.rs)
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-layout)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Layout {
     /// Deep Zoom Image -- `{level}/{col}_{row}.{ext}`, plus `.dzi` manifest.
@@ -62,6 +64,8 @@ pub enum Layout {
 ///
 /// * [CLI plan command](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 /// * [pdf_to_pyramid tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_to_pyramid.rs)
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#plan)
 #[derive(Debug, Clone)]
 pub struct PyramidPlanner {
     image_width: u32,
@@ -87,6 +91,8 @@ pub struct PyramidPlanner {
 ///
 /// * [pdf_to_pyramid tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_to_pyramid.rs)
 /// * [pyramid_fs_sink tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pyramid_fs_sink.rs)
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#plan)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PyramidPlan {
     pub image_width: u32,
@@ -173,6 +179,8 @@ impl PyramidPlanner {
     ///
     /// Returns [`PlannerError`] if any dimension is zero, tile size is zero,
     /// or overlap is not strictly less than tile size.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-tile-size)
     pub fn new(
         image_width: u32,
         image_height: u32,
@@ -203,6 +211,8 @@ impl PyramidPlanner {
     }
 
     /// Enable or disable centring the image within the tile grid.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-centre)
     pub fn with_centre(mut self, centre: bool) -> Self {
         self.centre = centre;
         self
@@ -301,6 +311,8 @@ impl PyramidPlanner {
     ///     // reduce DPI and retry with smaller dimensions
     /// }
     /// ```
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-memory-limit)
     pub fn estimate_peak_memory(&self) -> u64 {
         let bytes_per_pixel: u64 = 4; // RGBA8
         let source_bytes = self.image_width as u64 * self.image_height as u64 * bytes_per_pixel;
@@ -662,6 +674,8 @@ impl PyramidPlan {
     /// This estimate is conservative — it ignores smaller intermediate buffers
     /// that are freed quickly. Used by [`generate_pyramid_auto`](crate::streaming::generate_pyramid_auto)
     /// to decide whether the monolithic path fits within the memory budget.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-memory-limit)
     pub fn estimate_peak_memory_for_format(&self, format: crate::pixel::PixelFormat) -> u64 {
         let bpp = format.bytes_per_pixel() as u64;
         let canvas_bytes = self.canvas_width as u64 * self.canvas_height as u64 * bpp;

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -51,6 +51,8 @@ pub enum RasterError {
 ///
 /// * [pdf_to_pyramid tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_to_pyramid.rs)
 /// * [pyramid_fs_sink tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pyramid_fs_sink.rs)
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#pyramid)
 #[derive(Debug, Clone)]
 pub struct Raster {
     width: u32,

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -210,6 +210,8 @@ fn downscale_half_alpha(src: &Raster) -> Result<Raster, RasterError> {
 /// - [test_resize_rounding](https://github.com/libviprs/libviprs-tests/blob/main/tests/ported_resample.rs)
 ///   exercises arbitrary-ratio downscaling and checks that output dimensions
 ///   are correctly rounded.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-match-page-size)
 pub fn downscale_to(src: &Raster, dst_w: u32, dst_h: u32) -> Result<Raster, RasterError> {
     if dst_w == 0 || dst_h == 0 {
         return Err(RasterError::ZeroDimension {

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -72,6 +72,8 @@ pub const CHECKPOINT_FILENAME: &str = ".libviprs-job.json";
 /// * [`ResumeMode::Verify`] — do not write anything. Walk the plan and check
 ///   that every tile is present and internally consistent on disk. Useful for
 ///   post-hoc validation of a finished job.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum ResumeMode {
     /// Discard pre-existing output and regenerate every tile.
@@ -100,6 +102,8 @@ pub enum ResumeMode {
 /// checkpoint file every `n` completed tiles (default `0` = never) and
 /// `.with_checkpoint_root(path)` to place the checkpoint somewhere other
 /// than the sink's base directory.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResumePolicy {
     mode: ResumeMode,
@@ -119,6 +123,8 @@ impl Default for ResumePolicy {
 
 impl ResumePolicy {
     /// Start a fresh run. Equivalent to [`ResumeMode::Overwrite`].
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-overwrite)
     pub fn overwrite() -> Self {
         Self {
             mode: ResumeMode::Overwrite,
@@ -128,6 +134,8 @@ impl ResumePolicy {
 
     /// Continue an interrupted run from the on-disk checkpoint. Equivalent
     /// to [`ResumeMode::Resume`].
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume)
     pub fn resume() -> Self {
         Self {
             mode: ResumeMode::Resume,
@@ -137,6 +145,8 @@ impl ResumePolicy {
 
     /// Audit an existing output directory against the plan without writing
     /// anything. Equivalent to [`ResumeMode::Verify`].
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-verify)
     pub fn verify() -> Self {
         Self {
             mode: ResumeMode::Verify,
@@ -184,6 +194,8 @@ impl ResumePolicy {
 /// `schema_version` is stored as a [`String`] so we can read back old
 /// checkpoints, compare them against [`SCHEMA_VERSION`], and return a
 /// structured error if they disagree.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[non_exhaustive]
 pub struct JobMetadata {
@@ -314,6 +326,8 @@ pub(super) mod tile_coord_vec_serde {
 /// `Io(io::Error)` wraps filesystem failures from the underlying
 /// [`std::fs`] calls; `PlanHashMismatch` and `SchemaMismatch` surface
 /// semantic incompatibilities that make it unsafe to resume.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume)
 #[derive(Debug, Error)]
 pub enum ResumeError {
     /// The checkpoint's `plan_hash` disagrees with the current plan's hash.
@@ -357,6 +371,8 @@ pub enum ResumeError {
 /// type is purely a namespace for `load` / `save` / `checkpoint_path` rather
 /// than a live handle. Callers that want to hold onto the last-known metadata
 /// should keep their own [`JobMetadata`] around.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume)
 pub struct JobCheckpoint;
 
 impl JobCheckpoint {

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -91,6 +91,9 @@ fn sample_jitter(max_nanos: u64, jitter_tick: &AtomicU64) -> u64 {
 /// * `jitter` — when `true`, a uniformly-distributed random slice in
 ///   `[0, backoff / 2]` is added to each sleep. Jitter helps de-synchronise
 ///   many parallel workers hammering the same flaky endpoint.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-retry-max)
+/// (and [`--retry-backoff`](https://libviprs.org/cli/#flag-retry-backoff) for the backoff arg)
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct RetryPolicy {
@@ -180,12 +183,25 @@ impl RetryPolicy {
 /// * [`FailurePolicy::RetryThenSkip`] — retry per the embedded policy; on
 ///   exhaustion, account the tile in
 ///   `EngineResult::skipped_due_to_failure` and continue.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-failure-policy)
 #[derive(Debug, Clone, PartialEq, Default)]
 #[non_exhaustive]
 pub enum FailurePolicy {
+    /// Propagate the first error; no retries.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-failure-policy)
     #[default]
     FailFast,
+    /// Retry per the embedded policy; propagate the last error if every
+    /// retry is exhausted.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-failure-policy)
     RetryThenFail(RetryPolicy),
+    /// Retry per the embedded policy; on exhaustion, skip the tile and
+    /// continue.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-failure-policy)
     RetryThenSkip(RetryPolicy),
 }
 
@@ -256,6 +272,8 @@ fn duration_from_nanos_u128(nanos: u128) -> Duration {
 ///   (not by `RetryingSink` itself) when `RetryThenSkip` drops a tile.
 ///   Exposed here so the engine can stash the running total without a
 ///   second data structure.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-retry-max)
 pub struct RetryingSink<S: TileSink> {
     inner: S,
     policy: RetryPolicy,

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -128,6 +128,8 @@ pub struct Tile {
 /// for filesystem sink integration tests and
 /// [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 /// for how the CLI wires up a sink.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#pyramid)
 pub trait TileSink: Send + Sync {
     fn write_tile(&self, tile: &Tile) -> Result<(), SinkError>;
     fn finish(&self) -> Result<(), SinkError> {
@@ -388,9 +390,15 @@ impl TileSink for SlowSink {
 /// for format selection and
 /// [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 /// for how the CLI maps user flags to a `TileFormat`.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-format)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TileFormat {
     Png,
+    /// JPEG-encoded tiles. The `quality` knob trades off filesize against
+    /// visual fidelity (1–100, higher = better quality, larger files).
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-quality)
     Jpeg {
         quality: u8,
     },
@@ -425,6 +433,8 @@ impl TileFormat {
 /// for integration tests and
 /// [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 /// for how the `pyramid` command constructs an `FsSink`.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-sink)
 ///
 /// `Debug` is implemented manually because the internal [`DedupeIndex`] does
 /// not derive `Debug`.
@@ -576,6 +586,9 @@ impl FsSink {
     /// Attach a [`ManifestBuilder`](crate::manifest::ManifestBuilder) so the
     /// sink emits a `manifest.json` alongside the pyramid when
     /// [`FsSink::finish`] is called.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-manifest-emit-checksums)
+    /// (and [checksum-algo](https://libviprs.org/cli/#flag-checksum-algo)).
     pub fn with_manifest(mut self, builder: crate::manifest::ManifestBuilder) -> Self {
         // If the builder specifies a checksum algorithm and the caller has
         // not separately configured checksums, default to EmitOnly so the
@@ -595,6 +608,9 @@ impl FsSink {
     /// Argument order: `(mode, algo)` to mirror `.with_checksums(Verify,
     /// Blake3)` call-site readability (the mode is usually the focus of the
     /// test/config, with the algorithm as a secondary choice).
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-manifest-emit-checksums)
+    /// (and [checksum-algo](https://libviprs.org/cli/#flag-checksum-algo)).
     pub fn with_checksums(
         mut self,
         mode: crate::checksum::ChecksumMode,
@@ -614,6 +630,8 @@ impl FsSink {
 
     /// Attach a [`DedupeStrategy`](crate::dedupe::DedupeStrategy) so the sink
     /// can coalesce identical blank tiles under a shared reference.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-dedupe-blanks)
     pub fn with_dedupe(mut self, strategy: crate::dedupe::DedupeStrategy) -> Self {
         if strategy != crate::dedupe::DedupeStrategy::None {
             self.dedupe_index = Some(crate::dedupe::DedupeIndex::new(strategy));
@@ -626,6 +644,8 @@ impl FsSink {
 
     /// Enable resume metadata. When set, [`FsSink::finish`] writes a small
     /// `.libviprs-job.json` checkpoint alongside the pyramid.
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume)
     pub fn with_resume(mut self, enabled: bool) -> Self {
         self.resume_enabled = enabled;
         self
@@ -642,6 +662,8 @@ impl FsSink {
     ///     .with_format(TileFormat::Jpeg { quality: 85 })
     ///     .with_dedupe(DedupeStrategy::Blanks);
     /// ```
+    ///
+    /// **See also:** [interactive example](https://libviprs.org/cli/#flag-format)
     pub fn with_format(mut self, format: TileFormat) -> Self {
         self.format = format;
         self
@@ -1314,6 +1336,8 @@ fn color_type_for_format(fmt: crate::pixel::PixelFormat) -> Result<image::ColorT
 ///
 /// See [pyramid_fs_sink tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pyramid_fs_sink.rs)
 /// for encoding in the context of tile output.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-format)
 pub fn encode_png(raster: &Raster) -> Result<Vec<u8>, SinkError> {
     let mut buf = Vec::new();
     let encoder = image::codecs::png::PngEncoder::new(std::io::Cursor::new(&mut buf));

--- a/src/sink_object_store.rs
+++ b/src/sink_object_store.rs
@@ -51,6 +51,8 @@ pub trait ObjectStore: Send + Sync {
 ///
 /// Retry behaviour is **not** configured here — wrap the resulting sink in
 /// [`crate::retry::RetryingSink`] if you need automatic retries.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-sink)
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct ObjectStoreConfig {
@@ -244,6 +246,10 @@ fn encode_tile(raster: &Raster, format: TileFormat) -> Result<Vec<u8>, SinkError
 /// retry should wrap this sink in [`crate::retry::RetryingSink`] with the
 /// appropriate [`crate::retry::RetryPolicy`] and
 /// [`crate::retry::FailurePolicy`].
+///
+/// On the CLI this sink is selected by passing an `s3://…` URI to `--sink`.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-sink)
 #[non_exhaustive]
 pub struct ObjectStoreSink {
     cfg: ObjectStoreConfig,

--- a/src/sink_packfile.rs
+++ b/src/sink_packfile.rs
@@ -34,6 +34,8 @@ use crate::sink::{SinkError, Tile, TileFormat, TileSink, encode_png};
 /// * [`PackfileFormat::Tar`] — uncompressed POSIX tar.
 /// * [`PackfileFormat::TarGz`] — POSIX tar wrapped in a gzip stream (`.tar.gz`).
 /// * [`PackfileFormat::Zip`] — standard ZIP archive with per-entry compression.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-sink)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackfileFormat {
     /// Plain uncompressed tar archive.
@@ -58,6 +60,10 @@ pub enum PackfileFormat {
 ///   checksum and sign.
 ///
 /// See [`PackfileFormat`] for the supported container formats.
+///
+/// On the CLI this sink is selected by passing a `packfile://…` URI to `--sink`.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-sink)
 pub struct PackfileSink {
     /// Final archive path (used to derive the archive stem for DZI / tile
     /// prefixes).

--- a/src/source.rs
+++ b/src/source.rs
@@ -12,6 +12,8 @@ use crate::raster::Raster;
 /// errors into a single enum so that callers of [`decode_file`],
 /// [`decode_bytes`], and [`generate_test_raster`] can handle all failure
 /// modes uniformly.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#pyramid)
 #[derive(Debug, Error)]
 pub enum SourceError {
     #[error("I/O error: {0}")]
@@ -53,6 +55,9 @@ fn color_type_to_format(ct: image::ColorType) -> Result<PixelFormat, SourceError
 /// - [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 ///   calls `decode_file` in the `info` command to display image metadata
 ///   and in the `pyramid` command to load the input raster.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#pyramid) (general
+/// entry point) and [`viprs info`](https://libviprs.org/cli/#info).
 pub fn decode_file(path: &Path) -> Result<Raster, SourceError> {
     let img = image::open(path)?;
     let (width, height) = img.dimensions();
@@ -91,6 +96,9 @@ pub fn decode_file(path: &Path) -> Result<Raster, SourceError> {
 /// - [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 ///   calls `decode_bytes` when the user passes `"-"` as the input file,
 ///   reading the image data from stdin.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#pyramid) (general
+/// entry point) and [`viprs info`](https://libviprs.org/cli/#info).
 pub fn decode_bytes(bytes: &[u8]) -> Result<Raster, SourceError> {
     let img = image::load_from_memory(bytes)?;
     let (width, height) = img.dimensions();
@@ -127,6 +135,8 @@ pub fn decode_bytes(bytes: &[u8]) -> Result<Raster, SourceError> {
 /// - [CLI source](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
 ///   exposes this as the `test-image` subcommand, generating a gradient
 ///   PNG for quick smoke-testing.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#test-image)
 pub fn generate_test_raster(width: u32, height: u32) -> Result<Raster, SourceError> {
     let bpp = PixelFormat::Rgb8.bytes_per_pixel();
     let mut data = vec![0u8; width as usize * height as usize * bpp];

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -53,6 +53,8 @@ use crate::sink::{Tile, TileSink};
 ///
 /// The streaming engine performs a pre-flight check against the worst-case
 /// strip and surfaces this policy when the budget is insufficient.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-memory-budget)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BudgetPolicy {
     /// Return [`EngineError::BudgetExceeded`] without doing any work.
@@ -76,6 +78,8 @@ pub enum BudgetPolicy {
 /// controls strip height selection. The budget is a soft upper bound — the
 /// engine uses it to maximise strip height (and therefore throughput) while
 /// keeping estimated peak memory below the target.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-memory-budget)
 #[derive(Debug, Clone)]
 pub struct StreamingConfig {
     /// Soft memory budget in bytes.
@@ -198,6 +202,8 @@ impl<'a> StripSource for RasterStripSource<'a> {
 /// render path that `render_page_pdfium` uses does rotate automatically, so
 /// we fall back to full-page render + slice. See
 /// [`render_strip_inner`](Self::render_strip_inner) for details.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-render)
 #[cfg(feature = "pdfium")]
 pub struct PdfiumStripSource {
     width: u32,
@@ -490,6 +496,8 @@ impl StripSource for PdfiumStripSource {
 ///
 /// `Some(strip_height)` — the largest aligned strip height within budget,
 /// capped at the canvas height. `None` if the budget is insufficient.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-memory-budget)
 pub fn compute_strip_height(plan: &PyramidPlan, format: PixelFormat, budget: u64) -> Option<u32> {
     let ch = plan.canvas_height as u64;
     let ts = plan.tile_size;
@@ -532,6 +540,8 @@ pub fn compute_strip_height(plan: &PyramidPlan, format: PixelFormat, budget: u64
 ///
 /// Use this to validate that a chosen strip height stays within budget,
 /// or to display estimated memory usage to callers before committing.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-memory-budget)
 pub fn estimate_streaming_memory(
     plan: &PyramidPlan,
     format: PixelFormat,

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -48,6 +48,10 @@ use crate::streaming::{
 /// Controls memory budget, per-strip tile concurrency, channel backpressure,
 /// and tile handling options. The budget determines how many strips can be
 /// in flight simultaneously during the Map phase.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-parallel)
+/// (memory budget is documented at
+/// [`#flag-memory-budget`](https://libviprs.org/cli/#flag-memory-budget))
 #[derive(Debug, Clone)]
 pub struct MapReduceConfig {
     /// Soft memory budget in bytes (covers all in-flight strips + accumulators).
@@ -134,6 +138,8 @@ fn estimate_mono_buffer_cost(plan: &PyramidPlan, format: PixelFormat) -> u64 {
 /// Compute the number of in-flight strips that fit within a memory budget.
 ///
 /// Returns at least 1.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-parallel)
 pub fn compute_inflight_strips(
     plan: &PyramidPlan,
     format: PixelFormat,
@@ -153,6 +159,8 @@ pub fn compute_inflight_strips(
 }
 
 /// Estimate peak memory for the MapReduce streaming engine.
+///
+/// **See also:** [interactive example](https://libviprs.org/cli/#flag-parallel)
 pub fn estimate_mapreduce_peak_memory(
     plan: &PyramidPlan,
     format: PixelFormat,


### PR DESCRIPTION
## Summary

- Adds rustdoc \`See also\` cross-references on public types in \`src/*.rs\` to the per-flag anchors on https://libviprs.org/cli/ (e.g. \`#flag-memory-budget\`, \`#flag-parallel\`, \`#flag-resume\`).
- README gains the same inline deep-links plus a top-of-file pointer.
- Comment-only; no API or runtime behaviour changes. \`cargo build\` is green.

## Test plan

- [ ] \`cargo build -p libviprs\`
- [ ] \`cargo doc -p libviprs --no-deps\` and spot-check the new "See also" lines render as clickable links on the public types touched.
- [ ] Click through one of the new anchors (e.g. https://libviprs.org/cli/#flag-memory-budget) and confirm it lands on the right flag.