### PR TITLE
Wire RetryingSink into engine write path so retry policies take effect

### DIFF
--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -859,3 +859,132 @@ mod resume {
     #[allow(dead_code)]
     fn _unused_marker(_: AtomicU64) {}
 }
+
+// ---------------------------------------------------------------------------
+// Retry-wiring tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod retry_wiring_tests {
+    use super::*;
+    use crate::pixel::PixelFormat;
+    use crate::planner::{Layout, PyramidPlanner};
+    use crate::raster::Raster;
+    use crate::sink::{MemorySink, SinkError, Tile};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A sink that fails its first `fails` `write_tile` calls with a transient
+    /// error, then forwards every subsequent call to an inner [`MemorySink`].
+    /// Models an object store that intermittently rejects writes.
+    struct FlakySink {
+        inner: MemorySink,
+        fails_left: AtomicU32,
+    }
+
+    impl FlakySink {
+        fn new(fails: u32) -> Self {
+            Self {
+                inner: MemorySink::new(),
+                fails_left: AtomicU32::new(fails),
+            }
+        }
+
+        fn written(&self) -> usize {
+            self.inner.tile_count()
+        }
+    }
+
+    impl TileSink for FlakySink {
+        fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+            loop {
+                let cur = self.fails_left.load(Ordering::SeqCst);
+                if cur == 0 {
+                    break;
+                }
+                if self
+                    .fails_left
+                    .compare_exchange(cur, cur - 1, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+                {
+                    return Err(SinkError::Other("transient".into()));
+                }
+            }
+            self.inner.write_tile(tile)
+        }
+    }
+
+    fn small_source() -> Raster {
+        // 4x4 RGB solid so every tile is non-blank and actually written.
+        let data = vec![10u8; 4 * 4 * 3];
+        Raster::new(4, 4, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    fn small_plan() -> PyramidPlan {
+        PyramidPlanner::new(4, 4, 2, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan()
+    }
+
+    fn fast_policy(max_retries: u32) -> RetryPolicy {
+        RetryPolicy::new(max_retries, std::time::Duration::from_micros(1))
+            .with_multiplier(1.0)
+            .with_max_backoff(std::time::Duration::from_micros(10))
+            .with_jitter(false)
+    }
+
+    // A transient write failure under `RetryThenFail` must be retried through
+    // the builder, not propagated on the first error. Fails on unwired code
+    // (the whole run errors out); passes once the RetryingSink is engaged.
+    #[test]
+    fn builder_retry_then_fail_recovers_transient_failures() {
+        let source = small_source();
+        let plan = small_plan();
+        let sink = FlakySink::new(2);
+
+        let (result, sink) = EngineBuilder::new(&source, plan, sink)
+            .with_retry(fast_policy(5))
+            .run_collect()
+            .expect("transient failures must be retried, not propagated");
+
+        assert!(
+            result.retry_count >= 2,
+            "expected the configured retry policy to drive at least 2 retries, got {}",
+            result.retry_count
+        );
+        assert_eq!(
+            result.skipped_due_to_failure, 0,
+            "RetryThenFail must not skip any tile"
+        );
+        assert!(sink.written() > 0, "every tile must ultimately be written");
+    }
+
+    // Under `RetryThenSkip`, a tile must only be skipped after its retries are
+    // exhausted. With enough retry budget the transient failures are absorbed
+    // and nothing is skipped. Fails on unwired code (tiles dropped on the
+    // first error, skip counter non-zero, retry_count zero).
+    #[test]
+    fn builder_retry_then_skip_only_skips_after_exhaustion() {
+        let source = small_source();
+        let plan = small_plan();
+        let sink = FlakySink::new(2);
+
+        let (result, sink) = EngineBuilder::new(&source, plan, sink)
+            .with_failure_policy(FailurePolicy::RetryThenSkip(fast_policy(5)))
+            .run_collect()
+            .expect("run should succeed");
+
+        assert!(
+            result.retry_count >= 2,
+            "expected retries to be driven before skipping, got {}",
+            result.retry_count
+        );
+        assert_eq!(
+            result.skipped_due_to_failure, 0,
+            "no tile should be skipped while retry budget remains"
+        );
+        assert!(
+            sink.written() > 0,
+            "tiles recovered by retry must land in the sink"
+        );
+    }
+}

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -33,7 +33,7 @@ use crate::observe::{EngineObserver, NoopObserver};
 use crate::planner::PyramidPlan;
 use crate::raster::Raster;
 use crate::resume::{ResumeMode, ResumePolicy};
-use crate::retry::{FailurePolicy, RetryPolicy};
+use crate::retry::{FailurePolicy, RetryPolicy, RetryingSink};
 use crate::sink::TileSink;
 use crate::streaming::{
     BudgetPolicy, RasterStripSource, StreamingConfig, StripSource, generate_pyramid_streaming,
@@ -421,6 +421,37 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             None => &NoopObserver,
         };
 
+        // #119: route writes through `RetryingSink` when the configured
+        // failure policy carries a `RetryPolicy`. Previously the engine only
+        // inspected the `FailurePolicy` *variant* and never read the embedded
+        // policy, so `EngineBuilder::with_retry` / `--on-failure retry=N,D`
+        // performed zero retries. Wrapping here engages the retry loop inside
+        // `write_tile` for every engine kind (monolithic / streaming /
+        // map-reduce) on both the plain and resume paths; the engine then
+        // sees only the terminal outcome, so its existing `RetryThenSkip`
+        // accounting kicks in only after retries are exhausted.
+        //
+        // The wrapper borrows the sink, so the original `sink` is still
+        // returned to the caller (for `run_collect` inspection) and continues
+        // to record every tile that lands.
+        //
+        // A sink the caller already wrapped in `RetryingSink` reports
+        // `applies_retry_policy() == true`; we skip re-wrapping it so retries
+        // and skip-accounting are not double-counted.
+        let retrying: Option<RetryingSink<&S>> = match &engine_cfg.failure_policy {
+            FailurePolicy::RetryThenFail(p) | FailurePolicy::RetryThenSkip(p)
+                if !sink.applies_retry_policy() =>
+            {
+                Some(RetryingSink::new(&sink, p.clone()))
+            }
+            _ => None,
+        };
+        // The concrete sink the engine drives its writes through.
+        let engine_sink: &dyn TileSink = match &retrying {
+            Some(r) => r,
+            None => &sink,
+        };
+
         let kind = resolve_engine_kind(engine_kind, &source);
 
         // Unified resume path: every engine kind now flows through the
@@ -496,7 +527,10 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 
             // Overwrite / Resume: shared (skip, cp) setup + ResumeAwareSink.
             let (skip, cp) = prepare_resume_state(&sink, &plan, &engine_cfg, policy.mode())?;
-            let wrapped = resume::ResumeAwareSink::new(&sink, &skip, cp.as_ref());
+            // Route resume writes through the retry wrapper (when configured)
+            // so a transient failure is retried before the resume checkpoint
+            // records the tile as complete.
+            let wrapped = resume::ResumeAwareSink::new(engine_sink, &skip, cp.as_ref());
 
             let mut result = match (kind, source) {
                 (EngineKind::Monolithic, EngineSource::Raster(raster)) => {
@@ -561,7 +595,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 
         let result = match (kind, source) {
             (EngineKind::Monolithic, EngineSource::Raster(raster)) => {
-                generate_pyramid_observed(raster, &plan, &sink, &engine_cfg, observer_ref)?
+                generate_pyramid_observed(raster, &plan, engine_sink, &engine_cfg, observer_ref)?
             }
             (EngineKind::Monolithic, EngineSource::Strip(_)) => {
                 return Err(EngineError::IncompatibleSource {
@@ -572,11 +606,11 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             (EngineKind::Streaming, EngineSource::Raster(raster)) => {
                 let source = RasterStripSource::new(raster);
                 let cfg = build_streaming_config(engine_cfg, memory_budget_bytes, budget_policy);
-                generate_pyramid_streaming(&source, &plan, &sink, &cfg, observer_ref)?
+                generate_pyramid_streaming(&source, &plan, engine_sink, &cfg, observer_ref)?
             }
             (EngineKind::Streaming, EngineSource::Strip(source)) => {
                 let cfg = build_streaming_config(engine_cfg, memory_budget_bytes, budget_policy);
-                generate_pyramid_streaming(source.as_ref(), &plan, &sink, &cfg, observer_ref)?
+                generate_pyramid_streaming(source.as_ref(), &plan, engine_sink, &cfg, observer_ref)?
             }
             (EngineKind::MapReduce, EngineSource::Raster(raster)) => {
                 let source = RasterStripSource::new(raster);
@@ -587,7 +621,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                     background_rgb,
                     blank_strategy,
                 );
-                generate_pyramid_mapreduce(&source, &plan, &sink, &cfg, observer_ref)?
+                generate_pyramid_mapreduce(&source, &plan, engine_sink, &cfg, observer_ref)?
             }
             (EngineKind::MapReduce, EngineSource::Strip(source)) => {
                 let cfg = build_mapreduce_config(
@@ -597,7 +631,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                     background_rgb,
                     blank_strategy,
                 );
-                generate_pyramid_mapreduce(source.as_ref(), &plan, &sink, &cfg, observer_ref)?
+                generate_pyramid_mapreduce(source.as_ref(), &plan, engine_sink, &cfg, observer_ref)?
             }
             (EngineKind::Auto, _) => {
                 // `resolve_engine_kind` already flattened Auto to a concrete
@@ -851,6 +885,10 @@ mod resume {
 
         fn init_level_count(&self, levels: usize) {
             self.inner.init_level_count(levels)
+        }
+
+        fn applies_retry_policy(&self) -> bool {
+            self.inner.applies_retry_policy()
         }
     }
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -392,6 +392,25 @@ impl<S: TileSink> TileSink for RetryingSink<S> {
     fn checkpoint_root(&self) -> Option<&std::path::Path> {
         self.inner.checkpoint_root()
     }
+
+    fn init_level_count(&self, levels: usize) {
+        // Transparent decorator: forward the pre-sizing hint so wrapped sinks
+        // (e.g. `FsSink`) still preallocate their per-level bookkeeping when
+        // the engine drives writes through this retry wrapper.
+        self.inner.init_level_count(levels);
+    }
+
+    fn content_format(&self) -> Option<crate::sink::TileFormat> {
+        // Forward so resume plan-hashing sees the wrapped sink's on-disk
+        // format even when a retry policy is configured.
+        self.inner.content_format()
+    }
+
+    fn applies_retry_policy(&self) -> bool {
+        // This decorator runs the retry loop itself, so a caller that
+        // pre-wrapped their sink must not be wrapped again by the builder.
+        true
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -182,6 +182,19 @@ pub trait TileSink: Send + Sync {
     fn content_format(&self) -> Option<TileFormat> {
         None
     }
+
+    /// Engine hook: whether this sink (or a wrapper around it) already runs
+    /// its own retry loop inside `write_tile`.
+    ///
+    /// [`crate::EngineBuilder`] consults this before automatically wrapping a
+    /// sink in [`crate::retry::RetryingSink`] for a configured retry policy,
+    /// so a caller that pre-wrapped their sink in `RetryingSink` is not
+    /// double-wrapped (which would inflate `retry_count` and double-count
+    /// `skipped_due_to_failure`). Default is `false`; `RetryingSink` overrides
+    /// to `true`, and transparent decorators forward the inner sink's answer.
+    fn applies_retry_policy(&self) -> bool {
+        false
+    }
 }
 
 /// Forwarding impl so `Box<dyn TileSink>` (and `Box<T>` where `T: TileSink`)
@@ -227,6 +240,9 @@ impl<T: TileSink + ?Sized> TileSink for Box<T> {
     fn content_format(&self) -> Option<TileFormat> {
         (**self).content_format()
     }
+    fn applies_retry_policy(&self) -> bool {
+        (**self).applies_retry_policy()
+    }
 }
 
 /// Forwarding impl so `&T` satisfies [`TileSink`] wherever `T` does.
@@ -268,6 +284,9 @@ impl<T: TileSink + ?Sized> TileSink for &T {
     }
     fn content_format(&self) -> Option<TileFormat> {
         (*self).content_format()
+    }
+    fn applies_retry_policy(&self) -> bool {
+        (*self).applies_retry_policy()
     }
 }
 


### PR DESCRIPTION
Closes #119

## Problem
`RetryingSink` is constructed only in tests/docs and is never wired into the engine write path. The engine consults only the *variant* of `FailurePolicy` (with a wildcard binding for the embedded `RetryPolicy`), so `RetryThenFail` degrades to `FailFast` and `RetryThenSkip` drops tiles on the first error. `EngineBuilder::with_retry` and the CLI `--on-failure retry=N,D` therefore perform zero retries.

## Plan
1. (done) Add builder-level tests that drive a transiently-failing sink through `EngineBuilder` and assert the configured retries run. These fail first.
2. In `EngineBuilder::run_collect`, when the resolved failure policy carries a `RetryPolicy` (`RetryThenFail` / `RetryThenSkip`), wrap the sink in `RetryingSink` before handing it to every engine kind (monolithic / streaming / map-reduce) on both the plain and resume paths. The retry loop then runs inside `write_tile`, so the engine only sees the terminal outcome and its existing `RetryThenSkip` accounting kicks in only after retries are exhausted.
3. Run core unit + doc tests and the integration suite; all green.

## Acceptance criteria
- [ ] Retry policies configured via `EngineBuilder`/CLI perform the configured retries.
- [ ] `RetryThenSkip` only skips after retries are exhausted.
- [ ] Integration test exercises transient-failure recovery via the builder.