### PR TITLE
fix: persist checkpoint on the error path and default a Resume cadence

### DIFF
--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -532,20 +532,23 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             // records the tile as complete.
             let wrapped = resume::ResumeAwareSink::new(engine_sink, &skip, cp.as_ref());
 
-            let mut result = match (kind, source) {
+            // Capture the run outcome rather than propagating it with `?`
+            // straight away: the checkpoint must be flushed on *both* the
+            // success and the error path (see the flush below).
+            let run_result: Result<EngineResult, EngineError> = match (kind, source) {
                 (EngineKind::Monolithic, EngineSource::Raster(raster)) => {
-                    generate_pyramid_observed(raster, &plan, &wrapped, &engine_cfg, observer_ref)?
+                    generate_pyramid_observed(raster, &plan, &wrapped, &engine_cfg, observer_ref)
                 }
                 (EngineKind::Streaming, EngineSource::Raster(raster)) => {
                     let strip = RasterStripSource::new(raster);
                     let cfg =
                         build_streaming_config(engine_cfg, memory_budget_bytes, budget_policy);
-                    generate_pyramid_streaming(&strip, &plan, &wrapped, &cfg, observer_ref)?
+                    generate_pyramid_streaming(&strip, &plan, &wrapped, &cfg, observer_ref)
                 }
                 (EngineKind::Streaming, EngineSource::Strip(strip)) => {
                     let cfg =
                         build_streaming_config(engine_cfg, memory_budget_bytes, budget_policy);
-                    generate_pyramid_streaming(strip.as_ref(), &plan, &wrapped, &cfg, observer_ref)?
+                    generate_pyramid_streaming(strip.as_ref(), &plan, &wrapped, &cfg, observer_ref)
                 }
                 (EngineKind::MapReduce, EngineSource::Raster(raster)) => {
                     let strip = RasterStripSource::new(raster);
@@ -556,7 +559,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                         background_rgb,
                         blank_strategy,
                     );
-                    generate_pyramid_mapreduce(&strip, &plan, &wrapped, &cfg, observer_ref)?
+                    generate_pyramid_mapreduce(&strip, &plan, &wrapped, &cfg, observer_ref)
                 }
                 (EngineKind::MapReduce, EngineSource::Strip(strip)) => {
                     let cfg = build_mapreduce_config(
@@ -566,7 +569,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                         background_rgb,
                         blank_strategy,
                     );
-                    generate_pyramid_mapreduce(strip.as_ref(), &plan, &wrapped, &cfg, observer_ref)?
+                    generate_pyramid_mapreduce(strip.as_ref(), &plan, &wrapped, &cfg, observer_ref)
                 }
                 (EngineKind::Monolithic, EngineSource::Strip(_)) => {
                     unreachable!("Monolithic + Strip rejected above")
@@ -575,6 +578,26 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                     unreachable!("Auto should have been resolved before match")
                 }
             };
+
+            // Persist the checkpoint whether the run succeeded or failed.
+            // On the error path this is the only chance to make completed
+            // tiles durable: an interrupted run (kill -9 / OOM / preemption
+            // surfaced as a sink error, or an exhausted retry budget) would
+            // otherwise drop the in-memory `CheckpointState` here and force a
+            // later `--resume` to re-render everything. On the failure path a
+            // checkpoint I/O error is swallowed so the original engine error
+            // — the reason the run stopped — is what propagates to the
+            // caller.
+            if let Some(cp) = cp.as_ref() {
+                match &run_result {
+                    Ok(_) => cp.flush().map_err(EngineError::ResumeFailed)?,
+                    Err(_) => {
+                        let _ = cp.flush();
+                    }
+                }
+            }
+
+            let mut result = run_result?;
 
             // Adjust tiles_produced down by the number of tiles the
             // resume wrapper short-circuited. This restores the
@@ -585,10 +608,6 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             let skipped = wrapped.skipped_count();
             if skipped > 0 {
                 result.tiles_produced = result.tiles_produced.saturating_sub(skipped);
-            }
-
-            if let Some(cp) = cp.as_ref() {
-                cp.flush().map_err(EngineError::ResumeFailed)?;
             }
             return Ok((result, sink));
         }

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -1026,3 +1026,117 @@ mod retry_wiring_tests {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Checkpoint durability on the error path
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod checkpoint_durability_tests {
+    use super::*;
+    use crate::pixel::PixelFormat;
+    use crate::planner::{Layout, PyramidPlanner};
+    use crate::raster::Raster;
+    use crate::resume::{JobCheckpoint, ResumePolicy};
+    use crate::sink::{MemorySink, SinkError, Tile, TileSink};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A sink that forwards its first `ok` `write_tile` calls to an inner
+    /// [`MemorySink`] and then fails every subsequent call with a permanent
+    /// error. Models a process that is killed / runs out of disk part-way
+    /// through emitting a pyramid.
+    struct FailAfterSink {
+        inner: MemorySink,
+        ok_left: AtomicU32,
+    }
+
+    impl FailAfterSink {
+        fn new(ok: u32) -> Self {
+            Self {
+                inner: MemorySink::new(),
+                ok_left: AtomicU32::new(ok),
+            }
+        }
+    }
+
+    impl TileSink for FailAfterSink {
+        fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+            if self.ok_left.load(Ordering::SeqCst) == 0 {
+                return Err(SinkError::Other("permanent failure".into()));
+            }
+            self.ok_left.fetch_sub(1, Ordering::SeqCst);
+            self.inner.write_tile(tile)
+        }
+    }
+
+    fn solid_source() -> Raster {
+        // 8x8 RGB solid so every tile is non-blank and actually written.
+        let data = vec![10u8; 8 * 8 * 3];
+        Raster::new(8, 8, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    fn solid_plan() -> PyramidPlan {
+        PyramidPlanner::new(8, 8, 2, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan()
+    }
+
+    // A run that dies mid-way must still leave an on-disk checkpoint that
+    // records the tiles it completed, so a later `--resume` skips them
+    // instead of re-rendering everything. Before the fix the checkpoint was
+    // flushed only on the success path, so an interrupted run left nothing
+    // on disk and `JobCheckpoint::load` returned `None`. The high cadence
+    // here guarantees no periodic flush fired, isolating the error-path
+    // flush as the only way the two completed tiles can reach disk.
+    #[test]
+    fn interrupted_resume_run_persists_completed_tiles() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = solid_source();
+        let plan = solid_plan();
+        let sink = FailAfterSink::new(2);
+
+        let outcome = EngineBuilder::new(&source, plan, sink)
+            .with_resume(
+                ResumePolicy::resume()
+                    .with_checkpoint_root(dir.path())
+                    .with_checkpoint_every(1_000_000),
+            )
+            .run_collect();
+
+        assert!(
+            outcome.is_err(),
+            "the permanent sink failure must abort the run"
+        );
+
+        let meta = JobCheckpoint::load(dir.path())
+            .expect("checkpoint load must not error")
+            .expect("an interrupted run must leave a checkpoint on disk");
+        assert_eq!(
+            meta.completed_tiles.len(),
+            2,
+            "the checkpoint must record exactly the tiles completed before the failure"
+        );
+    }
+
+    // The Resume factory must default to a non-zero flush cadence so that a
+    // long run periodically persists progress even when the caller never sets
+    // an explicit cadence. Overwrite / Verify keep the "final flush only"
+    // default of 0.
+    #[test]
+    fn resume_policy_defaults_to_nonzero_cadence() {
+        assert!(
+            ResumePolicy::resume().checkpoint_every() > 0,
+            "Resume mode must default to a non-zero checkpoint cadence"
+        );
+        assert_eq!(
+            ResumePolicy::overwrite().checkpoint_every(),
+            0,
+            "Overwrite must keep the final-flush-only default"
+        );
+        assert_eq!(
+            ResumePolicy::verify().checkpoint_every(),
+            0,
+            "Verify must keep the final-flush-only default"
+        );
+    }
+}

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -93,6 +93,13 @@ pub enum ResumeMode {
     Verify,
 }
 
+/// Default flush cadence seeded by [`ResumePolicy::resume`]: persist the
+/// checkpoint every 1000 completed tiles. Chosen as a balance between crash
+/// granularity (at most ~1000 tiles re-rendered after an interruption) and
+/// filesystem churn (one small JSON rewrite per 1000 writes). Overwrite and
+/// Verify keep the "final flush only" default of `0`.
+pub const DEFAULT_RESUME_CHECKPOINT_EVERY: u64 = 1000;
+
 /// Fluent builder bundling a [`ResumeMode`] with its checkpoint-persistence
 /// knobs.
 ///
@@ -107,9 +114,11 @@ pub enum ResumeMode {
 ///   [`ResumeMode::Verify`].
 ///
 /// After picking a factory, chain `.with_checkpoint_every(n)` to flush the
-/// checkpoint file every `n` completed tiles (default `0` = never) and
+/// checkpoint file every `n` completed tiles (`0` = final flush only) and
 /// `.with_checkpoint_root(path)` to place the checkpoint somewhere other
-/// than the sink's base directory.
+/// than the sink's base directory. [`ResumePolicy::resume`] seeds a non-zero
+/// cadence ([`DEFAULT_RESUME_CHECKPOINT_EVERY`]); Overwrite and Verify start
+/// at `0`.
 ///
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume)
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -143,10 +152,20 @@ impl ResumePolicy {
     /// Continue an interrupted run from the on-disk checkpoint. Equivalent
     /// to [`ResumeMode::Resume`].
     ///
+    /// Unlike [`ResumePolicy::overwrite`] / [`ResumePolicy::verify`], this
+    /// factory seeds a non-zero flush cadence
+    /// ([`DEFAULT_RESUME_CHECKPOINT_EVERY`]) so that a long run periodically
+    /// persists progress even when the caller never sets an explicit cadence
+    /// — the whole point of Resume mode is that an interruption does not
+    /// throw away completed work. Override it with
+    /// [`ResumePolicy::with_checkpoint_every`] (including `0` to defer the
+    /// write to the end of the run).
+    ///
     /// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume)
     pub fn resume() -> Self {
         Self {
             mode: ResumeMode::Resume,
+            checkpoint_every: DEFAULT_RESUME_CHECKPOINT_EVERY,
             ..Self::default()
         }
     }
@@ -162,8 +181,10 @@ impl ResumePolicy {
         }
     }
 
-    /// Flush the checkpoint file every `n` completed tiles. `0` (the
-    /// default) defers the checkpoint write until the end of the run.
+    /// Flush the checkpoint file every `n` completed tiles. `0` defers the
+    /// checkpoint write until the end of the run. Overrides the cadence
+    /// seeded by the factory (notably the non-zero
+    /// [`DEFAULT_RESUME_CHECKPOINT_EVERY`] set by [`ResumePolicy::resume`]).
     pub fn with_checkpoint_every(mut self, n: u64) -> Self {
         self.checkpoint_every = n;
         self


### PR DESCRIPTION
Closes #121

## Problem
Checkpoints were durable only on success. The terminal `cp.flush()` in the `EngineBuilder` run driver ran only after the engine returned `Ok`, so any engine/sink error propagated via `?` before it. A kill -9 / OOM / preemption surfaced as a sink error mid-run left no checkpoint, and a later `--resume` re-rendered everything. `ResumePolicy::resume()` also inherited `checkpoint_every == 0` (final-flush-only), so even a clean long run persisted nothing until the very end.

## Plan / fix
- Capture the engine run outcome instead of `?`-propagating it immediately, then flush the checkpoint on **both** the success and error paths (covers all engine kinds: Monolithic, Streaming, MapReduce). On the failure path the checkpoint I/O error is swallowed so the original engine error still propagates.
- Seed a non-zero default cadence `DEFAULT_RESUME_CHECKPOINT_EVERY = 1000` in `ResumePolicy::resume()`; Overwrite and Verify keep the final-flush-only default of 0. `with_checkpoint_every(n)` still overrides (including back to 0).

## Tests (test-first)
Two new tests in `src/engine_builder.rs` (`checkpoint_durability_tests`), committed failing before the fix:
- `interrupted_resume_run_persists_completed_tiles`: a sink that fails part-way aborts the run, yet an on-disk checkpoint records exactly the tiles completed before the failure (high cadence isolates the error-path flush as the only durability route).
- `resume_policy_defaults_to_nonzero_cadence`: Resume defaults > 0; Overwrite/Verify stay 0.

## Notes
- `cargo test` (core unit + doc), `cargo clippy --all-targets`, and `cargo fmt --check` on touched files are clean. The pre-existing engine.rs:861 fmt diff already on main is untouched here.
- Integration suite (libviprs-tests) run against this branch via a temporary `--config paths` override: 0 new failures; the only reds are the 3 documented pre-existing `phase3_resume` PlanHashMismatch failures from the #120/#131 plan-hash change, which also fail on pristine main.
- The engine.rs:473-487 flush cited in the issue is only reached with `checkpoint_state`, which `generate_pyramid_observed` always passes as `None`; live checkpoint wiring goes entirely through `ResumeAwareSink` + the builder-held state, which this fix covers.
- The "CLI cadence flag" lives in the separate `libviprs-cli` repository; this PR lands the library mechanism (`with_checkpoint_every` + the non-zero Resume default) it wires to. A `--checkpoint-every` flag in libviprs-cli is a downstream follow-up outside this repo.