### PR TITLE
Sanitize untrusted manifest-relative paths and stream reads in verifiers

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -88,6 +88,86 @@ pub fn hash_tile(bytes: &[u8], algo: ChecksumAlgo) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Untrusted-path sanitization + streaming hash
+// ---------------------------------------------------------------------------
+
+/// Join an attacker-controlled *relative* manifest path onto a trusted `root`,
+/// rejecting anything that could escape `root`.
+///
+/// Manifest `per_tile` keys are attacker-controlled: a hostile bundle can list
+/// `/etc/passwd`, a Windows drive prefix, or `../../secret`. `Path::join` with
+/// an absolute or prefixed component silently *replaces* the base, and `..`
+/// walks upward — both give arbitrary-file read (and a hash/existence oracle,
+/// since the digest is echoed back on mismatch).
+///
+/// This returns `Some(root.join(rel))` only when every component of `rel` is a
+/// plain name (or a redundant `.`); it returns `None` for an empty path or any
+/// path containing a root, a prefix (e.g. `C:`), or a `..` component. Because
+/// only `Normal`/`CurDir` components survive, the join can never escape `root`.
+pub(crate) fn safe_manifest_join(root: &Path, rel: &str) -> Option<PathBuf> {
+    use std::path::Component;
+
+    let rel_path = Path::new(rel);
+    if rel_path.as_os_str().is_empty() {
+        return None;
+    }
+    for comp in rel_path.components() {
+        match comp {
+            Component::Normal(_) | Component::CurDir => {}
+            Component::RootDir | Component::Prefix(_) | Component::ParentDir => return None,
+        }
+    }
+    Some(root.join(rel_path))
+}
+
+/// Hash the contents of the file at `path` by streaming it through the hasher
+/// in fixed-size chunks, capping peak memory regardless of file size.
+///
+/// This replaces `std::fs::read` + [`hash_tile`], which buffered the whole file
+/// and was an OOM primitive when pointed at a huge (or infinite, e.g.
+/// `/dev/zero`) file. Returns the same lowercase hex digest as [`hash_tile`]
+/// would for identical bytes.
+pub(crate) fn hash_file(path: &Path, algo: ChecksumAlgo) -> std::io::Result<String> {
+    use std::io::Read;
+
+    // 64 KiB is large enough to amortize syscall/read overhead while keeping
+    // the transient buffer trivially small.
+    let mut buf = [0u8; 64 * 1024];
+    let mut file = std::fs::File::open(path)?;
+
+    match algo {
+        ChecksumAlgo::Blake3 => {
+            let mut hasher = blake3::Hasher::new();
+            loop {
+                let n = file.read(&mut buf)?;
+                if n == 0 {
+                    break;
+                }
+                hasher.update(&buf[..n]);
+            }
+            Ok(hasher.finalize().to_hex().to_string())
+        }
+        ChecksumAlgo::Sha256 => {
+            let mut hasher = sha2::Sha256::new();
+            loop {
+                let n = file.read(&mut buf)?;
+                if n == 0 {
+                    break;
+                }
+                hasher.update(&buf[..n]);
+            }
+            let out = hasher.finalize();
+            let mut s = String::with_capacity(out.len() * 2);
+            for b in out.iter() {
+                use std::fmt::Write;
+                let _ = write!(s, "{:02x}", b);
+            }
+            Ok(s)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // VerifyReport / VerifyError
 // ---------------------------------------------------------------------------
 
@@ -141,6 +221,13 @@ pub enum VerifyError {
 
     #[error("unknown checksum algorithm in manifest: {0}")]
     UnknownAlgo(String),
+
+    /// A `per_tile` key was an absolute, prefixed, or `..`-containing path that
+    /// would escape the pyramid directory. Rejected before any filesystem
+    /// access so it cannot be used for path traversal or as a hash/existence
+    /// oracle.
+    #[error("manifest tile path escapes pyramid directory: {0}")]
+    UnsafePath(String),
 
     #[error("checksum mismatch")]
     Mismatch,
@@ -237,10 +324,16 @@ pub fn verify_output(dir: &Path) -> Result<VerifyReport, VerifyError> {
         };
 
         let rel_path = PathBuf::from(rel);
-        let abs = dir.join(&rel_path);
+        // Reject traversal / absolute / prefixed paths before touching the
+        // filesystem — a hostile manifest must not be able to read outside the
+        // pyramid directory or probe file existence via the report.
+        let abs = match safe_manifest_join(dir, rel) {
+            Some(p) => p,
+            None => return Err(VerifyError::UnsafePath(rel.clone())),
+        };
 
-        let bytes = match std::fs::read(&abs) {
-            Ok(b) => b,
+        let got = match hash_file(&abs, algo) {
+            Ok(g) => g,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 report.tiles_missing.push(rel_path);
                 continue;
@@ -253,7 +346,6 @@ pub fn verify_output(dir: &Path) -> Result<VerifyReport, VerifyError> {
             }
         };
 
-        let got = hash_tile(&bytes, algo);
         if got.eq_ignore_ascii_case(digest_hex) {
             report.tiles_ok += 1;
         } else {
@@ -312,6 +404,54 @@ mod tests {
     #[test]
     fn checksum_mode_default_is_none() {
         assert_eq!(ChecksumMode::default(), ChecksumMode::None);
+    }
+
+    #[test]
+    fn safe_manifest_join_rejects_escaping_paths() {
+        let root = Path::new("/tmp/pyramid");
+        // Absolute / rooted paths.
+        assert!(safe_manifest_join(root, "/etc/passwd").is_none());
+        // Parent-dir traversal, at any depth.
+        assert!(safe_manifest_join(root, "../secret").is_none());
+        assert!(safe_manifest_join(root, "0/../../secret").is_none());
+        assert!(safe_manifest_join(root, "a/b/../../../x").is_none());
+        // Empty path.
+        assert!(safe_manifest_join(root, "").is_none());
+    }
+
+    #[test]
+    fn safe_manifest_join_accepts_plain_relative_paths() {
+        let root = Path::new("/tmp/pyramid");
+        assert_eq!(
+            safe_manifest_join(root, "0/0_0.raw"),
+            Some(PathBuf::from("/tmp/pyramid/0/0_0.raw"))
+        );
+        // A redundant `.` is harmless and does not escape.
+        assert_eq!(
+            safe_manifest_join(root, "./0/0_0.raw"),
+            Some(PathBuf::from("/tmp/pyramid/./0/0_0.raw"))
+        );
+    }
+
+    #[test]
+    fn hash_file_matches_in_memory_hash_for_both_algos() {
+        let dir = tempfile::tempdir().unwrap();
+        // Larger than the 64 KiB streaming chunk to exercise multiple reads.
+        let bytes = vec![0x5Au8; 200 * 1024 + 3];
+        let p = dir.path().join("tile.raw");
+        std::fs::write(&p, &bytes).unwrap();
+
+        for algo in [ChecksumAlgo::Blake3, ChecksumAlgo::Sha256] {
+            assert_eq!(hash_file(&p, algo).unwrap(), hash_tile(&bytes, algo));
+        }
+    }
+
+    #[test]
+    fn hash_file_reports_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.raw");
+        let err = hash_file(&missing, ChecksumAlgo::Blake3).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -862,13 +862,22 @@ pub(crate) fn raster_verify(
                             Some(s) => s,
                             None => continue,
                         };
-                        let abs = root.join(rel);
-                        let bytes = match std::fs::read(&abs) {
-                            Ok(b) => b,
+                        // Reject traversal / absolute / prefixed manifest keys
+                        // before any filesystem access, and stream the tile
+                        // through the hasher to cap memory (see #79).
+                        let abs = match crate::checksum::safe_manifest_join(root, rel) {
+                            Some(p) => p,
+                            None => {
+                                return Err(EngineError::Sink(SinkError::Other(format!(
+                                    "Verify: manifest tile path escapes checkpoint root: {rel}"
+                                ))));
+                            }
+                        };
+                        let got = match crate::checksum::hash_file(&abs, algo) {
+                            Ok(g) => g,
                             Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
                             Err(e) => return Err(EngineError::Sink(SinkError::Io(e))),
                         };
-                        let got = crate::checksum::hash_tile(&bytes, algo);
                         if !got.eq_ignore_ascii_case(expected_s) {
                             return Err(EngineError::ChecksumMismatch {
                                 tile: parse_tile_rel_path(rel)

--- a/src/stream_verify.rs
+++ b/src/stream_verify.rs
@@ -161,13 +161,22 @@ pub(crate) fn verify_from_strip_source(
                         let Some(expected_s) = expected.as_str() else {
                             continue;
                         };
-                        let abs = root.join(rel);
-                        let bytes = match std::fs::read(&abs) {
-                            Ok(b) => b,
+                        // Reject traversal / absolute / prefixed manifest keys
+                        // before any filesystem access, and stream the tile
+                        // through the hasher to cap memory (see #79).
+                        let abs = match crate::checksum::safe_manifest_join(root, rel) {
+                            Some(p) => p,
+                            None => {
+                                return Err(EngineError::Sink(SinkError::Other(format!(
+                                    "Verify: manifest tile path escapes checkpoint root: {rel}"
+                                ))));
+                            }
+                        };
+                        let got = match crate::checksum::hash_file(&abs, algo) {
+                            Ok(g) => g,
                             Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
                             Err(e) => return Err(EngineError::Sink(SinkError::Io(e))),
                         };
-                        let got = crate::checksum::hash_tile(&bytes, algo);
                         if !got.eq_ignore_ascii_case(expected_s) {
                             return Err(EngineError::ChecksumMismatch {
                                 tile: parse_tile_rel_path(rel)

--- a/tests/path_traversal.rs
+++ b/tests/path_traversal.rs
@@ -1,0 +1,110 @@
+//! Regression tests for manifest-driven path traversal in the checksum
+//! verifier (issue #79).
+//!
+//! A `manifest.json` discovered inside an untrusted checkpoint/pyramid bundle
+//! carries attacker-controlled `checksums.per_tile` keys. Before the fix these
+//! were joined onto the pyramid root with `Path::join` and read whole with
+//! `std::fs::read`, so a key like `/etc/hostname` or `../secret.txt` let a
+//! hostile bundle read arbitrary files and surface their digests (a hash /
+//! existence oracle), and an oversized target was an OOM primitive.
+//!
+//! These tests assert that such keys are rejected *before* any filesystem
+//! access, and that a well-formed relative key still verifies.
+
+use std::fs;
+
+use serde_json::json;
+
+fn write_manifest(pyramid: &std::path::Path, per_tile: serde_json::Value) {
+    let manifest = json!({
+        "checksums": {
+            "algo": "blake3",
+            "per_tile": per_tile,
+        }
+    });
+    fs::write(
+        pyramid.join("manifest.json"),
+        serde_json::to_vec(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn verify_rejects_parent_directory_traversal() {
+    let parent = tempfile::tempdir().unwrap();
+    let pyramid = parent.path().join("pyramid");
+    fs::create_dir(&pyramid).unwrap();
+
+    // A secret that lives OUTSIDE the pyramid dir. The traversal key points at
+    // it; a vulnerable verifier reads and hashes it.
+    let secret = parent.path().join("secret.txt");
+    fs::write(&secret, b"TOP SECRET CONTENTS").unwrap();
+
+    // Deliberately-wrong digest so a vulnerable verifier would surface the file
+    // in `tiles_mismatched` (proving it read it).
+    write_manifest(
+        &pyramid,
+        json!({ "../secret.txt": "0000000000000000000000000000000000000000000000000000000000000000" }),
+    );
+
+    let res = libviprs::checksum::verify_output(&pyramid);
+    assert!(res.is_err(), "traversal path must be rejected, got {res:?}");
+}
+
+#[test]
+fn verify_rejects_absolute_path() {
+    let parent = tempfile::tempdir().unwrap();
+    let pyramid = parent.path().join("pyramid");
+    fs::create_dir(&pyramid).unwrap();
+
+    // An absolute key. `Path::join` with an absolute component replaces the
+    // base entirely, so a vulnerable verifier reads the absolute target.
+    write_manifest(
+        &pyramid,
+        json!({ "/etc/hostname": "0000000000000000000000000000000000000000000000000000000000000000" }),
+    );
+
+    let res = libviprs::checksum::verify_output(&pyramid);
+    assert!(res.is_err(), "absolute path must be rejected, got {res:?}");
+}
+
+#[test]
+fn verify_accepts_wellformed_relative_tile() {
+    let parent = tempfile::tempdir().unwrap();
+    let pyramid = parent.path().join("pyramid");
+    fs::create_dir_all(pyramid.join("0")).unwrap();
+
+    let tile_bytes = b"legitimate tile bytes";
+    let tile_rel = "0/0_0.raw";
+    fs::write(pyramid.join(tile_rel), tile_bytes).unwrap();
+
+    let digest = blake3::hash(tile_bytes).to_hex().to_string();
+    write_manifest(&pyramid, json!({ tile_rel: digest }));
+
+    let report = libviprs::checksum::verify_output(&pyramid).expect("valid manifest verifies");
+    assert_eq!(report.tiles_checked, 1);
+    assert_eq!(report.tiles_ok, 1);
+    assert!(report.tiles_mismatched.is_empty());
+    assert!(report.tiles_missing.is_empty());
+}
+
+#[test]
+fn verify_streams_large_tile_without_buffering_whole_file() {
+    let parent = tempfile::tempdir().unwrap();
+    let pyramid = parent.path().join("pyramid");
+    fs::create_dir_all(pyramid.join("0")).unwrap();
+
+    // A tile larger than the internal streaming chunk (64 KiB), to exercise the
+    // multi-read streaming path and confirm the digest still matches a
+    // one-shot reference hash.
+    let tile_bytes = vec![0xABu8; 3 * 1024 * 1024 + 7];
+    let tile_rel = "0/0_0.raw";
+    fs::write(pyramid.join(tile_rel), &tile_bytes).unwrap();
+
+    let digest = blake3::hash(&tile_bytes).to_hex().to_string();
+    write_manifest(&pyramid, json!({ tile_rel: digest }));
+
+    let report = libviprs::checksum::verify_output(&pyramid).expect("valid manifest verifies");
+    assert_eq!(report.tiles_ok, 1);
+    assert!(report.tiles_mismatched.is_empty());
+}


### PR DESCRIPTION
Closes #79

## Problem
Manifest-driven verification joined attacker-controlled `per_tile` keys onto the checkpoint/pyramid root with `Path::join` and read the target whole with `fs::read`. Absolute/prefix components replace the base and `..` escapes upward, giving path traversal / arbitrary-file read; the digest is echoed back on mismatch (hash + existence oracle); the unbounded read is an OOM primitive.

## Plan
- Add `checksum::safe_manifest_join`: reject empty, `RootDir`, `Prefix`, and `ParentDir` components before any filesystem access.
- Add `checksum::hash_file`: stream the file through the hasher in 64 KiB chunks (bounded memory) instead of `fs::read` + `hash_tile`.
- Apply at all three sites: `checksum.rs:239`, `engine.rs:865`, `stream_verify.rs:164`. Rejected keys return a typed error (`VerifyError::UnsafePath` / `SinkError::Other`) with no digest leaked.

## Tests (test-first)
- `tests/path_traversal.rs`: absolute and `..`-escaping keys are rejected before FS access (both FAIL on current main — they read the target and surface its digest); well-formed and >64 KiB streaming tiles still verify.
- Unit tests for `safe_manifest_join` (escaping vs plain) and `hash_file` (matches in-memory hash for both algos; NotFound propagates).

## Verification
- `cargo test` (245 unit + 4 integration + doc) green.
- `cargo clippy --all-targets` clean.
- `cargo fmt --check` clean on all touched lines (only pre-existing engine.rs test-code diffs remain, already on main).

Acceptance criteria: absolute/prefix/`..` rejected before FS access in all three verifiers; reads stream (bounded memory); tests cover traversal + large-file reads.