### PR TITLE
Honor FailurePolicy in the streaming and MapReduce engines

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -740,7 +740,7 @@ fn secs_to_ymd_hms_engine(secs: i64) -> (i32, u32, u32, u32, u32, u32) {
 /// callers see the explicit variant (tests in `phase3_checksum.rs` match on
 /// `EngineError::ChecksumMismatch`). All other sink errors pass through as
 /// `EngineError::Sink`.
-fn promote_sink_error(err: SinkError) -> EngineError {
+pub(crate) fn promote_sink_error(err: SinkError) -> EngineError {
     match err {
         SinkError::ChecksumMismatch {
             tile_rel_path,

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -1307,3 +1307,133 @@ mod checkpoint_durability_tests {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// FailurePolicy parity across engine kinds (issue #134)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod failure_policy_parity_tests {
+    use super::*;
+    use crate::pixel::PixelFormat;
+    use crate::planner::{Layout, PyramidPlanner};
+    use crate::raster::Raster;
+    use crate::sink::{MemorySink, SinkError, Tile};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A sink that forwards its first `ok` `write_tile` calls to an inner
+    /// [`MemorySink`] and then fails every subsequent call with a *permanent*
+    /// error. Models a sink that dies partway through a run; under
+    /// `RetryThenSkip` the doomed tiles must be skipped (not propagated) on
+    /// every engine kind.
+    struct FailAfterSink {
+        inner: MemorySink,
+        ok_left: AtomicU32,
+    }
+
+    impl FailAfterSink {
+        fn new(ok: u32) -> Self {
+            Self {
+                inner: MemorySink::new(),
+                ok_left: AtomicU32::new(ok),
+            }
+        }
+
+        fn written(&self) -> usize {
+            self.inner.tile_count()
+        }
+    }
+
+    impl TileSink for FailAfterSink {
+        fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+            loop {
+                let cur = self.ok_left.load(Ordering::SeqCst);
+                if cur == 0 {
+                    return Err(SinkError::Other("permanent failure".into()));
+                }
+                if self
+                    .ok_left
+                    .compare_exchange(cur, cur - 1, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+                {
+                    return self.inner.write_tile(tile);
+                }
+            }
+        }
+    }
+
+    fn source() -> Raster {
+        // 8x8 RGB solid so every tile is non-blank and actually written.
+        let data = vec![10u8; 8 * 8 * 3];
+        Raster::new(8, 8, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    fn plan() -> PyramidPlan {
+        PyramidPlanner::new(8, 8, 2, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan()
+    }
+
+    fn fast_policy(max_retries: u32) -> RetryPolicy {
+        RetryPolicy::new(max_retries, std::time::Duration::from_micros(1))
+            .with_multiplier(1.0)
+            .with_max_backoff(std::time::Duration::from_micros(10))
+            .with_jitter(false)
+    }
+
+    // Under `RetryThenSkip`, a permanently-failing sink must cause the doomed
+    // tiles to be *skipped* — the run completes with a non-zero
+    // `skipped_due_to_failure`, not an error — regardless of which engine kind
+    // executes it. Before the fix, only the monolithic engine honored the
+    // policy; the streaming and MapReduce engines propagated the first
+    // terminal write error (FailFast behaviour), so `run_collect` returned
+    // `Err`. This test drives each concrete kind and asserts uniform skip
+    // semantics.
+    fn assert_skip_honored(kind: EngineKind, concurrency: Option<usize>) {
+        let ok = 2u32;
+        let sink = FailAfterSink::new(ok);
+        let src = source();
+
+        let mut builder = EngineBuilder::new(&src, plan(), sink)
+            .with_engine(kind)
+            .with_failure_policy(FailurePolicy::RetryThenSkip(fast_policy(2)));
+        if let Some(c) = concurrency {
+            builder = builder.with_concurrency(c);
+        }
+
+        let (result, sink) = builder.run_collect().unwrap_or_else(|e| {
+            panic!("{kind:?} must skip doomed tiles under RetryThenSkip, got error: {e:?}")
+        });
+
+        assert!(
+            result.skipped_due_to_failure > 0,
+            "{kind:?}: expected at least one tile skipped due to failure, got {}",
+            result.skipped_due_to_failure
+        );
+        assert_eq!(
+            sink.written() as u32,
+            ok,
+            "{kind:?}: exactly the pre-failure tiles must land in the sink"
+        );
+    }
+
+    #[test]
+    fn monolithic_honors_retry_then_skip() {
+        assert_skip_honored(EngineKind::Monolithic, None);
+    }
+
+    #[test]
+    fn streaming_honors_retry_then_skip() {
+        assert_skip_honored(EngineKind::Streaming, None);
+    }
+
+    #[test]
+    fn mapreduce_sequential_honors_retry_then_skip() {
+        assert_skip_honored(EngineKind::MapReduce, Some(0));
+    }
+
+    #[test]
+    fn mapreduce_parallel_honors_retry_then_skip() {
+        assert_skip_honored(EngineKind::MapReduce, Some(2));
+    }
+}

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -628,6 +628,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                         buffer_size,
                         background_rgb,
                         blank_strategy,
+                        &engine_cfg.failure_policy,
                         cancel.clone(),
                     );
                     generate_pyramid_mapreduce(&strip, &plan, &wrapped, &cfg, observer_ref)
@@ -639,6 +640,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                         buffer_size,
                         background_rgb,
                         blank_strategy,
+                        &engine_cfg.failure_policy,
                         cancel.clone(),
                     );
                     generate_pyramid_mapreduce(strip.as_ref(), &plan, &wrapped, &cfg, observer_ref)
@@ -711,6 +713,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                     buffer_size,
                     background_rgb,
                     blank_strategy,
+                    &engine_cfg.failure_policy,
                     cancel.clone(),
                 );
                 generate_pyramid_mapreduce(&source, &plan, engine_sink, &cfg, observer_ref)?
@@ -722,6 +725,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                     buffer_size,
                     background_rgb,
                     blank_strategy,
+                    &engine_cfg.failure_policy,
                     cancel.clone(),
                 );
                 generate_pyramid_mapreduce(source.as_ref(), &plan, engine_sink, &cfg, observer_ref)?
@@ -784,12 +788,14 @@ fn build_streaming_config(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_mapreduce_config(
     memory_budget_bytes: Option<u64>,
     concurrency: Option<usize>,
     buffer_size: Option<usize>,
     background_rgb: Option<[u8; 3]>,
     blank_strategy: Option<BlankTileStrategy>,
+    failure_policy: &FailurePolicy,
     cancel: Option<crate::cancel::CancelToken>,
 ) -> MapReduceConfig {
     let mut cfg = MapReduceConfig::default();
@@ -808,6 +814,7 @@ fn build_mapreduce_config(
     if let Some(bts) = blank_strategy {
         cfg.blank_tile_strategy = bts;
     }
+    cfg.failure_policy = failure_policy.clone();
     cfg.cancel = cancel;
     cfg
 }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -40,7 +40,9 @@
 //! - [`generate_pyramid_auto`] — auto-selects monolithic or streaming based on
 //!   the budget vs. estimated monolithic peak memory.
 
-use crate::engine::{BlankTileStrategy, EngineConfig, EngineError, EngineResult};
+use crate::engine::{
+    BlankTileStrategy, EngineConfig, EngineError, EngineResult, promote_sink_error,
+};
 use crate::observe::{EngineEvent, EngineObserver, MemoryTracker};
 use crate::pixel::PixelFormat;
 use crate::planner::{Layout, PyramidPlan, TileCoord};
@@ -1226,7 +1228,7 @@ pub(crate) fn generate_pyramid_streaming(
         queue_pressure_peak: 0,
         duration: std::time::Duration::ZERO,
         stage_durations: crate::engine::StageDurations::default(),
-        skipped_due_to_failure: 0,
+        skipped_due_to_failure: sink.sink_skipped_due_to_failure(),
     })
 }
 
@@ -1493,11 +1495,26 @@ pub(crate) fn emit_strip_tiles(
             if blank {
                 skipped += 1;
             }
-            sink.write_tile(&Tile {
+            if let Err(e) = sink.write_tile(&Tile {
                 coord,
                 raster: tile_raster,
                 blank,
-            })?;
+            }) {
+                // A write that failed because its retry backoff was interrupted
+                // by a cancellation must surface as Cancelled, not be swallowed
+                // by RetryThenSkip or reported as a plain sink error. Mirror the
+                // monolithic engine so the configured FailurePolicy takes effect
+                // on every engine kind (issue #134).
+                config.check_cancelled()?;
+                match &config.failure_policy {
+                    crate::retry::FailurePolicy::RetryThenSkip(_) => {
+                        sink.note_sink_skipped();
+                        observer.on_event(EngineEvent::TileCompleted { coord });
+                        continue;
+                    }
+                    _ => return Err(promote_sink_error(e)),
+                }
+            }
             observer.on_event(EngineEvent::TileCompleted { coord });
             count += 1;
         }

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -67,6 +67,11 @@ pub struct MapReduceConfig {
     /// before each batch of strips and stops with
     /// [`EngineError::Cancelled`] once cancelled (#133).
     pub cancel: Option<crate::cancel::CancelToken>,
+    /// How terminal write failures are handled. Threaded from the builder so
+    /// the MapReduce engine honors the same `FailurePolicy` as the monolithic
+    /// and streaming engines (issue #134). Under `RetryThenSkip` a tile whose
+    /// retries are exhausted is skipped and accounted, not propagated.
+    pub failure_policy: crate::retry::FailurePolicy,
 }
 
 impl Default for MapReduceConfig {
@@ -78,6 +83,7 @@ impl Default for MapReduceConfig {
             background_rgb: [255, 255, 255],
             blank_tile_strategy: BlankTileStrategy::Emit,
             cancel: None,
+            failure_policy: crate::retry::FailurePolicy::default(),
         }
     }
 }
@@ -89,7 +95,7 @@ impl MapReduceConfig {
             buffer_size: self.buffer_size,
             background_rgb: self.background_rgb,
             blank_tile_strategy: self.blank_tile_strategy,
-            failure_policy: crate::retry::FailurePolicy::default(),
+            failure_policy: self.failure_policy.clone(),
             checkpoint_every: 0,
             dedupe_strategy: None,
             checkpoint_root: None,
@@ -288,7 +294,25 @@ fn emit_strip_tiles_parallel(
             if tile.blank {
                 skipped += 1;
             }
-            sink.write_tile(&tile)?;
+            if let Err(e) = sink.write_tile(&tile) {
+                // Honor the configured FailurePolicy so the MapReduce engine
+                // matches the monolithic and streaming engines (issue #134). A
+                // write whose retry backoff was interrupted by a cancellation
+                // must surface as Cancelled, not be swallowed by RetryThenSkip.
+                if let Some(token) = &config.cancel {
+                    if token.is_cancelled() {
+                        return Err(EngineError::Cancelled);
+                    }
+                }
+                match &config.failure_policy {
+                    crate::retry::FailurePolicy::RetryThenSkip(_) => {
+                        sink.note_sink_skipped();
+                        observer.on_event(EngineEvent::TileCompleted { coord });
+                        continue;
+                    }
+                    _ => return Err(crate::engine::promote_sink_error(e)),
+                }
+            }
             observer.on_event(EngineEvent::TileCompleted { coord });
             count += 1;
         }
@@ -665,7 +689,7 @@ pub(crate) fn generate_pyramid_mapreduce(
         queue_pressure_peak: 0,
         duration: std::time::Duration::ZERO,
         stage_durations: crate::engine::StageDurations::default(),
-        skipped_due_to_failure: 0,
+        skipped_due_to_failure: sink.sink_skipped_due_to_failure(),
     })
 }
 


### PR DESCRIPTION
Closes #134

## Problem
`FailurePolicy` was consulted only by the monolithic engine. `streaming.rs`
never referenced it and the MapReduce engine hardcoded `FailurePolicy::default()`,
so `RetryThenSkip` skip-on-terminal-failure semantics silently vanished when the
engine flipped (including under default `Auto`) — the same builder program behaved
differently per engine.

## Plan
1. Thread the canonical `FailurePolicy` into the MapReduce config (was hardcoded default).
2. Honor `RetryThenSkip` in the shared streaming tile-emission helpers
   (`emit_strip_tiles`, and the MapReduce parallel emitter): on a terminal write
   failure, check cancellation, then account the skip via `note_sink_skipped` and
   continue rather than propagating — mirroring the monolithic engine.
3. Surface `skipped_due_to_failure` in the streaming and MapReduce `EngineResult`.

## Tests
Test-first: `failure_policy_parity_tests` drives each concrete `EngineKind` against
a permanently-failing sink under `RetryThenSkip` and asserts uniform skip semantics.
Monolithic passed before; streaming and MapReduce fail until the fix lands.