### PR TITLE
Fix centred non-square canvas allocation (square make_background_tile)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1050,7 +1050,7 @@ fn embed_in_canvas(
     let cw = plan.canvas_width;
     let ch = plan.canvas_height;
     let bpp = source.format().bytes_per_pixel();
-    let mut canvas = make_background_tile(cw, bpp, background_rgb);
+    let mut canvas = make_background_tile(cw, ch, bpp, background_rgb);
 
     let ox = plan.centre_offset_x as usize;
     let oy = plan.centre_offset_y as usize;
@@ -1358,17 +1358,16 @@ fn extract_and_emit_parallel(
     })
 }
 
-/// Allocates a `tile_size × tile_size` pixel buffer filled with the
-/// background color.
+/// Allocates a `width × height` pixel buffer filled with the background
+/// color.
 ///
-/// Used to pad edge tiles and to produce solid-background tiles for
-/// canvas regions that lie outside the source image (e.g. Google layout
-/// with centre). The background RGB triplet is expanded to match the
-/// pixel format's bytes-per-pixel: grayscale uses the red channel,
-/// RGB copies all three, RGBA appends alpha=255, and other formats
-/// repeat the red channel.
-fn make_background_tile(ts: u32, bpp: usize, background_rgb: [u8; 3]) -> Vec<u8> {
-    let mut padded = vec![0u8; ts as usize * ts as usize * bpp];
+/// Used to pad edge tiles (square, `tile_size × tile_size`) and to build
+/// the full-resolution centre canvas (which may be non-square). The
+/// background RGB triplet is expanded to match the pixel format's
+/// bytes-per-pixel: grayscale uses the red channel, RGB copies all three,
+/// RGBA appends alpha=255, and other formats repeat the red channel.
+fn make_background_tile(width: u32, height: u32, bpp: usize, background_rgb: [u8; 3]) -> Vec<u8> {
+    let mut padded = vec![0u8; width as usize * height as usize * bpp];
     let bg_pixel: Vec<u8> = match bpp {
         1 => vec![background_rgb[0]],
         3 => background_rgb.to_vec(),
@@ -1427,7 +1426,7 @@ fn extract_tile(
 
         if rect.x >= rw || rect.y >= rh {
             // Tile entirely outside raster — solid background
-            let padded = make_background_tile(ts, bpp, background_rgb);
+            let padded = make_background_tile(ts, ts, bpp, background_rgb);
             return Raster::new(ts, ts, raster.format(), padded);
         }
 
@@ -1441,7 +1440,7 @@ fn extract_tile(
 
         // Partial: extract overlap and pad
         let content = raster.extract(rect.x, rect.y, inter_w, inter_h)?;
-        let mut padded = make_background_tile(ts, bpp, background_rgb);
+        let mut padded = make_background_tile(ts, ts, bpp, background_rgb);
         let src_stride = inter_w as usize * bpp;
         let dst_stride = ts as usize * bpp;
         for row in 0..inter_h as usize {
@@ -1460,7 +1459,7 @@ fn extract_tile(
     // Only pad when there's no overlap — overlap tiles have intentionally
     // different sizes and must not be resized.
     if plan.overlap == 0 && (content.width() < ts || content.height() < ts) {
-        let mut padded = make_background_tile(ts, bpp, background_rgb);
+        let mut padded = make_background_tile(ts, ts, bpp, background_rgb);
 
         // Copy content rows into the padded buffer
         let src_stride = content.width() as usize * bpp;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2268,4 +2268,55 @@ mod tests {
             "expected PlanHashMismatch on tile-format change, got {err:?}"
         );
     }
+
+    /**
+     * Tests that a centred non-square canvas embeds and renders successfully.
+     * `embed_in_canvas` must allocate a `canvas_width × canvas_height` buffer;
+     * a square allocation makes `Raster::new` reject any non-square canvas with
+     * `BufferSizeMismatch`. Works by building a centred DeepZoom plan whose
+     * canvas is 1024x256, embedding the source directly, and running the full
+     * pyramid to the sink.
+     * Input: 1000x200 image, tile_size=256, centre=true -> canvas 1024x256.
+     */
+    #[test]
+    fn centred_non_square_canvas_renders() {
+        let src = gradient_raster(1000, 200);
+        let plan = PyramidPlanner::new(1000, 200, 256, 0, Layout::DeepZoom)
+            .unwrap()
+            .with_centre(true)
+            .plan();
+
+        // Sanity: the plan really is a non-square centred canvas that offsets
+        // the image on both axes (so embed_in_canvas is exercised).
+        assert_ne!(
+            plan.canvas_width, plan.canvas_height,
+            "expected a non-square canvas"
+        );
+        assert!(plan.centre_offset_x > 0 && plan.centre_offset_y > 0);
+
+        // Direct embed must succeed and produce a canvas-sized raster.
+        let canvas =
+            embed_in_canvas(&src, &plan, EngineConfig::default().background_rgb).unwrap();
+        assert_eq!(canvas.width(), plan.canvas_width);
+        assert_eq!(canvas.height(), plan.canvas_height);
+
+        // The source pixels must survive at the centre offset, and the
+        // background must fill the padding above the image.
+        let bpp = src.format().bytes_per_pixel();
+        let ox = plan.centre_offset_x as usize;
+        let oy = plan.centre_offset_y as usize;
+        let dst_stride = plan.canvas_width as usize * bpp;
+        let embedded = &canvas.data()[oy * dst_stride + ox * bpp
+            ..oy * dst_stride + ox * bpp + bpp];
+        let src_first = &src.data()[..bpp];
+        assert_eq!(embedded, src_first, "source pixel lost at centre offset");
+
+        // End-to-end: the whole pyramid renders without error.
+        let sink = MemorySink::new();
+        let config = EngineConfig::default();
+        let result =
+            generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
+        assert_eq!(result.tiles_produced, plan.total_tile_count());
+        assert_eq!(sink.tile_count() as u64, plan.total_tile_count());
+    }
 }


### PR DESCRIPTION
Closes #131

## Problem
`embed_in_canvas` built the full-resolution centre canvas via `make_background_tile(cw, ...)`, but that helper squared its single size argument (`cw x cw x bpp`). `Raster::new(cw, ch, ...)` then rejected every non-square canvas with `BufferSizeMismatch` (after transiently over-allocating up to 4x the needed memory).

## Plan
- Give `make_background_tile` explicit `width` and `height` parameters and allocate `width x height x bpp`.
- Canvas caller passes `(cw, ch)`; the three square tile-padding callers pass `(ts, ts)` unchanged.
- Test-first: a failing test that builds a centred non-square DeepZoom plan (1000x200 -> canvas 1024x256), embeds directly, and renders the full pyramid.

## Acceptance criteria
- [x] Centred non-square canvases render successfully.
- [x] Test covers a non-square centred DeepZoom plan.