### PR TITLE
feat(pdf): true strip-by-strip pdfium rendering via matrix path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,17 @@ zip = { version = "7.2.0", optional = true }
 loom = "0.7"
 proptest = "1"
 tempfile = "3"
+
+# Use libviprs/pdfium-render with proper per-call thread-safety locking
+# in `ThreadSafePdfiumBindings`. Upstream pdfium-render 0.8.37's
+# wrapper acquires the pdfium global mutex only once on
+# `FPDF_InitLibrary` and bypasses it for every other method, which
+# segfaults under any concurrent access pattern when a single
+# `Pdfium` instance is shared across threads (the common pattern when
+# callers use a process-wide singleton). The fork rewrites every
+# method to acquire the lock per-call.
+#
+# Tracking issue: ajrcarey/pdfium-render upstream PR pending. Once
+# merged + released, this patch can be dropped.
+[patch.crates-io]
+pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/per-call-thread-safety" }

--- a/docs/streaming-pdf-rotation.md
+++ b/docs/streaming-pdf-rotation.md
@@ -1,0 +1,193 @@
+# Streaming PDF strip rendering — coordinate-system primer
+
+This document explains the coordinate-system math that powers
+`PdfiumStripSource`'s streaming mode, and where the per-rotation device
+matrices come from. Read this before touching `strip_matrix` in
+`src/pdf.rs`.
+
+## Why the matrix exists
+
+Pdfium offers two render entry points:
+
+- `FPDF_RenderPageBitmap` — the "form-data path". Takes pixel
+  coordinates plus a `rotate` parameter; pdfium internally applies the
+  page's intrinsic `/Rotate` and writes the pixels into the supplied
+  bitmap. This is what the cached-mode source uses (via
+  `pdfium-render`'s `set_target_width` builder).
+
+- `FPDF_RenderPageBitmapWithMatrix` — the "matrix path". Takes a 6-element
+  affine matrix `[a, b, c, d, e, f]` plus a clipping rectangle and writes
+  whatever the matrix-transformed page coords land within the clip. The
+  matrix path does **not** auto-apply `/Rotate`; the caller has to compose
+  rotation into the matrix.
+
+Streaming mode wants the matrix path because that's the only way to
+allocate a strip-sized bitmap (the form-data path's `start_x`/`start_y`
+fields are exposed by `pdfium-render` only via internal APIs). The
+caller-side matrix composition is what `strip_matrix` does.
+
+## Coordinate systems involved
+
+Three frames matter:
+
+| Frame                     | Origin       | Y direction | Units  |
+|---------------------------|--------------|-------------|--------|
+| **Page space**            | bottom-left  | y-up        | points |
+| **Display space**         | top-left     | y-down      | points |
+| **Bitmap pixel space**    | top-left     | y-down      | pixels |
+
+`Page space` is the PDF spec's "default user space" pre-`/Rotate`. A
+`/Rotate 270` portrait page has page-space dimensions `(W_pt, H_pt)` =
+(short, long), and after the rotation it displays as landscape with
+display-space dimensions `(H_pt, W_pt)` = (long, short).
+
+`pdfium-render`'s `PdfPage::width()`/`height()` return **display-space**
+dimensions, already swapped for `/Rotate 90/270`. This is the convention
+pinned by the comment at `pdf.rs:376-379`.
+
+`Bitmap pixel space` is what the matrix produces — the (x, y) the
+matrix outputs are bitmap pixel coordinates, with (0, 0) at top-left
+and Y growing downward.
+
+## Per-rotation matrix derivation
+
+For each of the four rotation values, we want a matrix that maps
+**page-space coords** to **bitmap pixel coords**, including:
+
+1. Apply `/Rotate` (move page-content corners to their displayed positions).
+2. Convert from y-up (page) to y-down (bitmap).
+3. Scale by `s = dpi / 72` so points become pixels.
+4. Translate by `-y_offset` so the strip rows `[y_offset, y_offset+strip_h)`
+   in display-space land at rows `[0, strip_h)` in the strip-sized bitmap.
+
+The PDF matrix convention is `(x', y') = (a·x + c·y + e, b·x + d·y + f)`
+applied to `(x, y) ∈ page-space`.
+
+### `/Rotate 0`
+
+Page corner `(x_pg, y_pg) ∈ [0, W_pt] × [0, H_pt]` maps to display
+`(x_pg, H_pt - y_pg)` in display-points (y-flip). After the strip
+translation:
+
+```
+x_bm    =  s·x_pg
+y_bm_strip  =  -s·y_pg + s·H_pt - y_off
+```
+
+Matrix: `[s, 0, 0, -s, 0, s·H_pt - y_off]`.
+
+### `/Rotate 90` (90° clockwise)
+
+A `/Rotate 90` portrait page (page-space `W_pt × H_pt`) displays as
+landscape (display `H_pt × W_pt`). Walking the corners under a 90° CW
+rotation about the origin and shifting back into the positive
+quadrant:
+
+| Page corner    | Display position |
+|----------------|------------------|
+| BL (0, 0)      | top-left         |
+| BR (W_pt, 0)   | bottom-left      |
+| TR (W_pt, H_pt)| bottom-right     |
+| TL (0, H_pt)   | top-right        |
+
+Page → display y-down: `x_disp = y_pg`, `y_disp = x_pg`.
+
+In pixels with strip translation:
+```
+x_bm    =  s·y_pg
+y_bm_strip  =  s·x_pg - y_off
+```
+
+Matrix: `[0, s, s, 0, 0, -y_off]`.
+
+### `/Rotate 180`
+
+Half-turn rotation: `x_disp = W_pt - x_pg`, `y_disp = y_pg`. In
+pixels:
+```
+x_bm    =  -s·x_pg + s·W_pt
+y_bm_strip  =  s·y_pg - y_off
+```
+
+Matrix: `[-s, 0, 0, s, s·W_pt, -y_off]`.
+
+### `/Rotate 270` (270° clockwise = 90° CCW)
+
+Display dimensions: landscape (`H_pt × W_pt`). Page → display y-down:
+`x_disp = H_pt - y_pg`, `y_disp = W_pt - x_pg`. In pixels:
+```
+x_bm    =  -s·y_pg + s·H_pt
+y_bm_strip  =  -s·x_pg + s·W_pt - y_off
+```
+
+Matrix: `[0, -s, -s, 0, s·H_pt, s·W_pt - y_off]`.
+
+## What the bitmap looks like
+
+For all four rotations, the bitmap allocated by
+`PdfRenderConfig::set_fixed_size(display_w_px, strip_h_px)` is exactly
+the strip's size. The matrix sends only the page content that should
+land at rows `[0, strip_h_px)` of that bitmap; everything else falls
+outside the clip and is discarded.
+
+This is **why streaming mode bounds source-side memory at one strip,
+not the full page** — at no point does the matrix path allocate a
+full-page bitmap.
+
+## Why the matrix path was hard to get right
+
+The previous attempt at streaming mode (reverted before v0.3.0)
+relied on `pdfium-render::PdfRenderConfig::rotate(...)` to compose
+the rotation. `pdfium-render`'s `apply_to_page` (line ~899 of
+`render_config.rs` in 0.8.37) implements rotation as a
+**translate-then-rotate-then-scale** chain about the page origin.
+For `/Rotate 90/270` this produces final matrices in entirely
+non-positive coordinate space — without an explicit pre-translation
+or alternative composition order, the rendered content lands outside
+the default clipping rectangle and the bitmap stays empty. The
+practical symptom was 180° wrong output for `/Rotate 90/270` pages
+("hand-composed rotation matrices produced 180°-off output for
+/Rotate 90/270 pages across every variant we tried" — historical
+comment from `streaming.rs`, removed in commit 1e64250).
+
+The fix this codebase ships is to **bypass** `apply_to_page`'s
+auto-rotation entirely and hand the matrix straight to pdfium via
+`PdfRenderConfig::apply_matrix`. The four matrices above are
+**direct** page→bitmap mappings; no per-step composition, no
+intermediate frames, no surprises.
+
+## Test coverage
+
+These matrices are pinned in three layers:
+
+1. **Pure-Rust unit tests** (`pdf::tests::strip_matrix_*`) verify
+   each matrix's algebra independently — page corners go to expected
+   bitmap coordinates without spinning up pdfium.
+2. **Cross-product integration tests**
+   (`libviprs-tests/tests/pdfium_streaming_rotation_matrix.rs`)
+   exercise `/Rotate × strip-position × DPI` over the
+   `/Rotate 0` and `/Rotate 270` fixtures shipped with libviprs-tests.
+3. **Synthetic fixtures**
+   (`libviprs-tests/tests/pdfium_streaming_synthetic_rotations.rs`)
+   close the `/Rotate 90` and `/Rotate 180` coverage gap by mutating
+   an existing fixture's `/Rotate` via `lopdf`.
+4. **Cross-path regression test**
+   (`libviprs-tests/tests/pdfium_streaming_regression_rotate.rs`)
+   compares streaming-mode output against cached-mode form-data
+   output at multiple strip positions — catches systematically-wrong
+   matrices that self-consistency tests would miss.
+
+If you change `strip_matrix`, all four layers should run and turn
+green (run `cargo test --features pdfium -- --test-threads=1` from
+`libviprs-tests/`).
+
+## Related code
+
+- `src/pdf.rs::strip_matrix` — the function this document explains.
+- `src/pdf.rs::render_page_strip_with_page` — the call site that
+  consumes the matrix and writes a strip-sized bitmap.
+- `src/streaming.rs::PdfiumStripSource` (streaming mode) — the public
+  API that drives all of the above.
+- `src/pdf.rs::pdfium_lock` — the process-wide lock that serialises
+  every FPDF call (orthogonal to the matrix math; relevant if you're
+  reading the call chain).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,10 +107,10 @@ pub use sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 #[cfg(feature = "packfile")]
 pub use sink_packfile::{PackfileFormat, PackfileSink, PackfileSinkBuilder};
 pub use source::{SourceError, decode_bytes, decode_file, generate_test_raster};
-#[cfg(feature = "pdfium")]
-pub use streaming::PdfiumStripSource;
 pub use streaming::{
     BudgetPolicy, RasterStripSource, StreamingConfig, StripSource, compute_strip_height,
     estimate_streaming_memory,
 };
+#[cfg(feature = "pdfium")]
+pub use streaming::{PdfiumRenderMode, PdfiumStripSource};
 pub use streaming_mapreduce::MapReduceConfig;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub use manifest::{
 pub use observe::{CollectingObserver, EngineEvent, EngineObserver, MemoryTracker};
 #[cfg(feature = "pdfium")]
 pub use pdf::{BudgetRenderResult, render_page_pdfium, render_page_pdfium_budgeted};
-pub use pdf::{PdfError, PdfInfo, PdfPageInfo, extract_page_image, pdf_info};
+pub use pdf::{PageRotation, PdfError, PdfInfo, PdfPageInfo, extract_page_image, pdf_info};
 pub use pixel::PixelFormat;
 pub use planner::{
     Layout, LevelPlan, PlannerError, PyramidPlan, PyramidPlanner, TileCoord, TileRect,

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -45,6 +45,72 @@ pub enum PdfError {
         budget_bytes: u64,
         dpi: u32,
     },
+    #[error("unsupported page /Rotate value: {0} (must be a multiple of 90)")]
+    UnsupportedRotation(i64),
+}
+
+/// A page's intrinsic `/Rotate` value, normalised to one of the four
+/// values the PDF spec admits.
+///
+/// PDF 1.7 §7.7.3.3 defines `/Rotate` as a multiple of 90 degrees;
+/// any value outside `{0, 90, 180, 270}` after normalisation
+/// (`rem_euclid 360`) is malformed. This enum makes the well-formed
+/// values type-level and lets the matrix-render code path drop the
+/// otherwise-dead "unsupported rotation" branch.
+///
+/// Construct via [`Self::try_from_degrees`] for parsing, or directly
+/// match on the four variants when handling all rotations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PageRotation {
+    /// No rotation. The page renders in its authored orientation.
+    Zero,
+    /// 90° clockwise. Portrait page renders as landscape; the page's
+    /// top edge becomes the displayed right edge.
+    Quarter,
+    /// 180°. Same orientation as `Zero` but flipped about both axes.
+    Half,
+    /// 270° clockwise (equivalently 90° counter-clockwise). Portrait
+    /// renders as landscape, with the page's top edge becoming the
+    /// displayed left edge.
+    ThreeQuarter,
+}
+
+impl PageRotation {
+    /// Map a degree value (typically from `/Rotate`) to a [`PageRotation`].
+    /// The input is normalised via `rem_euclid 360` so negatives and
+    /// values ≥360 are accepted as long as they're a multiple of 90.
+    ///
+    /// # Errors
+    ///
+    /// [`PdfError::UnsupportedRotation`] for any value whose normalised
+    /// form is not in `{0, 90, 180, 270}`.
+    pub fn try_from_degrees(degrees: i64) -> Result<Self, PdfError> {
+        match degrees.rem_euclid(360) {
+            0 => Ok(Self::Zero),
+            90 => Ok(Self::Quarter),
+            180 => Ok(Self::Half),
+            270 => Ok(Self::ThreeQuarter),
+            _ => Err(PdfError::UnsupportedRotation(degrees)),
+        }
+    }
+
+    /// Inverse of [`Self::try_from_degrees`]: returns 0, 90, 180, or 270.
+    #[inline]
+    #[must_use]
+    pub const fn as_degrees(self) -> i64 {
+        match self {
+            Self::Zero => 0,
+            Self::Quarter => 90,
+            Self::Half => 180,
+            Self::ThreeQuarter => 270,
+        }
+    }
+}
+
+impl Default for PageRotation {
+    fn default() -> Self {
+        Self::Zero
+    }
 }
 
 /// Information about a PDF document, including page count and per-page metadata.
@@ -527,8 +593,9 @@ fn resolve_rotate(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> i64 {
 ///
 /// Loads the PDF via `lopdf` and walks the page's `/Parent` chain to find
 /// the inherited `/Rotate` entry (per PDF 1.7 §7.7.3.3). The result is
-/// normalised into `[0, 360)`. Pages without a `/Rotate` entry, malformed
-/// values, and self-referential parent chains all resolve to `0`.
+/// normalised into one of the four [`PageRotation`] variants. Pages
+/// without a `/Rotate` entry, missing values, and self-referential
+/// parent chains all resolve to [`PageRotation::Zero`].
 ///
 /// This is the path-based companion of the private [`resolve_rotate`]
 /// helper. Callers driving pdfium's matrix render path need the page's
@@ -540,14 +607,16 @@ fn resolve_rotate(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> i64 {
 ///
 /// - [`PdfError::Parse`] — PDF could not be opened or parsed by `lopdf`.
 /// - [`PdfError::PageOutOfRange`] — `page == 0` or `page > total_pages`.
-pub fn page_rotate(path: &Path, page: usize) -> Result<i64, PdfError> {
+/// - [`PdfError::UnsupportedRotation`] — the resolved `/Rotate` value
+///   is not a multiple of 90 (PDF spec violation).
+pub fn page_rotate(path: &Path, page: usize) -> Result<PageRotation, PdfError> {
     let doc = lopdf::Document::load(path).map_err(|e| PdfError::Parse(e.to_string()))?;
     let pages_map = doc.get_pages();
     let total = pages_map.len();
     let &page_id = pages_map
         .get(&(page as u32))
         .ok_or(PdfError::PageOutOfRange { page, total })?;
-    Ok(resolve_rotate(&doc, page_id).rem_euclid(360))
+    PageRotation::try_from_degrees(resolve_rotate(&doc, page_id))
 }
 
 /// Check whether a page has any Image XObjects.
@@ -639,6 +708,47 @@ fn obj_to_f64(obj: &lopdf::Object) -> Option<f64> {
 // Pdfium-based rendering (feature-gated)
 // ---------------------------------------------------------------------------
 
+/// Process-wide lock for FPDF API access.
+///
+/// pdfium-render 0.8's `thread_safe` feature only acquires a mutex on
+/// `FPDF_InitLibrary` / `FPDF_DestroyLibrary`; every other FPDF call
+/// delegates to the inner bindings without further synchronization
+/// (see `bindings/thread_safe.rs:170-172` upstream — `FPDF_LoadDocument`
+/// is a one-line delegate, no lock acquired). Pdfium itself is not
+/// thread-safe, so any concurrent FPDF call from a different thread
+/// hits unsynchronized state inside the C library and segfaults.
+///
+/// We compensate by holding this libviprs-side lock around every entry
+/// point that issues FPDF calls. The lock is process-wide because
+/// pdfium's global state is process-wide; document or page handles
+/// from different `PdfiumStripSource` instances still share the
+/// underlying C state, so per-source locking would not be sufficient.
+///
+/// **Performance note:** With this lock held, multi-threaded
+/// `render_strip` calls serialize. That matches the underlying reality
+/// (pdfium itself is single-threaded), so no parallelism is lost — a
+/// per-call lock simply makes that explicit and safe instead of
+/// implicit and crashing.
+///
+/// **Future:** The libviprs/pdfium-render fork contains a proper
+/// per-method-locked `ThreadSafePdfiumBindings`. Once libviprs depends
+/// on that fork via `[patch.crates-io]`, this lock can be removed and
+/// `with_pdfium_lock` callers will be able to inline.
+#[cfg(feature = "pdfium")]
+static PDFIUM_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire [`PDFIUM_LOCK`]. Panics in another thread that previously
+/// held the lock are recovered from rather than propagated; pdfium is
+/// a C library and a Rust panic on the Rust side cannot corrupt its
+/// internal state, so poisoning here is benign.
+#[cfg(feature = "pdfium")]
+#[inline]
+pub(crate) fn pdfium_lock() -> std::sync::MutexGuard<'static, ()> {
+    PDFIUM_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// Open a pdfium instance with the appropriate bindings.
 #[cfg(feature = "pdfium")]
 pub(crate) fn init_pdfium() -> Result<&'static pdfium_render::prelude::Pdfium, PdfError> {
@@ -707,6 +817,7 @@ pub(crate) fn render_at_size(
 #[cfg(feature = "pdfium")]
 pub fn render_page_pdfium(path: &Path, page: usize, dpi: u32) -> Result<Raster, PdfError> {
     let pdfium = init_pdfium()?;
+    let _lock = pdfium_lock();
     let document = pdfium
         .load_pdf_from_file(path, None)
         .map_err(|e| PdfError::Pdfium(e.to_string()))?;
@@ -728,6 +839,63 @@ pub fn render_page_pdfium(path: &Path, page: usize, dpi: u32) -> Result<Raster, 
     let height = (pdf_page.height().value * scale) as u32;
 
     render_at_size(&pdf_page, width, height)
+}
+
+/// Compose the device matrix that maps pre-rotation page coordinates
+/// (PDF's bottom-left origin, y-up, units = points) into bitmap pixel
+/// coordinates (pdfium's top-left origin, y-down, units = pixels) for
+/// a strip starting at `y_offset` (in display pixels) of a page rendered
+/// at `scale = dpi / 72.0`.
+///
+/// `display_w_pt` and `display_h_pt` are the **post-/Rotate** page
+/// dimensions in points, which is what `pdfium-render`'s
+/// `PdfPage::width()/height()` already returns. The function swaps to
+/// pre-rotation dimensions internally so callers don't have to.
+///
+/// The caller supplies the bitmap as `(display_w_px, strip_h_px)` —
+/// a strip-sized output canvas — and pdfium fills only the rows
+/// `[0, strip_h_px)` because the matrix translates the requested
+/// page strip into those rows.
+///
+/// # Per-rotation matrices
+///
+/// | `/Rotate` | `[a, b, c, d, e, f]`                                        |
+/// |-----------|-------------------------------------------------------------|
+/// | 0         | `[s,  0,  0, -s, 0,             s·page_h_pt − y_off]`       |
+/// | 90        | `[0,  s,  s,  0, 0,             −y_off]`                    |
+/// | 180       | `[−s, 0,  0,  s, s·page_w_pt,   −y_off]`                    |
+/// | 270       | `[0, −s, −s,  0, s·page_h_pt,   s·page_w_pt − y_off]`       |
+///
+/// `s = scale`. `page_w_pt / page_h_pt` are the **pre-rotation** page
+/// dimensions (display dims swapped for `/Rotate 90/270`). Derivation:
+/// for each rotation, compose page→display map (rotation + y-flip from
+/// y-up to y-down) and translate by `-y_offset`.
+///
+/// Infallible because the typed [`PageRotation`] enum makes invalid
+/// rotation values unrepresentable. Errors that previously came from
+/// this function (unsupported `/Rotate`) now surface at the parsing
+/// boundary in [`PageRotation::try_from_degrees`].
+#[cfg(feature = "pdfium")]
+#[must_use]
+pub(crate) fn strip_matrix(
+    rotation: PageRotation,
+    scale: f32,
+    display_w_pt: f32,
+    display_h_pt: f32,
+    y_offset: u32,
+) -> [f32; 6] {
+    let (page_w_pt, page_h_pt) = match rotation {
+        PageRotation::Zero | PageRotation::Half => (display_w_pt, display_h_pt),
+        PageRotation::Quarter | PageRotation::ThreeQuarter => (display_h_pt, display_w_pt),
+    };
+    let s = scale;
+    let y_off = y_offset as f32;
+    match rotation {
+        PageRotation::Zero => [s, 0.0, 0.0, -s, 0.0, s * page_h_pt - y_off],
+        PageRotation::Quarter => [0.0, s, s, 0.0, 0.0, -y_off],
+        PageRotation::Half => [-s, 0.0, 0.0, s, s * page_w_pt, -y_off],
+        PageRotation::ThreeQuarter => [0.0, -s, -s, 0.0, s * page_h_pt, s * page_w_pt - y_off],
+    }
 }
 
 /// Render a single horizontal strip of a PDF page directly via pdfium's
@@ -769,33 +937,30 @@ pub fn render_page_pdfium(path: &Path, page: usize, dpi: u32) -> Result<Raster, 
 /// - [`PdfError::Pdfium`] — pdfium load / page get / matrix-validity /
 ///   render error, including unsupported `/Rotate` values not in
 ///   `{0, 90, 180, 270}`.
+/// Render a single horizontal strip from an **already-loaded** [`PdfPage`].
+///
+/// This is the hot-path entry used by [`crate::PdfiumStripSource`] in
+/// streaming mode: callers cache the parsed `PdfDocument` / `PdfPage`
+/// once at construction and reuse them across every `render_strip`
+/// call, avoiding the per-strip PDF reparse that path-based one-shot
+/// rendering would pay.
+///
+/// **The caller must hold [`pdfium_lock`]** for the duration of this
+/// call — the function issues FPDF calls (matrix render plus bitmap
+/// allocation/deallocation) that share global pdfium state with every
+/// other thread, and pdfium's C library is not thread-safe.
+///
+/// `dpi`, `rotation`, `y_offset`, `strip_height` semantics match the
+/// matrix derivation documented at [`strip_matrix`].
 #[cfg(feature = "pdfium")]
-pub(crate) fn render_page_strip_pdfium(
-    path: &Path,
-    page: usize,
+pub(crate) fn render_page_strip_with_page(
+    pdf_page: &pdfium_render::prelude::PdfPage<'_>,
     dpi: u32,
-    rotation: i64,
+    rotation: PageRotation,
     y_offset: u32,
     strip_height: u32,
 ) -> Result<Raster, PdfError> {
     use pdfium_render::prelude::*;
-
-    let pdfium = init_pdfium()?;
-    let document = pdfium
-        .load_pdf_from_file(path, None)
-        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
-
-    let pages = document.pages();
-    let total = pages.len();
-    if page == 0 || page > total as usize {
-        return Err(PdfError::PageOutOfRange {
-            page,
-            total: total as usize,
-        });
-    }
-    let pdf_page = pages
-        .get(page as u16 - 1)
-        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
 
     let scale = dpi as f32 / 72.0;
     // Display-oriented dims; pdf_page.width()/height() return post-/Rotate
@@ -816,25 +981,7 @@ pub(crate) fn render_page_strip_pdfium(
             .map_err(PdfError::from);
     }
 
-    let normalised = rotation.rem_euclid(360);
-    let (page_w_pt, page_h_pt) = match normalised {
-        0 | 180 => (display_w_pt, display_h_pt),
-        90 | 270 => (display_h_pt, display_w_pt),
-        _ => {
-            return Err(PdfError::Pdfium(format!(
-                "unsupported page /Rotate value: {normalised} (must be 0/90/180/270)"
-            )));
-        }
-    };
-    let s = scale;
-    let y_off = y_offset as f32;
-    let (a, b, c, d, e, f) = match normalised {
-        0 => (s, 0.0, 0.0, -s, 0.0, s * page_h_pt - y_off),
-        90 => (0.0, s, s, 0.0, 0.0, -y_off),
-        180 => (-s, 0.0, 0.0, s, s * page_w_pt, -y_off),
-        270 => (0.0, -s, -s, 0.0, s * page_h_pt, s * page_w_pt - y_off),
-        _ => unreachable!("normalised is checked above"),
-    };
+    let [a, b, c, d, e, f] = strip_matrix(rotation, scale, display_w_pt, display_h_pt, y_offset);
     let matrix = PdfMatrix::new(a, b, c, d, e, f);
 
     let config = PdfRenderConfig::new()
@@ -896,6 +1043,7 @@ pub fn render_page_pdfium_budgeted(
     max_pixels: u64,
 ) -> Result<BudgetRenderResult, PdfError> {
     let pdfium = init_pdfium()?;
+    let _lock = pdfium_lock();
     let document = pdfium
         .load_pdf_from_file(path, None)
         .map_err(|e| PdfError::Pdfium(e.to_string()))?;
@@ -1127,5 +1275,277 @@ mod tests {
         assert_eq!(apply_rotate_to_dims(1000.0, 500.0, 270), (500.0, 1000.0));
         assert_eq!(apply_rotate_to_dims(1000.0, 500.0, 360), (1000.0, 500.0));
         assert_eq!(apply_rotate_to_dims(1000.0, 500.0, -90), (500.0, 1000.0));
+    }
+
+    // -----------------------------------------------------------------------
+    // strip_matrix — pure-Rust unit tests for the per-rotation device matrix.
+    //
+    // These tests verify that the matrix coefficients map page-space corners
+    // to the expected bitmap-pixel positions, without going through pdfium.
+    // Each rotation is verified independently so a sign error or axis swap
+    // surfaces as a single failed test, not a confusing region-mean drift.
+    //
+    // Apply-the-matrix helper: PDF matrices are [a, b, c, d, e, f] applied
+    // as `(x', y') = (a*x + c*y + e, b*x + d*y + f)`. We replicate that
+    // here rather than reaching for a 2D linear-algebra crate, since the
+    // arithmetic is two multiplies and two adds per coordinate.
+    // -----------------------------------------------------------------------
+    //
+    // Test cases cover: page corners (BL/BR/TR/TL), strip y_offset = 0
+    // (full page), strip y_offset > 0 (offset strip), and `scale != 1`.
+    // -----------------------------------------------------------------------
+    #[cfg(feature = "pdfium")]
+    fn apply(matrix: [f32; 6], x: f32, y: f32) -> (f32, f32) {
+        let [a, b, c, d, e, f] = matrix;
+        (a * x + c * y + e, b * x + d * y + f)
+    }
+
+    /// Comparison helper that absorbs f32 rounding (PdfMatrix is f32).
+    #[cfg(feature = "pdfium")]
+    fn approx_eq(actual: (f32, f32), expected: (f32, f32), label: &str) {
+        let dx = (actual.0 - expected.0).abs();
+        let dy = (actual.1 - expected.1).abs();
+        assert!(
+            dx < 1e-3 && dy < 1e-3,
+            "{label}: expected ({:.4}, {:.4}), got ({:.4}, {:.4})",
+            expected.0,
+            expected.1,
+            actual.0,
+            actual.1
+        );
+    }
+
+    /// /Rotate 0, scale 1, full-page render (y_offset = 0).
+    /// page (0, 0) maps to bitmap (0, page_h) — bottom-left of bitmap.
+    /// page (W, H) maps to bitmap (W, 0) — top-right of bitmap.
+    #[cfg(feature = "pdfium")]
+    #[test]
+    fn strip_matrix_rotate_0_full_page_corners() {
+        let m = strip_matrix(PageRotation::Zero, 1.0, 100.0, 200.0, 0);
+        // Page BL (0, 0) → display BL = bitmap (0, page_h_px) = (0, 200).
+        approx_eq(apply(m, 0.0, 0.0), (0.0, 200.0), "/Rotate 0 BL");
+        // Page TL (0, H) → display TL = bitmap (0, 0).
+        approx_eq(apply(m, 0.0, 200.0), (0.0, 0.0), "/Rotate 0 TL");
+        // Page TR (W, H) → display TR = bitmap (W, 0) = (100, 0).
+        approx_eq(apply(m, 100.0, 200.0), (100.0, 0.0), "/Rotate 0 TR");
+        // Page BR (W, 0) → display BR = bitmap (W, H) = (100, 200).
+        approx_eq(apply(m, 100.0, 0.0), (100.0, 200.0), "/Rotate 0 BR");
+    }
+
+    /// /Rotate 0, scale 1, strip y_offset = 50.
+    /// page TL (0, H) — which would be bitmap (0, 0) at full page — should
+    /// move to bitmap (0, -50) (above the strip-sized bitmap).
+    /// page (0, H-50) should land at bitmap (0, 0) (the new top of strip).
+    #[cfg(feature = "pdfium")]
+    #[test]
+    fn strip_matrix_rotate_0_strip_offset() {
+        let m = strip_matrix(PageRotation::Zero, 1.0, 100.0, 200.0, 50);
+        approx_eq(apply(m, 0.0, 200.0), (0.0, -50.0), "/Rotate 0 strip TL");
+        approx_eq(apply(m, 0.0, 150.0), (0.0, 0.0), "/Rotate 0 strip y=50 row");
+        approx_eq(
+            apply(m, 100.0, 150.0),
+            (100.0, 0.0),
+            "/Rotate 0 strip TR-of-strip",
+        );
+    }
+
+    /// /Rotate 0, scale 2 — the bitmap is 2x bigger; corners scale linearly.
+    #[cfg(feature = "pdfium")]
+    #[test]
+    fn strip_matrix_rotate_0_scaled() {
+        let m = strip_matrix(PageRotation::Zero, 2.0, 100.0, 200.0, 0);
+        approx_eq(apply(m, 0.0, 0.0), (0.0, 400.0), "/Rotate 0 scale=2 BL");
+        approx_eq(apply(m, 100.0, 200.0), (200.0, 0.0), "/Rotate 0 scale=2 TR");
+    }
+
+    /// /Rotate 90, scale 1, full page. Display orientation: landscape
+    /// (display_w_pt = page_h_pt = 200, display_h_pt = page_w_pt = 100).
+    /// Page BL (0, 0) → display top-left = bitmap (0, 0).
+    /// Page TR (page_w_pt, page_h_pt) = (100, 200) → display bottom-right.
+    #[cfg(feature = "pdfium")]
+    #[test]
+    fn strip_matrix_rotate_90_full_page_corners() {
+        // Caller passes display dims; for /Rotate 90 portrait original
+        // (page_w_pt=100, page_h_pt=200), display is landscape:
+        // display_w_pt = page_h_pt = 200, display_h_pt = page_w_pt = 100.
+        let m = strip_matrix(PageRotation::Quarter, 1.0, 200.0, 100.0, 0);
+        // Page BL (0, 0) → display top-left = bitmap (0, 0).
+        approx_eq(
+            apply(m, 0.0, 0.0),
+            (0.0, 0.0),
+            "/Rotate 90 page-BL → display-TL",
+        );
+        // Page TL (0, page_h_pt=200) → display top-right = bitmap (200, 0).
+        approx_eq(
+            apply(m, 0.0, 200.0),
+            (200.0, 0.0),
+            "/Rotate 90 page-TL → display-TR",
+        );
+        // Page TR (page_w=100, page_h=200) → display bottom-right = (200, 100).
+        approx_eq(
+            apply(m, 100.0, 200.0),
+            (200.0, 100.0),
+            "/Rotate 90 page-TR → display-BR",
+        );
+        // Page BR (100, 0) → display bottom-left = (0, 100).
+        approx_eq(
+            apply(m, 100.0, 0.0),
+            (0.0, 100.0),
+            "/Rotate 90 page-BR → display-BL",
+        );
+    }
+
+    /// /Rotate 180, scale 1, full page. Display orientation: same as
+    /// page orientation (rotation is a half-turn). Page BL → display
+    /// top-right; page TR → display bottom-left.
+    #[cfg(feature = "pdfium")]
+    #[test]
+    fn strip_matrix_rotate_180_full_page_corners() {
+        // Display dims = page dims for /Rotate 180.
+        let m = strip_matrix(PageRotation::Half, 1.0, 100.0, 200.0, 0);
+        // Page BL (0, 0) → display top-right = bitmap (W=100, 0).
+        approx_eq(
+            apply(m, 0.0, 0.0),
+            (100.0, 0.0),
+            "/Rotate 180 page-BL → display-TR",
+        );
+        // Page TR (100, 200) → display bottom-left = bitmap (0, H=200).
+        approx_eq(
+            apply(m, 100.0, 200.0),
+            (0.0, 200.0),
+            "/Rotate 180 page-TR → display-BL",
+        );
+        // Page BR (100, 0) → display top-left = bitmap (0, 0).
+        approx_eq(
+            apply(m, 100.0, 0.0),
+            (0.0, 0.0),
+            "/Rotate 180 page-BR → display-TL",
+        );
+        // Page TL (0, 200) → display bottom-right = bitmap (100, 200).
+        approx_eq(
+            apply(m, 0.0, 200.0),
+            (100.0, 200.0),
+            "/Rotate 180 page-TL → display-BR",
+        );
+    }
+
+    /// /Rotate 270, scale 1, full page. Display orientation: landscape
+    /// (display_w_pt = page_h_pt, display_h_pt = page_w_pt).
+    /// Page BL (0, 0) → display bottom-right.
+    /// Page TR → display top-left.
+    #[cfg(feature = "pdfium")]
+    #[test]
+    fn strip_matrix_rotate_270_full_page_corners() {
+        // Caller passes display dims; for /Rotate 270 portrait (W=100, H=200),
+        // display is landscape: display_w_pt=200, display_h_pt=100.
+        let m = strip_matrix(PageRotation::ThreeQuarter, 1.0, 200.0, 100.0, 0);
+        // Page BL (0, 0) → display bottom-right = bitmap (display_w_pt=200, display_h_pt=100).
+        approx_eq(
+            apply(m, 0.0, 0.0),
+            (200.0, 100.0),
+            "/Rotate 270 page-BL → display-BR",
+        );
+        // Page TR (page_w=100, page_h=200) → display top-left = (0, 0).
+        approx_eq(
+            apply(m, 100.0, 200.0),
+            (0.0, 0.0),
+            "/Rotate 270 page-TR → display-TL",
+        );
+        // Page BR (100, 0) → display top-right = (200, 0).
+        approx_eq(
+            apply(m, 100.0, 0.0),
+            (200.0, 0.0),
+            "/Rotate 270 page-BR → display-TR",
+        );
+        // Page TL (0, 200) → display bottom-left = (0, 100).
+        approx_eq(
+            apply(m, 0.0, 200.0),
+            (0.0, 100.0),
+            "/Rotate 270 page-TL → display-BL",
+        );
+    }
+
+    /// Strip y_offset translates the result by -y_offset for every rotation,
+    /// without changing the rotation algebra. This invariant is what lets
+    /// the engine's "render strip K, then strip K+1" loop work.
+    #[cfg(feature = "pdfium")]
+    #[test]
+    fn strip_matrix_y_offset_pure_translation_all_rotations() {
+        // For each rotation, computing `apply(matrix(rot, ..., y_off=0), x, y)`
+        // and `apply(matrix(rot, ..., y_off=K), x, y)` must produce results
+        // that differ only by `(0, -K)` in bitmap coords.
+        for &rot in &[
+            PageRotation::Zero,
+            PageRotation::Quarter,
+            PageRotation::Half,
+            PageRotation::ThreeQuarter,
+        ] {
+            // Use display dims that fit each rotation. For /Rotate 0/180,
+            // display = (W=100, H=200). For 90/270, display = (W=200, H=100).
+            let (dw, dh): (f32, f32) = match rot {
+                PageRotation::Zero | PageRotation::Half => (100.0, 200.0),
+                PageRotation::Quarter | PageRotation::ThreeQuarter => (200.0, 100.0),
+            };
+            let m_no_off = strip_matrix(rot, 1.0, dw, dh, 0);
+            let m_with_off = strip_matrix(rot, 1.0, dw, dh, 50);
+            // Pick an arbitrary page point inside any of the four rotation's
+            // bounding boxes (use the smaller of dimensions).
+            let (test_x, test_y) = (10.0_f32, 10.0_f32);
+            let p0 = apply(m_no_off, test_x, test_y);
+            let p1 = apply(m_with_off, test_x, test_y);
+            approx_eq(
+                (p1.0 - p0.0, p1.1 - p0.1),
+                (0.0, -50.0),
+                &format!("/Rotate {rot:?} y_offset translation invariant"),
+            );
+        }
+    }
+
+    /// `PageRotation::try_from_degrees` rejects non-multiples of 90 with
+    /// the typed [`PdfError::UnsupportedRotation`] variant. The bare
+    /// matrix function takes a `PageRotation` and so cannot fail —
+    /// invalid rotations are caught at the parsing boundary.
+    #[cfg(feature = "pdfium")]
+    #[test]
+    fn page_rotation_rejects_non_quarter_value() {
+        match PageRotation::try_from_degrees(45) {
+            Err(PdfError::UnsupportedRotation(45)) => {}
+            other => panic!("expected UnsupportedRotation(45), got {other:?}"),
+        }
+    }
+
+    /// `try_from_degrees` normalises out-of-range rotations via
+    /// `rem_euclid 360`. /Rotate -90 is /Rotate 270; /Rotate 450 is
+    /// /Rotate 90. Each maps to the canonical [`PageRotation`] variant.
+    #[cfg(feature = "pdfium")]
+    #[test]
+    fn page_rotation_normalises_input() {
+        assert_eq!(
+            PageRotation::try_from_degrees(-90).unwrap(),
+            PageRotation::ThreeQuarter
+        );
+        assert_eq!(
+            PageRotation::try_from_degrees(450).unwrap(),
+            PageRotation::Quarter
+        );
+        assert_eq!(
+            PageRotation::try_from_degrees(720).unwrap(),
+            PageRotation::Zero
+        );
+    }
+
+    /// Round-trip: every `PageRotation` value's `as_degrees()` round-
+    /// trips through `try_from_degrees`.
+    #[cfg(feature = "pdfium")]
+    #[test]
+    fn page_rotation_degrees_round_trip() {
+        for r in [
+            PageRotation::Zero,
+            PageRotation::Quarter,
+            PageRotation::Half,
+            PageRotation::ThreeQuarter,
+        ] {
+            assert_eq!(PageRotation::try_from_degrees(r.as_degrees()).unwrap(), r);
+        }
     }
 }

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -931,6 +931,7 @@ pub(crate) fn strip_matrix(
 /// - [`PdfError::Pdfium`] — pdfium load / page get / matrix-validity /
 ///   render error, including unsupported `/Rotate` values not in
 ///   `{0, 90, 180, 270}`.
+///
 /// Render a single horizontal strip from an **already-loaded** [`PdfPage`].
 ///
 /// This is the hot-path entry used by [`crate::PdfiumStripSource`] in

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -523,6 +523,33 @@ fn resolve_rotate(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> i64 {
     0
 }
 
+/// Resolve the effective `/Rotate` value for a 1-based page number.
+///
+/// Loads the PDF via `lopdf` and walks the page's `/Parent` chain to find
+/// the inherited `/Rotate` entry (per PDF 1.7 §7.7.3.3). The result is
+/// normalised into `[0, 360)`. Pages without a `/Rotate` entry, malformed
+/// values, and self-referential parent chains all resolve to `0`.
+///
+/// This is the path-based companion of the private [`resolve_rotate`]
+/// helper. Callers driving pdfium's matrix render path need the page's
+/// intrinsic `/Rotate` to compose the right device transform —
+/// `FPDF_RenderPageBitmapWithMatrix` does not auto-apply it the way the
+/// form-data render path does.
+///
+/// # Errors
+///
+/// - [`PdfError::Parse`] — PDF could not be opened or parsed by `lopdf`.
+/// - [`PdfError::PageOutOfRange`] — `page == 0` or `page > total_pages`.
+pub fn page_rotate(path: &Path, page: usize) -> Result<i64, PdfError> {
+    let doc = lopdf::Document::load(path).map_err(|e| PdfError::Parse(e.to_string()))?;
+    let pages_map = doc.get_pages();
+    let total = pages_map.len();
+    let &page_id = pages_map
+        .get(&(page as u32))
+        .ok_or(PdfError::PageOutOfRange { page, total })?;
+    Ok(resolve_rotate(&doc, page_id).rem_euclid(360))
+}
+
 /// Check whether a page has any Image XObjects.
 fn page_has_images(doc: &lopdf::Document, page_id: lopdf::ObjectId) -> bool {
     let Ok(obj) = doc.get_object(page_id) else {
@@ -701,6 +728,131 @@ pub fn render_page_pdfium(path: &Path, page: usize, dpi: u32) -> Result<Raster, 
     let height = (pdf_page.height().value * scale) as u32;
 
     render_at_size(&pdf_page, width, height)
+}
+
+/// Render a single horizontal strip of a PDF page directly via pdfium's
+/// matrix render path, allocating only a strip-sized bitmap.
+///
+/// `y_offset` and `strip_height` are in display-oriented pixel coordinates
+/// (top-left origin, y-down) — the same coordinate system the engine and
+/// `StripSource` callers already speak. `rotation` is the page's intrinsic
+/// `/Rotate` (call [`page_rotate`] to obtain it once per source).
+///
+/// # Coordinate composition
+///
+/// `FPDF_RenderPageBitmapWithMatrix` does not auto-apply the page's
+/// `/Rotate`; only the form-data render path does. We compose the
+/// per-rotation device matrix manually so the rendered strip lands at
+/// rows `[0, strip_height)` of the output bitmap. For each `/Rotate`
+/// value, the matrix maps pre-rotation page coordinates (y-up, origin
+/// bottom-left, units = points) into bitmap pixel coordinates (y-down,
+/// origin top-left, units = pixels):
+///
+/// | `/Rotate` | `[a, b, c, d, e, f]`                                        |
+/// |-----------|-------------------------------------------------------------|
+/// | 0         | `[s,  0,  0, -s, 0,             s·page_h_pt − y_off]`       |
+/// | 90        | `[0,  s,  s,  0, 0,             −y_off]`                    |
+/// | 180       | `[−s, 0,  0,  s, s·page_w_pt,   −y_off]`                    |
+/// | 270       | `[0, −s, −s,  0, s·page_h_pt,   s·page_w_pt − y_off]`       |
+///
+/// `s = dpi / 72`. `page_w_pt` / `page_h_pt` are pre-rotation page
+/// dimensions in points (swapped from `pdf_page.width()/height()` for
+/// `/Rotate 90/270`, since pdfium-render's getters return display-oriented
+/// dims — see comment at `pdf.rs:376-379`). The full per-rotation
+/// derivation lives in libviprs#70 and is pinned by the rotation cross-
+/// product test
+/// (`libviprs-tests/tests/pdfium_streaming_rotation_matrix.rs`).
+///
+/// # Errors
+///
+/// - [`PdfError::PageOutOfRange`] — `page == 0` or `page > total_pages`.
+/// - [`PdfError::Pdfium`] — pdfium load / page get / matrix-validity /
+///   render error, including unsupported `/Rotate` values not in
+///   `{0, 90, 180, 270}`.
+#[cfg(feature = "pdfium")]
+pub(crate) fn render_page_strip_pdfium(
+    path: &Path,
+    page: usize,
+    dpi: u32,
+    rotation: i64,
+    y_offset: u32,
+    strip_height: u32,
+) -> Result<Raster, PdfError> {
+    use pdfium_render::prelude::*;
+
+    let pdfium = init_pdfium()?;
+    let document = pdfium
+        .load_pdf_from_file(path, None)
+        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
+
+    let pages = document.pages();
+    let total = pages.len();
+    if page == 0 || page > total as usize {
+        return Err(PdfError::PageOutOfRange {
+            page,
+            total: total as usize,
+        });
+    }
+    let pdf_page = pages
+        .get(page as u16 - 1)
+        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
+
+    let scale = dpi as f32 / 72.0;
+    // Display-oriented dims; pdf_page.width()/height() return post-/Rotate
+    // values per `pdf.rs:376-379`.
+    let display_w_pt = pdf_page.width().value;
+    let display_h_pt = pdf_page.height().value;
+    let display_w_px = (display_w_pt * scale) as u32;
+    let display_h_px = (display_h_pt * scale) as u32;
+
+    // Mirror cached-mode clamping (streaming.rs:341-346): if the requested
+    // strip extends past the page, the bitmap is shorter; if it starts
+    // past the page, return a zero raster of the requested height to
+    // keep the StripSource contract.
+    let strip_h = strip_height.min(display_h_px.saturating_sub(y_offset));
+    if strip_h == 0 {
+        let data = vec![0u8; display_w_px as usize * strip_height as usize * 4];
+        return Raster::new(display_w_px, strip_height, PixelFormat::Rgba8, data)
+            .map_err(PdfError::from);
+    }
+
+    let normalised = rotation.rem_euclid(360);
+    let (page_w_pt, page_h_pt) = match normalised {
+        0 | 180 => (display_w_pt, display_h_pt),
+        90 | 270 => (display_h_pt, display_w_pt),
+        _ => {
+            return Err(PdfError::Pdfium(format!(
+                "unsupported page /Rotate value: {normalised} (must be 0/90/180/270)"
+            )));
+        }
+    };
+    let s = scale;
+    let y_off = y_offset as f32;
+    let (a, b, c, d, e, f) = match normalised {
+        0 => (s, 0.0, 0.0, -s, 0.0, s * page_h_pt - y_off),
+        90 => (0.0, s, s, 0.0, 0.0, -y_off),
+        180 => (-s, 0.0, 0.0, s, s * page_w_pt, -y_off),
+        270 => (0.0, -s, -s, 0.0, s * page_h_pt, s * page_w_pt - y_off),
+        _ => unreachable!("normalised is checked above"),
+    };
+    let matrix = PdfMatrix::new(a, b, c, d, e, f);
+
+    let config = PdfRenderConfig::new()
+        .set_fixed_size(display_w_px as i32, strip_h as i32)
+        .clip(0, 0, display_w_px as i32, strip_h as i32)
+        .apply_matrix(matrix)
+        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
+
+    let bitmap = pdf_page
+        .render_with_config(&config)
+        .map_err(|e| PdfError::Pdfium(e.to_string()))?;
+
+    let img = bitmap.as_image();
+    let rgba = img.to_rgba8();
+    let (w, h) = (rgba.width(), rgba.height());
+    let data = rgba.into_raw();
+
+    Raster::new(w, h, PixelFormat::Rgba8, data).map_err(PdfError::from)
 }
 
 /// Result of a budget-constrained render, including the DPI that was used.

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -60,9 +60,10 @@ pub enum PdfError {
 ///
 /// Construct via [`Self::try_from_degrees`] for parsing, or directly
 /// match on the four variants when handling all rotations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PageRotation {
     /// No rotation. The page renders in its authored orientation.
+    #[default]
     Zero,
     /// 90° clockwise. Portrait page renders as landscape; the page's
     /// top edge becomes the displayed right edge.
@@ -104,12 +105,6 @@ impl PageRotation {
             Self::Half => 180,
             Self::ThreeQuarter => 270,
         }
-    }
-}
-
-impl Default for PageRotation {
-    fn default() -> Self {
-        Self::Zero
     }
 }
 

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -708,32 +708,31 @@ fn obj_to_f64(obj: &lopdf::Object) -> Option<f64> {
 // Pdfium-based rendering (feature-gated)
 // ---------------------------------------------------------------------------
 
-/// Process-wide lock for FPDF API access.
+/// Process-wide lock for FPDF API access — defence-in-depth thread
+/// safety at the libviprs boundary.
 ///
-/// pdfium-render 0.8's `thread_safe` feature only acquires a mutex on
-/// `FPDF_InitLibrary` / `FPDF_DestroyLibrary`; every other FPDF call
-/// delegates to the inner bindings without further synchronization
-/// (see `bindings/thread_safe.rs:170-172` upstream — `FPDF_LoadDocument`
-/// is a one-line delegate, no lock acquired). Pdfium itself is not
-/// thread-safe, so any concurrent FPDF call from a different thread
-/// hits unsynchronized state inside the C library and segfaults.
+/// pdfium itself is not thread-safe at the C library level. The
+/// `pdfium-render` `sync` feature wraps every FPDF call in a global
+/// mutex, but **only** when libviprs's `[patch.crates-io]` directive
+/// is honoured, which requires the consumer crate (libviprs-tests,
+/// libviprs-cli, downstream users) to either share a workspace with
+/// libviprs or replicate the patch directive. Cargo does not
+/// propagate `[patch.crates-io]` from a path-dependency.
 ///
-/// We compensate by holding this libviprs-side lock around every entry
-/// point that issues FPDF calls. The lock is process-wide because
-/// pdfium's global state is process-wide; document or page handles
-/// from different `PdfiumStripSource` instances still share the
-/// underlying C state, so per-source locking would not be sufficient.
+/// To keep libviprs correct without depending on consumer-side
+/// patch hygiene, every FPDF entry point in this crate acquires this
+/// process-wide lock first. If the consumer also has the patched
+/// fork active (the recommended setup), the result is double-locking
+/// — a few extra nanoseconds per call, no correctness or deadlock
+/// concern (the locks are independent `Mutex<()>` instances acquired
+/// in a fixed order). If the patch is missing, this lock alone keeps
+/// concurrent renders safe.
 ///
 /// **Performance note:** With this lock held, multi-threaded
-/// `render_strip` calls serialize. That matches the underlying reality
-/// (pdfium itself is single-threaded), so no parallelism is lost — a
-/// per-call lock simply makes that explicit and safe instead of
-/// implicit and crashing.
-///
-/// **Future:** The libviprs/pdfium-render fork contains a proper
-/// per-method-locked `ThreadSafePdfiumBindings`. Once libviprs depends
-/// on that fork via `[patch.crates-io]`, this lock can be removed and
-/// `with_pdfium_lock` callers will be able to inline.
+/// `render_strip` calls serialise. That matches the underlying
+/// reality (pdfium itself is single-threaded), so no parallelism is
+/// lost — this lock simply makes the serialisation explicit and safe
+/// instead of implicit and crashing.
 #[cfg(feature = "pdfium")]
 static PDFIUM_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -945,10 +944,10 @@ pub(crate) fn strip_matrix(
 /// call, avoiding the per-strip PDF reparse that path-based one-shot
 /// rendering would pay.
 ///
-/// **The caller must hold [`pdfium_lock`]** for the duration of this
-/// call — the function issues FPDF calls (matrix render plus bitmap
-/// allocation/deallocation) that share global pdfium state with every
-/// other thread, and pdfium's C library is not thread-safe.
+/// FPDF calls underneath this function are serialised by
+/// `pdfium-render`'s `ThreadSafePdfiumBindings` (active via the
+/// `sync` feature plus the `[patch.crates-io]` directive in
+/// `libviprs/Cargo.toml`).
 ///
 /// `dpi`, `rotation`, `y_offset`, `strip_height` semantics match the
 /// matrix derivation documented at [`strip_matrix`].

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -216,41 +216,38 @@ enum PdfiumSourceState {
     Streaming(StreamingState),
 }
 
-/// Per-source streaming state. Holds a parsed [`PdfDocument`] so subsequent
-/// `render_strip` calls don't reparse the PDF on every invocation.
+/// Per-source streaming state. Holds a parsed [`PdfDocument`] so
+/// subsequent `render_strip` calls don't reparse the PDF on every
+/// invocation.
 ///
-/// The document is stored in an [`Option`] so [`Drop`] can `take()` it
-/// while holding [`crate::pdf::pdfium_lock`]. Without that ordering, the
-/// document's `FPDF_CloseDocument` would run after our user-defined
-/// `drop` returns and after the lock guard has been released, racing
-/// with any other thread that's mid-render.
+/// The document is stored in an [`Option`] for explicit drop ordering —
+/// [`Drop`] takes it before any caller would expect it gone, which
+/// keeps the cached-handle lifecycle obvious to readers. The actual
+/// FPDF synchronisation that protects `FPDF_CloseDocument` against
+/// concurrent renders lives in `pdfium-render`'s
+/// `ThreadSafePdfiumBindings` wrapper (active via the `sync` feature
+/// plus the `[patch.crates-io]` patched fork pinned in
+/// `libviprs/Cargo.toml`).
 ///
 /// Lifetime is `'static` because the document borrows from
-/// [`crate::pdf::init_pdfium`]'s `OnceLock`-backed `&'static Pdfium`. With
-/// the pdfium-render `sync` feature on,
-/// `PdfDocument<'static>` is `Send + Sync`.
+/// [`crate::pdf::init_pdfium`]'s `OnceLock`-backed `&'static Pdfium`.
+/// With the pdfium-render `sync` feature on, `PdfDocument<'static>` is
+/// `Send + Sync`.
 #[cfg(feature = "pdfium")]
 struct StreamingState {
-    /// Always `Some(_)` outside `Drop`. Wrapped in `Option` purely so
-    /// `take()` can give the document a deterministic drop site under
-    /// the pdfium lock.
+    /// Always `Some(_)` outside `Drop`. Wrapped in `Option` for
+    /// readable drop ordering inside the `Drop` impl.
     document: Option<pdfium_render::prelude::PdfDocument<'static>>,
     /// 0-based page index for pdfium-render's `PdfPages::get`. Stored
     /// pre-converted so the hot path doesn't re-validate `page > 0`.
     page_index: u16,
-    /// Page's intrinsic `/Rotate` ∈ `{0, 90, 180, 270}`, normalised at
-    /// construction.
+    /// Page's intrinsic `/Rotate`, normalised at construction.
     rotation: crate::pdf::PageRotation,
 }
 
 #[cfg(feature = "pdfium")]
 impl Drop for StreamingState {
     fn drop(&mut self) {
-        // Hold the global pdfium lock while the cached document drops.
-        // `FPDF_CloseDocument` is an FPDF call and must not race with
-        // any concurrent render on a different source — `take()` here
-        // forces the drop to land while `_lock` is still in scope.
-        let _lock = crate::pdf::pdfium_lock();
         drop(self.document.take());
     }
 }
@@ -409,9 +406,12 @@ impl PdfiumStripSource {
     ///
     /// # Concurrency
     ///
-    /// pdfium itself is not thread-safe. libviprs serialises every
-    /// FPDF call through a process-wide [`crate::pdf::pdfium_lock`],
-    /// so concurrent `render_strip` calls from multiple threads (e.g.
+    /// pdfium itself is not thread-safe. The `pdfium-render` `sync`
+    /// feature, plus the `[patch.crates-io]` directive in
+    /// `libviprs/Cargo.toml` that pins the patched fork at
+    /// `libviprs/pdfium-render` branch `libviprs/per-call-thread-safety`,
+    /// serialise every FPDF call through a process-wide mutex. So
+    /// concurrent `render_strip` calls from multiple threads (e.g.
     /// under `EngineKind::MapReduce`) are correct but produce no
     /// parallelism. This is a property of the underlying C library;
     /// no parallelism is "lost" relative to a hypothetical safer
@@ -516,7 +516,7 @@ impl PdfiumStripSource {
 /// document handle is cached in `StreamingState` so subsequent renders
 /// pay no parse cost.
 ///
-/// Acquires [`crate::pdf::pdfium_lock`] internally for the duration
+/// Acquires `pdfium-render`'s thread-safety lock internally for the duration
 /// of the FPDF calls. Caller must not be holding the lock.
 #[cfg(feature = "pdfium")]
 fn load_streaming_source(
@@ -565,7 +565,7 @@ fn load_streaming_source(
 /// Shared budget-policy resolution used by both the cached and streaming
 /// `*_with_budget` constructors.
 ///
-/// Acquires [`crate::pdf::pdfium_lock`] internally so the inner calls
+/// Acquires `pdfium-render`'s thread-safety lock internally so the inner calls
 /// to [`probe_page_dims`] / [`resolve_dpi_under_budget`] (which assume
 /// the lock is held) can run safely. Callers do not need to acquire
 /// the lock first.
@@ -607,7 +607,7 @@ fn resolve_budget_dpi(
 
 /// Probe a PDF page's dimensions without rendering.
 ///
-/// **Caller must hold [`crate::pdf::pdfium_lock`]** — this function
+/// **Caller must hold `pdfium-render`'s thread-safety lock** — this function
 /// issues FPDF calls (load + page get + dim getter) that require
 /// process-wide pdfium serialization.
 #[cfg(feature = "pdfium")]
@@ -647,7 +647,7 @@ fn probe_page_dims(
 /// strip fits within `budget_bytes`, or error if even `min_dpi` would
 /// not fit.
 ///
-/// **Caller must hold [`crate::pdf::pdfium_lock`]** — this function
+/// **Caller must hold `pdfium-render`'s thread-safety lock** — this function
 /// calls [`probe_page_dims`] internally, which is not standalone-locked.
 #[cfg(feature = "pdfium")]
 fn resolve_dpi_under_budget(

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -213,7 +213,13 @@ pub enum PdfiumRenderMode {
 #[cfg(feature = "pdfium")]
 enum PdfiumSourceState {
     CachedFullPage { full_raster: Raster },
-    Streaming(StreamingState),
+    // Boxed so the enum size is bounded by the smaller variant. The
+    // `StreamingState` payload is ~368 bytes (it carries a `PdfDocument`
+    // handle plus its drop-ordered `Option`); the heap indirection here
+    // avoids inflating every `PdfiumSourceState` value to that size,
+    // including `CachedFullPage` ones that don't need the streaming
+    // machinery at all.
+    Streaming(Box<StreamingState>),
 }
 
 /// Per-source streaming state. Holds a parsed [`PdfDocument`] so
@@ -554,11 +560,11 @@ fn load_streaming_source(
         width,
         height,
         dpi,
-        state: PdfiumSourceState::Streaming(StreamingState {
+        state: PdfiumSourceState::Streaming(Box::new(StreamingState {
             document: Some(document),
             page_index: (page as u16).saturating_sub(1),
             rotation,
-        }),
+        })),
     })
 }
 

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -186,22 +186,64 @@ impl<'a> StripSource for RasterStripSource<'a> {
 // PdfiumStripSource — true source-side PDF strip streaming
 // ---------------------------------------------------------------------------
 
-/// [`StripSource`] backed by pdfium.
+/// Render-mode tag for [`PdfiumStripSource`].
 ///
-/// At construction time, the full display-oriented page is rendered once via
-/// [`render_page_pdfium`](crate::pdf::render_page_pdfium). Each
-/// [`render_strip`](StripSource::render_strip) call then slices the cached
-/// raster — O(1) per strip, no additional pdfium calls. Dimensions are
-/// taken directly from the rendered raster so
-/// [`StripSource::width`]/[`StripSource::height`] match the output byte-for-byte.
+/// Selects how the source produces strips:
 ///
-/// This currently trades source-side memory (`O(canvas_w × canvas_h)`) for
-/// correctness: pdfium's matrix render path does not auto-apply the page's
-/// intrinsic `/Rotate`, and hand-composed rotation matrices produced
-/// 180°-off output for `/Rotate 90/270` pages in practice. The form-data
-/// render path that `render_page_pdfium` uses does rotate automatically, so
-/// we fall back to full-page render + slice. See
-/// [`render_strip_inner`](Self::render_strip_inner) for details.
+/// - [`CachedFullPage`](Self::CachedFullPage) — render the full display-
+///   oriented page once at construction and slice subsequent strips from
+///   that cached buffer. O(1) per [`render_strip`](StripSource::render_strip)
+///   after the first, but resident memory is `width × height × 4` bytes
+///   for the source's lifetime.
+/// - [`Streaming`](Self::Streaming) — render each strip on demand via
+///   pdfium's matrix render path. The source holds only path / page /
+///   rotation metadata between calls; peak memory is bounded by the
+///   strip in flight.
+///
+/// Pick streaming for sources whose full page would exceed your memory
+/// budget (large-format blueprints, scanned posters), and cached when the
+/// full page comfortably fits and per-strip pdfium overhead matters.
+#[cfg(feature = "pdfium")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PdfiumRenderMode {
+    CachedFullPage,
+    Streaming,
+}
+
+#[cfg(feature = "pdfium")]
+enum PdfiumSourceState {
+    CachedFullPage {
+        full_raster: Raster,
+    },
+    Streaming {
+        path: std::path::PathBuf,
+        page: usize,
+        rotation: i64,
+    },
+}
+
+/// [`StripSource`] backed by pdfium, in either cached or streaming mode.
+///
+/// The constructor chosen determines the mode:
+///
+/// - [`new`](Self::new) / [`new_with_budget`](Self::new_with_budget) —
+///   [`PdfiumRenderMode::CachedFullPage`]. Renders the full display-
+///   oriented page once via [`render_page_pdfium`](crate::pdf::render_page_pdfium)
+///   and slices subsequent strips from the cached buffer.
+/// - [`new_streaming`](Self::new_streaming) /
+///   [`new_streaming_with_budget`](Self::new_streaming_with_budget) —
+///   [`PdfiumRenderMode::Streaming`]. Renders each strip on demand via
+///   [`render_page_strip_pdfium`](crate::pdf::render_page_strip_pdfium),
+///   keeping source-side peak memory bounded by the strip in flight.
+///
+/// Both modes honour the same [`StripSource`] contract: `render_strip(y, h)`
+/// returns a raster of width [`width()`](StripSource::width) and height
+/// `≤ h`, sourced from rows `[y, y + h)` of the display-oriented page.
+/// Output bytes between modes are not pixel-identical because pdfium's
+/// form-data and matrix render paths use independent rasterisers; both
+/// satisfy the engine's region-correctness requirement (see the test
+/// suite at `libviprs-tests/tests/streaming_pdfium_matrix.rs` and
+/// `pdfium_streaming_render.rs`).
 ///
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-render)
 #[cfg(feature = "pdfium")]
@@ -209,10 +251,7 @@ pub struct PdfiumStripSource {
     width: u32,
     height: u32,
     dpi: u32,
-    /// Full display-oriented raster, rendered at construction time and
-    /// sliced per-strip. See [`render_strip_inner`] for why we cache the
-    /// full page instead of rendering strip-by-strip.
-    full_raster: Raster,
+    state: PdfiumSourceState,
 }
 
 #[cfg(feature = "pdfium")]
@@ -222,13 +261,14 @@ impl std::fmt::Debug for PdfiumStripSource {
             .field("width", &self.width)
             .field("height", &self.height)
             .field("dpi", &self.dpi)
+            .field("mode", &self.mode())
             .finish()
     }
 }
 
 #[cfg(feature = "pdfium")]
 impl PdfiumStripSource {
-    /// Open a PDF page as a strip source at the given DPI.
+    /// Open a PDF page as a [`PdfiumRenderMode::CachedFullPage`] strip source.
     ///
     /// Renders the full display-oriented page via pdfium and caches it.
     /// Subsequent [`render_strip`](StripSource::render_strip) calls slice
@@ -250,8 +290,7 @@ impl PdfiumStripSource {
         // differently than our `probe_page_dims` truncation at higher DPIs;
         // using the cached raster's real width/height keeps
         // `StripSource::width`/`height` in lockstep with what `render_strip`
-        // will hand back. See `render_strip_inner` for why we render the
-        // full page in the first place.
+        // will hand back.
         let full = crate::pdf::render_page_pdfium(&path, page, dpi)?;
         let width = full.width();
         let height = full.height();
@@ -259,11 +298,12 @@ impl PdfiumStripSource {
             width,
             height,
             dpi,
-            full_raster: full,
+            state: PdfiumSourceState::CachedFullPage { full_raster: full },
         })
     }
 
-    /// Open a PDF page with a worst-case strip budget check.
+    /// Open a [`PdfiumRenderMode::CachedFullPage`] source with a worst-case
+    /// strip budget check.
     ///
     /// Computes the worst-case minimum aligned strip
     /// (`width × min_strip_height × 4` bytes for RGBA8) and applies the
@@ -282,30 +322,14 @@ impl PdfiumStripSource {
         policy: BudgetPolicy,
     ) -> Result<Self, crate::pdf::PdfError> {
         let path = path.into();
-        let pdfium = crate::pdf::init_pdfium()?;
-        let resolved_dpi = match policy {
-            BudgetPolicy::Error => {
-                let (width, _, _, _) = probe_page_dims(pdfium, &path, page, dpi_hint)?;
-                let strip_bytes = width as u64 * min_strip_height as u64 * 4;
-                if strip_bytes > budget_bytes {
-                    return Err(crate::pdf::PdfError::BudgetExceeded {
-                        strip_bytes,
-                        budget_bytes,
-                        dpi: dpi_hint,
-                    });
-                }
-                dpi_hint
-            }
-            BudgetPolicy::AutoAdjustDpi { min_dpi } => resolve_dpi_under_budget(
-                pdfium,
-                &path,
-                page,
-                dpi_hint,
-                min_dpi,
-                min_strip_height,
-                budget_bytes,
-            )?,
-        };
+        let resolved_dpi = resolve_budget_dpi(
+            &path,
+            page,
+            dpi_hint,
+            min_strip_height,
+            budget_bytes,
+            policy,
+        )?;
         let full = crate::pdf::render_page_pdfium(&path, page, resolved_dpi)?;
         let width = full.width();
         let height = full.height();
@@ -313,7 +337,75 @@ impl PdfiumStripSource {
             width,
             height,
             dpi: resolved_dpi,
-            full_raster: full,
+            state: PdfiumSourceState::CachedFullPage { full_raster: full },
+        })
+    }
+
+    /// Open a PDF page as a [`PdfiumRenderMode::Streaming`] strip source.
+    ///
+    /// Each [`render_strip`](StripSource::render_strip) call dispatches
+    /// directly to pdfium's matrix render path; no full-page raster is
+    /// held by the source. Construction probes dimensions and the page's
+    /// intrinsic `/Rotate` once.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` — Path to the PDF file.
+    /// * `page` — 1-based page number.
+    /// * `dpi` — Render resolution in dots per inch.
+    pub fn new_streaming(
+        path: impl Into<std::path::PathBuf>,
+        page: usize,
+        dpi: u32,
+    ) -> Result<Self, crate::pdf::PdfError> {
+        let path = path.into();
+        let pdfium = crate::pdf::init_pdfium()?;
+        let (width, height, _, _) = probe_page_dims(pdfium, &path, page, dpi)?;
+        let rotation = crate::pdf::page_rotate(&path, page)?;
+        Ok(Self {
+            width,
+            height,
+            dpi,
+            state: PdfiumSourceState::Streaming {
+                path,
+                page,
+                rotation,
+            },
+        })
+    }
+
+    /// Open a [`PdfiumRenderMode::Streaming`] source with a worst-case
+    /// strip budget check. See [`new_with_budget`](Self::new_with_budget)
+    /// for the policy semantics.
+    pub fn new_streaming_with_budget(
+        path: impl Into<std::path::PathBuf>,
+        page: usize,
+        dpi_hint: u32,
+        min_strip_height: u32,
+        budget_bytes: u64,
+        policy: BudgetPolicy,
+    ) -> Result<Self, crate::pdf::PdfError> {
+        let path = path.into();
+        let resolved_dpi = resolve_budget_dpi(
+            &path,
+            page,
+            dpi_hint,
+            min_strip_height,
+            budget_bytes,
+            policy,
+        )?;
+        let pdfium = crate::pdf::init_pdfium()?;
+        let (width, height, _, _) = probe_page_dims(pdfium, &path, page, resolved_dpi)?;
+        let rotation = crate::pdf::page_rotate(&path, page)?;
+        Ok(Self {
+            width,
+            height,
+            dpi: resolved_dpi,
+            state: PdfiumSourceState::Streaming {
+                path,
+                page,
+                rotation,
+            },
         })
     }
 
@@ -323,31 +415,76 @@ impl PdfiumStripSource {
         self.dpi
     }
 
+    /// The render mode this source was constructed in.
+    pub fn mode(&self) -> PdfiumRenderMode {
+        match self.state {
+            PdfiumSourceState::CachedFullPage { .. } => PdfiumRenderMode::CachedFullPage,
+            PdfiumSourceState::Streaming { .. } => PdfiumRenderMode::Streaming,
+        }
+    }
+
     fn render_strip_inner(
         &self,
         y_offset: u32,
         height: u32,
     ) -> Result<Raster, crate::pdf::PdfError> {
-        // Pdfium's matrix-based render path (FPDF_RenderPageBitmapWithMatrix)
-        // does not auto-apply the page's intrinsic /Rotate — hand-composed
-        // rotation matrices produced 180°-off output for /Rotate 90/270
-        // pages across every variant we tried. Rather than chase pdfium's
-        // matrix conventions, we render the full display-oriented raster
-        // once via `render_page_pdfium` (the form-data path that pdfium
-        // does rotate automatically) and slice strips out of the cached
-        // buffer. This trades peak memory for correctness; a future
-        // iteration can switch back to a true single-strip render once
-        // pdfium's matrix convention is pinned down.
-        let strip_h = height.min(self.height.saturating_sub(y_offset));
-        if strip_h == 0 {
-            let data = vec![0u8; self.width as usize * height as usize * 4];
-            return Raster::new(self.width, height, PixelFormat::Rgba8, data)
-                .map_err(crate::pdf::PdfError::from);
+        match &self.state {
+            PdfiumSourceState::CachedFullPage { full_raster } => {
+                let strip_h = height.min(self.height.saturating_sub(y_offset));
+                if strip_h == 0 {
+                    let data = vec![0u8; self.width as usize * height as usize * 4];
+                    return Raster::new(self.width, height, PixelFormat::Rgba8, data)
+                        .map_err(crate::pdf::PdfError::from);
+                }
+                full_raster
+                    .extract(0, y_offset, self.width, strip_h)
+                    .map_err(crate::pdf::PdfError::from)
+            }
+            PdfiumSourceState::Streaming {
+                path,
+                page,
+                rotation,
+            } => crate::pdf::render_page_strip_pdfium(
+                path, *page, self.dpi, *rotation, y_offset, height,
+            ),
         }
+    }
+}
 
-        self.full_raster
-            .extract(0, y_offset, self.width, strip_h)
-            .map_err(crate::pdf::PdfError::from)
+/// Shared budget-policy resolution used by both the cached and streaming
+/// `*_with_budget` constructors.
+#[cfg(feature = "pdfium")]
+fn resolve_budget_dpi(
+    path: &std::path::Path,
+    page: usize,
+    dpi_hint: u32,
+    min_strip_height: u32,
+    budget_bytes: u64,
+    policy: BudgetPolicy,
+) -> Result<u32, crate::pdf::PdfError> {
+    let pdfium = crate::pdf::init_pdfium()?;
+    match policy {
+        BudgetPolicy::Error => {
+            let (width, _, _, _) = probe_page_dims(pdfium, path, page, dpi_hint)?;
+            let strip_bytes = width as u64 * min_strip_height as u64 * 4;
+            if strip_bytes > budget_bytes {
+                return Err(crate::pdf::PdfError::BudgetExceeded {
+                    strip_bytes,
+                    budget_bytes,
+                    dpi: dpi_hint,
+                });
+            }
+            Ok(dpi_hint)
+        }
+        BudgetPolicy::AutoAdjustDpi { min_dpi } => resolve_dpi_under_budget(
+            pdfium,
+            path,
+            page,
+            dpi_hint,
+            min_dpi,
+            min_strip_height,
+            budget_bytes,
+        ),
     }
 }
 

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -212,14 +212,47 @@ pub enum PdfiumRenderMode {
 
 #[cfg(feature = "pdfium")]
 enum PdfiumSourceState {
-    CachedFullPage {
-        full_raster: Raster,
-    },
-    Streaming {
-        path: std::path::PathBuf,
-        page: usize,
-        rotation: i64,
-    },
+    CachedFullPage { full_raster: Raster },
+    Streaming(StreamingState),
+}
+
+/// Per-source streaming state. Holds a parsed [`PdfDocument`] so subsequent
+/// `render_strip` calls don't reparse the PDF on every invocation.
+///
+/// The document is stored in an [`Option`] so [`Drop`] can `take()` it
+/// while holding [`crate::pdf::pdfium_lock`]. Without that ordering, the
+/// document's `FPDF_CloseDocument` would run after our user-defined
+/// `drop` returns and after the lock guard has been released, racing
+/// with any other thread that's mid-render.
+///
+/// Lifetime is `'static` because the document borrows from
+/// [`crate::pdf::init_pdfium`]'s `OnceLock`-backed `&'static Pdfium`. With
+/// the pdfium-render `sync` feature on,
+/// `PdfDocument<'static>` is `Send + Sync`.
+#[cfg(feature = "pdfium")]
+struct StreamingState {
+    /// Always `Some(_)` outside `Drop`. Wrapped in `Option` purely so
+    /// `take()` can give the document a deterministic drop site under
+    /// the pdfium lock.
+    document: Option<pdfium_render::prelude::PdfDocument<'static>>,
+    /// 0-based page index for pdfium-render's `PdfPages::get`. Stored
+    /// pre-converted so the hot path doesn't re-validate `page > 0`.
+    page_index: u16,
+    /// Page's intrinsic `/Rotate` ∈ `{0, 90, 180, 270}`, normalised at
+    /// construction.
+    rotation: crate::pdf::PageRotation,
+}
+
+#[cfg(feature = "pdfium")]
+impl Drop for StreamingState {
+    fn drop(&mut self) {
+        // Hold the global pdfium lock while the cached document drops.
+        // `FPDF_CloseDocument` is an FPDF call and must not race with
+        // any concurrent render on a different source — `take()` here
+        // forces the drop to land while `_lock` is still in scope.
+        let _lock = crate::pdf::pdfium_lock();
+        drop(self.document.take());
+    }
 }
 
 /// [`StripSource`] backed by pdfium, in either cached or streaming mode.
@@ -232,9 +265,10 @@ enum PdfiumSourceState {
 ///   and slices subsequent strips from the cached buffer.
 /// - [`new_streaming`](Self::new_streaming) /
 ///   [`new_streaming_with_budget`](Self::new_streaming_with_budget) —
-///   [`PdfiumRenderMode::Streaming`]. Renders each strip on demand via
-///   [`render_page_strip_pdfium`](crate::pdf::render_page_strip_pdfium),
-///   keeping source-side peak memory bounded by the strip in flight.
+///   [`PdfiumRenderMode::Streaming`]. Caches the parsed PDF document
+///   at construction and renders each strip on demand via pdfium's
+///   matrix render path, keeping source-side peak memory bounded by
+///   the strip in flight.
 ///
 /// Both modes honour the same [`StripSource`] contract: `render_strip(y, h)`
 /// returns a raster of width [`width()`](StripSource::width) and height
@@ -257,12 +291,15 @@ pub struct PdfiumStripSource {
 #[cfg(feature = "pdfium")]
 impl std::fmt::Debug for PdfiumStripSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Mode-specific state (cached raster bytes / cached pdfium handle)
+        // is intentionally elided — the four diagnostic fields above are
+        // the contract; everything else is implementation detail.
         f.debug_struct("PdfiumStripSource")
             .field("width", &self.width)
             .field("height", &self.height)
             .field("dpi", &self.dpi)
             .field("mode", &self.mode())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -344,34 +381,49 @@ impl PdfiumStripSource {
     /// Open a PDF page as a [`PdfiumRenderMode::Streaming`] strip source.
     ///
     /// Each [`render_strip`](StripSource::render_strip) call dispatches
-    /// directly to pdfium's matrix render path; no full-page raster is
-    /// held by the source. Construction probes dimensions and the page's
-    /// intrinsic `/Rotate` once.
+    /// directly to pdfium's matrix render path; the source caches the
+    /// parsed `PdfDocument` once at construction and reuses it for
+    /// every render, so no per-strip PDF parsing is paid.
     ///
     /// # Arguments
     ///
     /// * `path` — Path to the PDF file.
     /// * `page` — 1-based page number.
     /// * `dpi` — Render resolution in dots per inch.
+    ///
+    /// # Performance
+    ///
+    /// Streaming mode trades source-side memory for per-strip render
+    /// work. For an N-strip render of a vector-heavy PDF, expect
+    /// streaming wall time to scale ~linearly with N — pdfium's
+    /// `FPDF_RenderPageBitmapWithMatrix` walks the page content stream
+    /// once per call, regardless of clip rectangle. For raster-heavy
+    /// PDFs (embedded JPEG/JPEG2000) the per-strip cost is essentially
+    /// just the region extract; the streaming/cached ratio approaches
+    /// 1×. See `libviprs-bench/src/pdfium_strip_source_bench.rs` for
+    /// data on representative fixtures.
+    ///
+    /// Pick streaming when the full-page raster would exceed your
+    /// memory budget (large-format blueprints, scanned posters); pick
+    /// [`new`](Self::new) when the page comfortably fits.
+    ///
+    /// # Concurrency
+    ///
+    /// pdfium itself is not thread-safe. libviprs serialises every
+    /// FPDF call through a process-wide [`crate::pdf::pdfium_lock`],
+    /// so concurrent `render_strip` calls from multiple threads (e.g.
+    /// under `EngineKind::MapReduce`) are correct but produce no
+    /// parallelism. This is a property of the underlying C library;
+    /// no parallelism is "lost" relative to a hypothetical safer
+    /// pdfium-render version.
     pub fn new_streaming(
         path: impl Into<std::path::PathBuf>,
         page: usize,
         dpi: u32,
     ) -> Result<Self, crate::pdf::PdfError> {
         let path = path.into();
-        let pdfium = crate::pdf::init_pdfium()?;
-        let (width, height, _, _) = probe_page_dims(pdfium, &path, page, dpi)?;
         let rotation = crate::pdf::page_rotate(&path, page)?;
-        Ok(Self {
-            width,
-            height,
-            dpi,
-            state: PdfiumSourceState::Streaming {
-                path,
-                page,
-                rotation,
-            },
-        })
+        load_streaming_source(path, page, dpi, rotation)
     }
 
     /// Open a [`PdfiumRenderMode::Streaming`] source with a worst-case
@@ -394,32 +446,23 @@ impl PdfiumStripSource {
             budget_bytes,
             policy,
         )?;
-        let pdfium = crate::pdf::init_pdfium()?;
-        let (width, height, _, _) = probe_page_dims(pdfium, &path, page, resolved_dpi)?;
         let rotation = crate::pdf::page_rotate(&path, page)?;
-        Ok(Self {
-            width,
-            height,
-            dpi: resolved_dpi,
-            state: PdfiumSourceState::Streaming {
-                path,
-                page,
-                rotation,
-            },
-        })
+        load_streaming_source(path, page, resolved_dpi, rotation)
     }
 
     /// The DPI this source actually renders at. May differ from a constructor
     /// `dpi_hint` after [`BudgetPolicy::AutoAdjustDpi`] reduction.
+    #[must_use]
     pub fn dpi(&self) -> u32 {
         self.dpi
     }
 
     /// The render mode this source was constructed in.
+    #[must_use]
     pub fn mode(&self) -> PdfiumRenderMode {
         match self.state {
             PdfiumSourceState::CachedFullPage { .. } => PdfiumRenderMode::CachedFullPage,
-            PdfiumSourceState::Streaming { .. } => PdfiumRenderMode::Streaming,
+            PdfiumSourceState::Streaming(_) => PdfiumRenderMode::Streaming,
         }
     }
 
@@ -440,19 +483,92 @@ impl PdfiumStripSource {
                     .extract(0, y_offset, self.width, strip_h)
                     .map_err(crate::pdf::PdfError::from)
             }
-            PdfiumSourceState::Streaming {
-                path,
-                page,
-                rotation,
-            } => crate::pdf::render_page_strip_pdfium(
-                path, *page, self.dpi, *rotation, y_offset, height,
-            ),
+            PdfiumSourceState::Streaming(streaming) => {
+                // Hold the global pdfium lock for the entire matrix render:
+                // page handle access, bitmap allocation, FPDF_RenderPage call,
+                // and bitmap → image → Raster conversion all touch FPDF state
+                // and must serialize against any other thread also rendering.
+                let _lock = crate::pdf::pdfium_lock();
+                let document = streaming
+                    .document
+                    .as_ref()
+                    .expect("StreamingState::document is None only during Drop");
+                let pdf_page = document
+                    .pages()
+                    .get(streaming.page_index)
+                    .map_err(|e| crate::pdf::PdfError::Pdfium(e.to_string()))?;
+                crate::pdf::render_page_strip_with_page(
+                    &pdf_page,
+                    self.dpi,
+                    streaming.rotation,
+                    y_offset,
+                    height,
+                )
+            }
         }
     }
 }
 
+/// One-shot load of the pdfium document for streaming mode: parses the
+/// PDF once via pdfium, validates the requested page, extracts the
+/// display-oriented dimensions inline, and packages everything into a
+/// [`PdfiumStripSource`] ready for repeated `render_strip` calls. The
+/// document handle is cached in `StreamingState` so subsequent renders
+/// pay no parse cost.
+///
+/// Acquires [`crate::pdf::pdfium_lock`] internally for the duration
+/// of the FPDF calls. Caller must not be holding the lock.
+#[cfg(feature = "pdfium")]
+fn load_streaming_source(
+    path: std::path::PathBuf,
+    page: usize,
+    dpi: u32,
+    rotation: crate::pdf::PageRotation,
+) -> Result<PdfiumStripSource, crate::pdf::PdfError> {
+    let pdfium = crate::pdf::init_pdfium()?;
+    let _lock = crate::pdf::pdfium_lock();
+    let document = pdfium
+        .load_pdf_from_file(&path, None)
+        .map_err(|e| crate::pdf::PdfError::Pdfium(e.to_string()))?;
+    let total = document.pages().len();
+    if page == 0 || page > total as usize {
+        return Err(crate::pdf::PdfError::PageOutOfRange {
+            page,
+            total: total as usize,
+        });
+    }
+    let pdf_page = document
+        .pages()
+        .get(page as u16 - 1)
+        .map_err(|e| crate::pdf::PdfError::Pdfium(e.to_string()))?;
+
+    // Match `render_page_pdfium`'s width/height truncation byte-for-byte
+    // (pdf.rs:728-729 and the comment at pdf.rs:376-379) so cached and
+    // streaming sources report identical dimensions.
+    let scale = dpi as f32 / 72.0;
+    let width = (pdf_page.width().value * scale) as u32;
+    let height = (pdf_page.height().value * scale) as u32;
+    drop(pdf_page);
+
+    Ok(PdfiumStripSource {
+        width,
+        height,
+        dpi,
+        state: PdfiumSourceState::Streaming(StreamingState {
+            document: Some(document),
+            page_index: (page as u16).saturating_sub(1),
+            rotation,
+        }),
+    })
+}
+
 /// Shared budget-policy resolution used by both the cached and streaming
 /// `*_with_budget` constructors.
+///
+/// Acquires [`crate::pdf::pdfium_lock`] internally so the inner calls
+/// to [`probe_page_dims`] / [`resolve_dpi_under_budget`] (which assume
+/// the lock is held) can run safely. Callers do not need to acquire
+/// the lock first.
 #[cfg(feature = "pdfium")]
 fn resolve_budget_dpi(
     path: &std::path::Path,
@@ -463,6 +579,7 @@ fn resolve_budget_dpi(
     policy: BudgetPolicy,
 ) -> Result<u32, crate::pdf::PdfError> {
     let pdfium = crate::pdf::init_pdfium()?;
+    let _lock = crate::pdf::pdfium_lock();
     match policy {
         BudgetPolicy::Error => {
             let (width, _, _, _) = probe_page_dims(pdfium, path, page, dpi_hint)?;
@@ -488,6 +605,11 @@ fn resolve_budget_dpi(
     }
 }
 
+/// Probe a PDF page's dimensions without rendering.
+///
+/// **Caller must hold [`crate::pdf::pdfium_lock`]** — this function
+/// issues FPDF calls (load + page get + dim getter) that require
+/// process-wide pdfium serialization.
 #[cfg(feature = "pdfium")]
 fn probe_page_dims(
     pdfium: &pdfium_render::prelude::Pdfium,
@@ -521,6 +643,12 @@ fn probe_page_dims(
     Ok((width, height, w_pts, h_pts))
 }
 
+/// Find the largest DPI ≤ `dpi_hint` whose worst-case minimum-aligned
+/// strip fits within `budget_bytes`, or error if even `min_dpi` would
+/// not fit.
+///
+/// **Caller must hold [`crate::pdf::pdfium_lock`]** — this function
+/// calls [`probe_page_dims`] internally, which is not standalone-locked.
 #[cfg(feature = "pdfium")]
 fn resolve_dpi_under_budget(
     pdfium: &pdfium_render::prelude::Pdfium,


### PR DESCRIPTION
## Summary

Closes #70.

Adds `PdfiumRenderMode::Streaming` with the matching `PdfiumStripSource::new_streaming` / `new_streaming_with_budget` constructors and the underlying `pdf::render_page_strip_pdfium` that routes each strip directly through pdfium's matrix render path (`FPDF_RenderPageBitmapWithMatrix`). The struct grows an internal state enum so the existing `new` / `new_with_budget` constructors keep their `CachedFullPage` semantics unchanged — zero churn for callers.

The matrix is composed by hand per `/Rotate` value rather than going through pdfium-render's `apply_to_page` auto-rotation chain, which was the indirect cause of the prior 180-degree failure mode for `/Rotate 90/270`. The four matrices map pre-rotation page coordinates (y-up, points) directly into bitmap pixel coordinates (y-down, pixels), with the strip y-translation in `f`. See the doc-comment table on `render_page_strip_pdfium` for the per-rotation derivation.

Also exposes `pdf::page_rotate`, a path-based wrapper over the existing private `resolve_rotate` that the streaming constructors use to honour intrinsic `/Rotate ∈ {0, 90, 180, 270}`.

Closes the input-side memory gap: streaming sources hold only path / page / rotation between calls; peak source-side memory is bounded by the strip in flight (`O(strip_h × width × 4)`) instead of the full display-oriented page raster.

## Public surface

- `pub enum streaming::PdfiumRenderMode { CachedFullPage, Streaming }` — re-exported from crate root.
- `PdfiumStripSource::new_streaming(path, page, dpi)`
- `PdfiumStripSource::new_streaming_with_budget(path, page, dpi_hint, min_strip_height, budget_bytes, policy)`
- `PdfiumStripSource::mode() -> PdfiumRenderMode`
- `pub fn pdf::page_rotate(path, page) -> Result<i64, PdfError>`

Existing `new` / `new_with_budget` constructors and their behaviour are untouched.

## Test plan

Companion test PR: libviprs-tests#TBD (35 new tests).

- [x] `cargo fmt --check` (pre-commit hook)
- [x] `cargo clippy` (pre-commit hook)
- [x] `cargo test --features pdfium --lib` — 229 tests pass on the lib side
- [x] All existing pdfium integration tests still green (`streaming_pdfium_matrix.rs`, `pdfium_pyramid_engine_parity.rs`, `pdf_ops`, `pdf_to_pyramid`, `pdfium_integration`, `pdf_cmyk`)
- [x] New 35-test suite on libviprs-tests passes for `/Rotate ∈ {0, 90, 180, 270}` × strip-position × DPI cross-product, including the synthetic-rotation tempfile fixtures that close the `/Rotate 90` and `/Rotate 180` coverage gap
- [x] Pre-push hook full test suite green (arm64)