### PR TITLE
Fix MapReduce StripSource concurrency contract violation (#105)

### DIFF
--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -124,11 +124,26 @@ impl Default for StreamingConfig {
 ///
 /// - `render_strip(y, h)` must return a raster of width [`width()`](Self::width)
 ///   and height ≤ `h`, starting at row `y` in the full-resolution image.
-/// - The engine calls strips in strictly increasing `y` order, but may request
-///   different heights for the last strip if the image height is not a multiple
-///   of the strip height.
-/// - Implementations must be `Send + Sync` so they can be shared across threads
-///   in future parallel-strip extensions.
+/// - The engine may request different heights for the last strip if the image
+///   height is not a multiple of the strip height.
+/// - Implementations must be `Send + Sync` so they can be shared across threads.
+///
+/// ## Access ordering and concurrency
+///
+/// By default the engine calls [`render_strip`](Self::render_strip)
+/// **sequentially, in strictly increasing `y` order** — one call completes
+/// before the next begins, and each `y_offset` is greater than the previous
+/// one. This is the pattern a cursor-based source (a streamed TIFF decoder, a
+/// network byte stream) can rely on, and it holds across *every* engine,
+/// including the parallel MapReduce engine.
+///
+/// A source that is safe to call from multiple threads and in any `y` order —
+/// a random-access source such as [`RasterStripSource`] or
+/// [`PdfiumStripSource`] — may override
+/// [`permits_concurrent_strips`](Self::permits_concurrent_strips) to return
+/// `true`. Only then may the MapReduce MAP phase render several strips
+/// concurrently (and therefore out of `y` order) within a batch. Sources that
+/// leave the default in place are never called concurrently or out of order.
 pub trait StripSource: Send + Sync {
     /// Render or extract the horizontal band starting at `y_offset` with up to
     /// `height` rows, in full-resolution image coordinates.
@@ -139,6 +154,18 @@ pub trait StripSource: Send + Sync {
     fn height(&self) -> u32;
     /// Pixel format of every strip returned by [`render_strip`](Self::render_strip).
     fn format(&self) -> PixelFormat;
+
+    /// Whether the engine may call [`render_strip`](Self::render_strip)
+    /// concurrently from multiple threads and out of `y` order.
+    ///
+    /// Defaults to `false`, guaranteeing the sequential, strictly-increasing-`y`
+    /// access pattern described in the [trait contract](StripSource#access-ordering-and-concurrency).
+    /// Random-access sources whose `render_strip` is cheap and thread-safe from
+    /// any offset may override this to `true` to let the MapReduce engine render
+    /// strips in parallel batches; cursor-based sources must leave it `false`.
+    fn permits_concurrent_strips(&self) -> bool {
+        false
+    }
 }
 
 /// [`StripSource`] backed by an in-memory [`Raster`].
@@ -179,6 +206,12 @@ impl<'a> StripSource for RasterStripSource<'a> {
 
     fn format(&self) -> PixelFormat {
         self.raster.format()
+    }
+
+    fn permits_concurrent_strips(&self) -> bool {
+        // Random access: `extract` copies from an immutable `&Raster`, so any
+        // offset is safe from any thread, in any order.
+        true
     }
 }
 
@@ -758,6 +791,14 @@ impl StripSource for PdfiumStripSource {
 
     fn format(&self) -> PixelFormat {
         PixelFormat::Rgba8
+    }
+
+    fn permits_concurrent_strips(&self) -> bool {
+        // Both modes are safe for concurrent, out-of-order access:
+        // `CachedFullPage` slices an immutable cached raster, and `Streaming`
+        // holds the process-wide `pdfium_lock()` for the whole matrix render,
+        // serialising every FPDF call regardless of thread or offset.
+        true
     }
 }
 

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -300,9 +300,12 @@ fn emit_strip_tiles_parallel(
 /// Generate a tile pyramid using the MapReduce streaming engine.
 ///
 /// Processes strips in parallel batches. Within each batch, strip rendering
-/// can happen concurrently (when `tile_concurrency > 0` and batch size > 1),
-/// while tile emission and propagation remain sequential to preserve the
-/// deterministic strip ordering required by `propagate_down`.
+/// can happen concurrently (when `tile_concurrency > 0`, batch size > 1, and
+/// the source opts in via [`StripSource::permits_concurrent_strips`]); sources
+/// that require the default sequential, increasing-`y` access pattern are
+/// rendered one strip at a time. Tile emission and propagation remain
+/// sequential regardless, to preserve the deterministic strip ordering required
+/// by `propagate_down`.
 ///
 /// # Pixel parity
 ///
@@ -400,8 +403,18 @@ pub(crate) fn generate_pyramid_mapreduce(
 
         let mut batch_tiles: u64 = 0;
 
-        // MAP: render all strips in this batch (parallel when beneficial)
-        let rendered_strips = if config.tile_concurrency > 0 && batch_specs.len() > 1 {
+        // MAP: render all strips in this batch (parallel when beneficial).
+        //
+        // Concurrent rendering issues `render_strip` from several threads at
+        // once and therefore out of `y` order. That only honours the
+        // `StripSource` contract for sources that opt in via
+        // `permits_concurrent_strips`; a default (cursor-based) source is
+        // promised sequential, strictly-increasing-`y` access, so it must take
+        // the sequential branch even when concurrency is enabled (issue #105).
+        let rendered_strips = if config.tile_concurrency > 0
+            && batch_specs.len() > 1
+            && source.permits_concurrent_strips()
+        {
             let mut strips: Vec<Option<Raster>> = vec![None; batch_specs.len()];
             std::thread::scope(|s| -> Result<(), EngineError> {
                 let mut handles = Vec::with_capacity(batch_specs.len());

--- a/tests/strip_source_ordering.rs
+++ b/tests/strip_source_ordering.rs
@@ -1,0 +1,171 @@
+//! Regression test for issue #105.
+//!
+//! The `StripSource` contract documents that the engine requests strips
+//! sequentially, in strictly increasing `y` order. The MapReduce MAP phase,
+//! however, used to spawn concurrent scoped threads that called
+//! `render_strip` in parallel (and therefore out of `y` order) for *every*
+//! source, silently breaking cursor-based sources (a streamed TIFF decoder or
+//! a network byte stream) that rely on the documented ordering.
+//!
+//! This test installs a `StripSource` that leaves `permits_concurrent_strips`
+//! at its default (`false`) — i.e. an ordinary cursor-style source — and
+//! asserts the engine honours the sequential, monotonic contract even under
+//! `EngineKind::MapReduce` with concurrency enabled. It records two kinds of
+//! violation:
+//!
+//! * two `render_strip` calls overlapping in time (concurrency), and
+//! * a call whose `y_offset` is not strictly greater than the previous one.
+//!
+//! On the pre-fix engine the MAP phase renders the first batch's strips on
+//! parallel threads, so both flags trip and the test fails. Once the engine
+//! only parallelises sources that opt in via `permits_concurrent_strips`, a
+//! default source is driven sequentially and the invariant holds.
+
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use libviprs::streaming::StripSource;
+use libviprs::{
+    EngineBuilder, EngineError, EngineKind, Layout, PixelFormat, PyramidPlanner, Raster, SinkError,
+    Tile, TileSink, generate_test_raster,
+};
+
+/// A cursor-style strip source that verifies the engine's access pattern.
+///
+/// Backed by an in-memory raster (so the pixels are real and the pyramid
+/// pipeline runs to completion), it additionally asserts, at runtime, that no
+/// two `render_strip` calls overlap and that `y_offset` never goes backwards —
+/// exactly the guarantees the trait promises and a real streaming decoder
+/// would depend on.
+struct OrderTrackingSource {
+    raster: Raster,
+    /// Number of `render_strip` calls currently executing. A cursor source
+    /// can tolerate exactly one; anything higher is a concurrency violation.
+    in_flight: AtomicUsize,
+    /// Highest `y_offset` seen so far (`-1` before the first call).
+    last_y: AtomicI64,
+    concurrent_violation: AtomicBool,
+    order_violation: AtomicBool,
+}
+
+impl OrderTrackingSource {
+    fn new(raster: Raster) -> Self {
+        Self {
+            raster,
+            in_flight: AtomicUsize::new(0),
+            last_y: AtomicI64::new(-1),
+            concurrent_violation: AtomicBool::new(false),
+            order_violation: AtomicBool::new(false),
+        }
+    }
+}
+
+impl StripSource for OrderTrackingSource {
+    // NOTE: `permits_concurrent_strips` is intentionally left at its default
+    // (`false`): this models a source that requires the documented sequential,
+    // increasing-`y` access pattern.
+
+    fn render_strip(&self, y_offset: u32, height: u32) -> Result<Raster, EngineError> {
+        // Detect overlapping calls: bump the in-flight counter, hold it for a
+        // moment so a genuinely concurrent sibling call is caught in the act,
+        // then drop it back.
+        let concurrent = self.in_flight.fetch_add(1, Ordering::SeqCst);
+        if concurrent != 0 {
+            self.concurrent_violation.store(true, Ordering::SeqCst);
+        }
+
+        // Detect out-of-order access: y must strictly increase across calls.
+        let prev = self.last_y.swap(y_offset as i64, Ordering::SeqCst);
+        if (y_offset as i64) <= prev {
+            self.order_violation.store(true, Ordering::SeqCst);
+        }
+
+        // Widen the window so overlapping calls reliably observe each other.
+        std::thread::sleep(Duration::from_millis(20));
+
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+
+        let h = height.min(self.raster.height() - y_offset);
+        self.raster
+            .extract(0, y_offset, self.raster.width(), h)
+            .map_err(EngineError::from)
+    }
+
+    fn width(&self) -> u32 {
+        self.raster.width()
+    }
+
+    fn height(&self) -> u32 {
+        self.raster.height()
+    }
+
+    fn format(&self) -> PixelFormat {
+        PixelFormat::Rgb8
+    }
+}
+
+#[derive(Default)]
+struct CountingSink {
+    count: AtomicUsize,
+}
+
+impl TileSink for CountingSink {
+    fn write_tile(&self, _tile: &Tile) -> Result<(), SinkError> {
+        self.count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+// The engine consumes the source by value, so the runtime flags are read back
+// out through a shared `Arc` handle after the run completes. Dimensions +
+// budget are chosen (via a probe against `compute_strip_height` /
+// `compute_inflight_strips`) so the MAP phase forms a batch of >1 strip with
+// concurrency enabled — i.e. the parallel path is actually taken.
+#[test]
+fn mapreduce_never_calls_render_strip_concurrently_or_out_of_order() {
+    use std::sync::Arc;
+
+    struct SharedSource(Arc<OrderTrackingSource>);
+    impl StripSource for SharedSource {
+        fn render_strip(&self, y: u32, height: u32) -> Result<Raster, EngineError> {
+            self.0.render_strip(y, height)
+        }
+        fn width(&self) -> u32 {
+            self.0.width()
+        }
+        fn height(&self) -> u32 {
+            self.0.height()
+        }
+        fn format(&self) -> PixelFormat {
+            self.0.format()
+        }
+    }
+
+    let (w, h) = (1024u32, 8192u32);
+    let raster = generate_test_raster(w, h).expect("raster");
+    let inner = Arc::new(OrderTrackingSource::new(raster));
+
+    let plan = PyramidPlanner::new(w, h, 256, 0, Layout::DeepZoom)
+        .expect("planner")
+        .plan();
+
+    let sink = CountingSink::default();
+    EngineBuilder::new(SharedSource(inner.clone()), plan, sink)
+        .with_engine(EngineKind::MapReduce)
+        .with_concurrency(4)
+        .with_buffer_size(2)
+        .with_memory_budget(30_000_000)
+        .run()
+        .expect("mapreduce run");
+
+    assert!(
+        !inner.concurrent_violation.load(Ordering::SeqCst),
+        "render_strip was called concurrently from multiple threads, violating \
+         the StripSource sequential-access contract (issue #105)"
+    );
+    assert!(
+        !inner.order_violation.load(Ordering::SeqCst),
+        "render_strip was called with non-increasing y_offset, violating the \
+         StripSource increasing-y contract (issue #105)"
+    );
+}


### PR DESCRIPTION
Closes #105

## Problem
The `StripSource` trait documents that the engine calls `render_strip` in strictly increasing `y` order, but the MapReduce MAP phase (`streaming_mapreduce.rs`) spawned concurrent scoped threads that called `render_strip` in parallel and out of `y` order for *every* source. Cursor-based sources (streamed TIFF, network byte streams) that rely on the documented contract silently produce wrong pixels or errors.

## Plan
- Add an opt-in `StripSource::permits_concurrent_strips()` method (default `false`) so the documented sequential, increasing-`y` contract holds by default for all sources, including unknown custom ones.
- Gate the MAP-phase parallel path on `source.permits_concurrent_strips()`; a default source is rendered sequentially in strictly increasing `y` order.
- Opt the in-tree random-access-safe sources (`RasterStripSource`, `PdfiumStripSource`) into concurrency so they keep the parallel fast path.
- Re-document the contract to state the concurrency guarantees a source may rely on.

## Test
`tests/strip_source_ordering.rs` installs a default (cursor-style) source that flags concurrent or out-of-order `render_strip` calls, drives it under `EngineKind::MapReduce` with concurrency enabled, and asserts the sequential contract holds. Fails before the fix, passes after.