### PR TITLE
Constrain Overwrite wipe to the sink dir; never auto-enable it (#123)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1066,8 +1066,14 @@ fn read_manifest(root: &std::path::Path) -> Option<serde_json::Value> {
 
 /// Remove every entry under `dir`, ignoring errors for individual entries so
 /// a pre-existing but partially-populated directory can still be wiped
-/// cleanly. The directory itself is retained. Caller should have verified
-/// the path is a directory they own.
+/// cleanly. The directory itself is retained.
+///
+/// Refuses to wipe a directory this crate does not own: a destructive
+/// Overwrite must only clear output we plausibly produced, never an
+/// arbitrary directory a caller mis-pointed the sink at. A directory is
+/// considered owned when it is empty or already holds our checkpoint marker
+/// ([`crate::resume::CHECKPOINT_FILENAME`]). Anything else yields
+/// [`std::io::ErrorKind::PermissionDenied`] and is left untouched.
 pub(crate) fn wipe_directory(dir: &std::path::Path) -> std::io::Result<()> {
     if !dir.exists() {
         std::fs::create_dir_all(dir)?;
@@ -1076,6 +1082,30 @@ pub(crate) fn wipe_directory(dir: &std::path::Path) -> std::io::Result<()> {
     if !dir.is_dir() {
         return Ok(());
     }
+
+    // Ownership guard: only proceed when the directory is empty or carries
+    // our marker. A single pass records both facts.
+    let mut is_empty = true;
+    let mut owned = false;
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        is_empty = false;
+        if entry.file_name() == crate::resume::CHECKPOINT_FILENAME {
+            owned = true;
+            break;
+        }
+    }
+    if !is_empty && !owned {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing to Overwrite-wipe {}: directory is not empty and holds no {} marker",
+                dir.display(),
+                crate::resume::CHECKPOINT_FILENAME
+            ),
+        ));
+    }
+
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let p = entry.path();
@@ -2378,9 +2408,11 @@ mod tests {
         let sentinel = ckpt.path().join("keep-me.txt");
         std::fs::write(&sentinel, b"precious").unwrap();
 
-        let mut cfg = EngineConfig::default();
-        cfg.checkpoint_every = 4;
-        cfg.checkpoint_root = Some(ckpt.path().to_path_buf());
+        let cfg = EngineConfig {
+            checkpoint_every: 4,
+            checkpoint_root: Some(ckpt.path().to_path_buf()),
+            ..EngineConfig::default()
+        };
 
         let sink = crate::sink::FsSink::new(out_dir.clone(), plan.clone())
             .with_format(crate::sink::TileFormat::Raw);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2300,6 +2300,150 @@ mod tests {
         assert_eq!(finished, 1, "Verify: finished event");
     }
 
+    /// Overwrite must clear the sink's OWN output directory (removing stale
+    /// tiles) while leaving the unrelated contents of a caller-supplied
+    /// `checkpoint_root` untouched. The previous behaviour wiped whatever
+    /// `resolve_checkpoint_root` resolved to — which prefers the config's
+    /// `checkpoint_root` — deleting the user's metadata dir and leaving the
+    /// stale tiles behind (issue #123).
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn overwrite_clears_sink_not_user_checkpoint_root() {
+        use crate::resume::{CHECKPOINT_FILENAME, ResumePolicy};
+        use crate::{EngineBuilder, EngineKind};
+        use tempfile::tempdir;
+
+        let src = gradient_raster(128, 96);
+        let planner = PyramidPlanner::new(128, 96, 64, 0, Layout::DeepZoom).unwrap();
+        let plan = planner.plan();
+
+        // The sink writes tiles here. Pre-populate it with a stale tile plus
+        // our ownership marker so Overwrite is entitled to clear it.
+        let out = tempdir().unwrap();
+        let out_dir = out.path().join("tiles");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        std::fs::write(out_dir.join(CHECKPOINT_FILENAME), b"{}").unwrap();
+        let stale = out_dir.join("stale_tile.raw");
+        std::fs::write(&stale, b"old bytes").unwrap();
+
+        // A SEPARATE, user-supplied checkpoint_root holding unrelated files
+        // the caller expects to keep.
+        let ckpt = tempdir().unwrap();
+        let ckpt_dir = ckpt.path().to_path_buf();
+        let sentinel = ckpt_dir.join("keep-me.txt");
+        std::fs::write(&sentinel, b"precious").unwrap();
+
+        let sink = crate::sink::FsSink::new(out_dir.clone(), plan.clone())
+            .with_format(crate::sink::TileFormat::Raw);
+
+        let policy = ResumePolicy::overwrite().with_checkpoint_root(ckpt_dir.clone());
+        EngineBuilder::new(&src, plan.clone(), &sink)
+            .with_engine(EngineKind::Monolithic)
+            .with_resume(policy)
+            .run()
+            .unwrap();
+
+        assert!(
+            sentinel.exists(),
+            "Overwrite wiped an unrelated file in the user's checkpoint_root"
+        );
+        assert!(
+            !stale.exists(),
+            "Overwrite left a stale tile in the sink's own output directory"
+        );
+        assert!(
+            out_dir.read_dir().unwrap().next().is_some(),
+            "Overwrite produced no output in the sink dir"
+        );
+    }
+
+    /// `with_config` must never fabricate a destructive Overwrite policy just
+    /// because the config carried checkpoint knobs. With no explicit resume
+    /// mode attached, the run must be non-destructive and leave the
+    /// checkpoint_root's contents intact (issue #123).
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn with_config_does_not_fabricate_destructive_overwrite() {
+        use crate::{EngineBuilder, EngineKind};
+        use tempfile::tempdir;
+
+        let src = gradient_raster(128, 96);
+        let planner = PyramidPlanner::new(128, 96, 64, 0, Layout::DeepZoom).unwrap();
+        let plan = planner.plan();
+
+        let out = tempdir().unwrap();
+        let out_dir = out.path().join("tiles");
+
+        let ckpt = tempdir().unwrap();
+        let sentinel = ckpt.path().join("keep-me.txt");
+        std::fs::write(&sentinel, b"precious").unwrap();
+
+        let mut cfg = EngineConfig::default();
+        cfg.checkpoint_every = 4;
+        cfg.checkpoint_root = Some(ckpt.path().to_path_buf());
+
+        let sink = crate::sink::FsSink::new(out_dir.clone(), plan.clone())
+            .with_format(crate::sink::TileFormat::Raw);
+
+        // No explicit resume policy — only `with_config` carrying the knobs.
+        EngineBuilder::new(&src, plan.clone(), &sink)
+            .with_engine(EngineKind::Monolithic)
+            .with_config(cfg)
+            .run()
+            .unwrap();
+
+        assert!(
+            sentinel.exists(),
+            "with_config implicitly enabled a destructive Overwrite and wiped the checkpoint_root"
+        );
+    }
+
+    /// The wipe helper must refuse a directory it does not own — one that is
+    /// neither empty nor holds our `.libviprs-job.json` marker — so a
+    /// mis-pointed sink dir can never delete unrelated user files (issue #123).
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn wipe_directory_refuses_non_owned_dir() {
+        use tempfile::tempdir;
+
+        let d = tempdir().unwrap();
+        let foreign = d.path().join("not-ours.txt");
+        std::fs::write(&foreign, b"data").unwrap();
+
+        let res = wipe_directory(d.path());
+        assert!(
+            res.is_err(),
+            "wipe_directory must refuse a directory it does not own"
+        );
+        assert!(
+            foreign.exists(),
+            "wipe_directory deleted a file in a non-owned directory"
+        );
+    }
+
+    /// The wipe helper still fully clears a directory it DOES own — one that
+    /// carries our marker — including nested tile dirs and the marker itself.
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn wipe_directory_clears_owned_dir() {
+        use crate::resume::CHECKPOINT_FILENAME;
+        use tempfile::tempdir;
+
+        let d = tempdir().unwrap();
+        std::fs::write(d.path().join(CHECKPOINT_FILENAME), b"{}").unwrap();
+        std::fs::write(d.path().join("0_0.raw"), b"tile").unwrap();
+        std::fs::create_dir(d.path().join("1")).unwrap();
+        std::fs::write(d.path().join("1").join("0_0.raw"), b"tile").unwrap();
+
+        wipe_directory(d.path()).unwrap();
+        assert!(d.path().exists(), "the directory itself must be retained");
+        assert_eq!(
+            d.path().read_dir().unwrap().count(),
+            0,
+            "an owned directory must be fully cleared"
+        );
+    }
+
     /// Resume must reject a run whose output contract changed, not just its
     /// geometry. Here run 1 writes a full PNG pyramid + checkpoint; run 2
     /// resumes the same directory but asks for JPEG tiles. Because the tile

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -229,10 +229,12 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
     /// `with_config` take precedence.
     ///
     /// Also threads the config's `checkpoint_every` and `checkpoint_root`
-    /// into a default [`ResumePolicy::overwrite`] if no explicit policy has
-    /// been attached yet — matching the behaviour of the old
-    /// `generate_pyramid_resumable` path where those knobs lived directly
-    /// on the `EngineConfig`.
+    /// into an *existing* [`ResumePolicy`] — but only when one has already
+    /// been attached (via [`EngineBuilder::with_resume`]). It never fabricates
+    /// a policy: [`ResumeMode::Overwrite`] is destructive (it wipes the sink
+    /// dir), so carrying a checkpoint cadence or root on the config must not
+    /// silently enable it. Callers that want a resumable run choose the mode
+    /// explicitly; without one, the checkpoint knobs are simply inert.
     pub fn with_config(mut self, config: EngineConfig) -> Self {
         self.concurrency = Some(config.concurrency);
         self.buffer_size = Some(config.buffer_size);
@@ -242,12 +244,12 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
         if let Some(ds) = config.dedupe_strategy {
             self.dedupe = Some(ds);
         }
-        // Carry the checkpoint knobs into an existing ResumePolicy (if set)
-        // so migrations from `generate_pyramid_resumable(.., &cfg, mode)`
+        // Carry the checkpoint knobs into an EXPLICITLY-chosen ResumePolicy
+        // only, so migrations from `generate_pyramid_resumable(.., &cfg, mode)`
         // don't silently lose the cadence / root that used to live on the
-        // config.
-        if config.checkpoint_every != 0 || config.checkpoint_root.is_some() {
-            let mut policy = self.resume.unwrap_or_else(ResumePolicy::overwrite);
+        // config. If no policy was attached we leave `resume` as `None`
+        // rather than conjuring a destructive Overwrite (issue #123).
+        if let Some(mut policy) = self.resume.take() {
             if config.checkpoint_every != 0 && policy.checkpoint_every() == 0 {
                 policy = policy.with_checkpoint_every(config.checkpoint_every);
             }
@@ -780,9 +782,35 @@ fn prepare_resume_state(
 > {
     match mode {
         ResumeMode::Overwrite => {
-            if let Some(root) = crate::engine::resolve_checkpoint_root(config, sink) {
-                crate::engine::wipe_directory(&root)
+            // Wipe only the sink's OWN output directory. Stale tiles live
+            // there, so that is the one place a fresh Overwrite must clear.
+            // We deliberately do NOT wipe `config.checkpoint_root`: a caller
+            // supplies it to keep metadata out of the output, and it may hold
+            // unrelated files that must survive.
+            if let Some(sink_dir) = sink.checkpoint_root() {
+                crate::engine::wipe_directory(sink_dir)
                     .map_err(|e| EngineError::ResumeFailed(crate::resume::ResumeError::from(e)))?;
+            }
+            // When an explicit checkpoint_root sits apart from the sink dir,
+            // it only ever holds our own `.libviprs-job.json`. Remove just
+            // that file so a stale checkpoint can't make this fresh run look
+            // resumable — leaving every other entry in place.
+            if let Some(root) = &config.checkpoint_root {
+                let same_as_sink = sink
+                    .checkpoint_root()
+                    .is_some_and(|s| s == root.as_path());
+                if !same_as_sink {
+                    let marker = root.join(crate::resume::CHECKPOINT_FILENAME);
+                    match std::fs::remove_file(&marker) {
+                        Ok(()) => {}
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(e) => {
+                            return Err(EngineError::ResumeFailed(
+                                crate::resume::ResumeError::from(e),
+                            ));
+                        }
+                    }
+                }
             }
             let cp = crate::engine::cp_for_sink(sink, plan, config, Vec::new(), Vec::new());
             Ok((std::collections::HashSet::new(), cp))


### PR DESCRIPTION
Closes #123

## Problem
Overwrite mode wipes whatever `resolve_checkpoint_root` returns — which prefers the caller-supplied `checkpoint_root` over the sink dir — deleting unrelated contents of that dir while leaving stale tiles in the actual output. `with_config` also silently fabricated a destructive `ResumePolicy::overwrite()` whenever checkpoint knobs were set with no explicit mode.

## Plan
- Overwrite wipes only the sink's OWN output dir (`sink.checkpoint_root()`), never a caller-supplied `checkpoint_root`; there we only remove our `.libviprs-job.json`.
- `with_config` threads checkpoint knobs into an EXISTING policy only — it never fabricates a destructive mode.
- `wipe_directory` refuses to clear a directory it does not own (must be empty or contain `.libviprs-job.json`).

## Tests (added failing-first)
- `overwrite_clears_sink_not_user_checkpoint_root`
- `with_config_does_not_fabricate_destructive_overwrite`
- `wipe_directory_refuses_non_owned_dir`
- `wipe_directory_clears_owned_dir`