### PR TITLE
Gate releases on pdfium-render fork source audit (#149)

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -27,3 +27,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: RUSTFLAGS="--cfg loom" cargo test --lib loom_tests
+
+  pdfium-source:
+    name: pdfium-render source audit (#149)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Fail the release gate if the pdfium-render thread-safety fork is not
+      # resolved from the libviprs git source (i.e. the [patch.crates-io] was
+      # dropped and the unpatched, segfault-prone wrapper would be linked).
+      - run: bash scripts/audit-pdfium-source.sh . -- --features pdfium

--- a/scripts/audit-pdfium-source.sh
+++ b/scripts/audit-pdfium-source.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# audit-pdfium-source.sh — release gate for issue #149.
+#
+# The `pdfium-render` thread-safety fork (per-call locking in
+# `ThreadSafePdfiumBindings`) is applied via `[patch.crates-io]` in this
+# crate's `Cargo.toml`. A `[patch]` table only takes effect from the root
+# of the workspace performing the build, so any sibling crate or crates.io
+# consumer that does NOT replicate the patch silently links the unpatched
+# `pdfium-render 0.8.x` wrapper, which segfaults under concurrent access.
+#
+# This script resolves the dependency graph for a given manifest and fails
+# if `pdfium-render` is sourced from the crates.io registry instead of the
+# pinned libviprs git fork. Run it in every repo that enables the `pdfium`
+# feature before publishing / releasing.
+#
+# Usage:
+#   scripts/audit-pdfium-source.sh [MANIFEST_DIR] [-- <extra cargo metadata args>]
+#
+# MANIFEST_DIR defaults to the current directory. Exit status:
+#   0  pdfium-render resolves from the libviprs git fork (or is absent).
+#   1  pdfium-render resolves from the crates.io registry (unpatched).
+#   2  usage / tooling error.
+
+set -euo pipefail
+
+EXPECTED_HOST="github.com/libviprs/pdfium-render"
+
+manifest_dir="."
+extra_args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --) shift; extra_args=("$@"); break ;;
+    -h|--help)
+      sed -n '2,26p' "$0"; exit 0 ;;
+    *) manifest_dir="$1"; shift ;;
+  esac
+done
+
+manifest_path="${manifest_dir%/}/Cargo.toml"
+if [[ ! -f "$manifest_path" ]]; then
+  echo "audit-pdfium-source: no Cargo.toml at '$manifest_path'" >&2
+  exit 2
+fi
+
+metadata="$(cargo metadata --format-version 1 --manifest-path "$manifest_path" \
+  "${extra_args[@]}" 2>/dev/null)" || {
+  echo "audit-pdfium-source: 'cargo metadata' failed for '$manifest_path'" >&2
+  exit 2
+}
+
+# Extract the resolved `source` field for the `pdfium-render` package.
+source_field="$(printf '%s' "$metadata" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+hits = [p.get("source") or "" for p in data["packages"] if p["name"] == "pdfium-render"]
+print("ABSENT" if not hits else hits[0])
+')"
+
+case "$source_field" in
+  ABSENT)
+    echo "audit-pdfium-source: OK — pdfium-render is not in the graph for '$manifest_path'"
+    exit 0 ;;
+  git+*"$EXPECTED_HOST"*)
+    echo "audit-pdfium-source: OK — pdfium-render resolves from the libviprs fork:"
+    echo "  $source_field"
+    exit 0 ;;
+  *)
+    echo "audit-pdfium-source: FAIL — pdfium-render does NOT resolve from the libviprs fork (issue #149)." >&2
+    echo "  resolved source: ${source_field:-<empty/registry>}" >&2
+    echo "  expected a git source containing: $EXPECTED_HOST" >&2
+    echo "  add the [patch.crates-io] pdfium-render fork to this manifest's workspace root." >&2
+    exit 1 ;;
+esac

--- a/tests/pdfium_source_audit.rs
+++ b/tests/pdfium_source_audit.rs
@@ -1,0 +1,96 @@
+//! Regression coverage for issue #149.
+//!
+//! The `pdfium-render` per-call thread-safety fork is applied through this
+//! crate's `[patch.crates-io]` table. A `[patch]` only takes effect from the
+//! build root, so any consumer that omits it silently links the unpatched
+//! `pdfium-render 0.8.x` wrapper (documented to segfault under concurrent
+//! access in `src/streaming.rs`). These tests exercise the release gate that
+//! detects that condition, `scripts/audit-pdfium-source.sh`:
+//!
+//!   1. `audit_gate_accepts_patched_core` — this crate carries the fork, so
+//!      the gate must pass. Guards against the patch being dropped/renamed.
+//!   2. `audit_gate_rejects_unpatched_consumer` — a synthesized sibling that
+//!      depends on `pdfium-render` without the patch resolves the crates.io
+//!      registry crate; the gate must reject it (this is the #149 defect).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn audit_script() -> PathBuf {
+    repo_root().join("scripts").join("audit-pdfium-source.sh")
+}
+
+fn run_audit(manifest_dir: &std::path::Path, extra: &[&str]) -> std::process::Output {
+    let script = audit_script();
+    assert!(
+        script.exists(),
+        "release gate missing: {} (issue #149)",
+        script.display()
+    );
+    let mut cmd = Command::new("bash");
+    cmd.arg(&script).arg(manifest_dir);
+    if !extra.is_empty() {
+        cmd.arg("--");
+        cmd.args(extra);
+    }
+    cmd.output().expect("failed to spawn audit script")
+}
+
+#[test]
+fn audit_gate_accepts_patched_core() {
+    let out = run_audit(&repo_root(), &["--features", "pdfium"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "audit gate rejected the patched core crate.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("github.com/libviprs/pdfium-render"),
+        "audit gate did not confirm the libviprs fork source.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn audit_gate_rejects_unpatched_consumer() {
+    // A minimal consumer that depends on pdfium-render the way the sibling
+    // crates do today: a plain registry dependency with no [patch] fork.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\n\
+         name = \"vip149-unpatched-consumer\"\n\
+         version = \"0.0.0\"\n\
+         edition = \"2021\"\n\
+         \n\
+         [dependencies]\n\
+         pdfium-render = { version = \"0.8\", features = [\"sync\"] }\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("src").join("lib.rs"), "").unwrap();
+
+    let out = run_audit(dir.path(), &[]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // Tooling error (exit 2) means we couldn't resolve the graph (e.g. no
+    // network in a sandbox); don't turn that into a false failure.
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: could not resolve consumer graph\nstderr: {stderr}");
+        return;
+    }
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "audit gate should reject an unpatched consumer (issue #149).\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("does NOT resolve from the libviprs fork"),
+        "audit gate rejected for the wrong reason.\nstderr: {stderr}"
+    );
+}


### PR DESCRIPTION
Part of #149

## Plan
`pdfium-render`'s per-call thread-safety fork is applied via `[patch.crates-io]`
in this crate's `Cargo.toml`. A `[patch]` only takes effect from the build root,
so the core crate resolves the fork correctly but every sibling (`libviprs-cli`,
`libviprs-tests`, `libviprs-bench`) and every crates.io consumer silently links
the unpatched, segfault-prone wrapper.

Full remediation spans multiple repositories and cannot land in a single PR to
this repo:
- **AC #1 (all sibling lockfiles resolve the fork):** requires editing the three
  sibling repos' manifests to replicate `[patch.crates-io]`, and — for published
  crates.io consumers, which cannot carry `[patch]` at all — upstreaming the fork.
  Out of scope for a PR to `libviprs/libviprs`.
- **AC #2 (a CI check asserts the correct source before release):** delivered here.

## What this PR adds
- `scripts/audit-pdfium-source.sh` — resolves a manifest's dependency graph and
  fails if `pdfium-render` is sourced from the crates.io registry instead of the
  pinned libviprs git fork. Reusable by every repo that enables the `pdfium`
  feature.
- `.github/workflows/merge-gate.yml` — runs the audit on the release gate, so a
  dropped/renamed patch is caught before publish.
- `tests/pdfium_source_audit.rs` — test-first coverage: proves the gate accepts
  the patched core crate and rejects a synthesized unpatched consumer (the #149
  defect).

## Follow-ups to fully close #149
1. Add `[patch.crates-io] pdfium-render = <fork>` + wire this audit into
   `libviprs-cli`, `libviprs-tests`, `libviprs-bench`.
2. Upstream the per-call locking to `pdfium-render` and depend on the released
   version so crates.io consumers are safe without a patch.

