### PR TITLE
Stabilize main: rustfmt + fix resume PlanHashMismatch under wrapped sinks

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -921,20 +921,19 @@ pub(crate) fn raster_verify(
                 // something to silently skip — otherwise a manifest stamped
                 // with a bogus algo would pass with zero digests checked
                 // (issue #95).
-                let algo = crate::manifest::ChecksumAlgo::from_manifest_str(algo_str)
-                    .ok_or_else(|| {
+                let algo = crate::manifest::ChecksumAlgo::from_manifest_str(algo_str).ok_or_else(
+                    || {
                         EngineError::Sink(SinkError::Other(format!(
                             "Verify: unknown checksum algorithm {algo_str:?} in manifest"
                         )))
-                    })?;
+                    },
+                )?;
                 {
                     // A recorded tile that is gone from disk is a verification
                     // failure, not something to skip — unless it is a
                     // manifest-referenced blank whose content lives in
                     // `_shared/` (issue #93).
-                    let blank_refs = manifest
-                        .get("blank_references")
-                        .and_then(|v| v.as_object());
+                    let blank_refs = manifest.get("blank_references").and_then(|v| v.as_object());
                     for (rel, expected) in per_tile {
                         let expected_s = match expected.as_str() {
                             Some(s) => s,
@@ -1058,9 +1057,7 @@ pub(crate) fn raster_verify(
                         let is_dedupe_ref = plan
                             .tile_path(coord, &ext)
                             .is_some_and(|rel| blank_ref_paths.contains(&rel));
-                        if !is_dedupe_ref
-                            && !regenerated_tile_matches_marker(&expected, config)
-                        {
+                        if !is_dedupe_ref && !regenerated_tile_matches_marker(&expected, config) {
                             return Err(EngineError::ChecksumMismatch {
                                 tile: coord,
                                 expected: "blank tile (placeholder marker)".to_string(),
@@ -2669,8 +2666,7 @@ mod tests {
         assert!(plan.centre_offset_x > 0 && plan.centre_offset_y > 0);
 
         // Direct embed must succeed and produce a canvas-sized raster.
-        let canvas =
-            embed_in_canvas(&src, &plan, EngineConfig::default().background_rgb).unwrap();
+        let canvas = embed_in_canvas(&src, &plan, EngineConfig::default().background_rgb).unwrap();
         assert_eq!(canvas.width(), plan.canvas_width);
         assert_eq!(canvas.height(), plan.canvas_height);
 
@@ -2680,16 +2676,14 @@ mod tests {
         let ox = plan.centre_offset_x as usize;
         let oy = plan.centre_offset_y as usize;
         let dst_stride = plan.canvas_width as usize * bpp;
-        let embedded = &canvas.data()[oy * dst_stride + ox * bpp
-            ..oy * dst_stride + ox * bpp + bpp];
+        let embedded = &canvas.data()[oy * dst_stride + ox * bpp..oy * dst_stride + ox * bpp + bpp];
         let src_first = &src.data()[..bpp];
         assert_eq!(embedded, src_first, "source pixel lost at centre offset");
 
         // End-to-end: the whole pyramid renders without error.
         let sink = MemorySink::new();
         let config = EngineConfig::default();
-        let result =
-            generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
+        let result = generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
         assert_eq!(result.tiles_produced, plan.total_tile_count());
         assert_eq!(sink.tile_count() as u64, plan.total_tile_count());
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -831,6 +831,7 @@ pub(crate) fn cp_for_sink(
         levels_completed,
         started_at: now.clone(),
         last_checkpoint_at: now,
+        content_format: contract.format,
     };
     Some(CheckpointState::new(
         root,
@@ -869,12 +870,10 @@ pub(crate) fn raster_verify(
     // byte mismatch on the first one, which is strictly less useful than
     // failing fast with the structural error.
     if let Some(meta) = JobCheckpoint::load(root)? {
-        let contract = crate::resume::PlanContract::from_engine(config, sink);
-        let expected = compute_plan_hash(plan, &contract);
-        if meta.plan_hash != expected {
+        if let Err(got) = crate::resume::verify_checkpoint_contract(&meta, plan, config, sink) {
             return Err(EngineError::PlanHashMismatch {
                 expected: meta.plan_hash,
-                got: expected,
+                got,
             });
         }
     }

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -888,16 +888,16 @@ fn prepare_resume_state(
             Ok((std::collections::HashSet::new(), cp))
         }
         ResumeMode::Resume => {
-            let contract = crate::resume::PlanContract::from_engine(config, sink);
-            let expected_hash = crate::resume::compute_plan_hash(plan, &contract);
             let (completed, levels) =
                 if let Some(root) = crate::engine::resolve_checkpoint_root(config, sink) {
                     match crate::resume::JobCheckpoint::load(&root)? {
                         Some(meta) => {
-                            if meta.plan_hash != expected_hash {
+                            if let Err(got) =
+                                crate::resume::verify_checkpoint_contract(&meta, plan, config, sink)
+                            {
                                 return Err(EngineError::PlanHashMismatch {
                                     expected: meta.plan_hash.clone(),
-                                    got: expected_hash,
+                                    got,
                                 });
                             }
                             (meta.completed_tiles, meta.levels_completed)

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -870,9 +870,7 @@ fn prepare_resume_state(
             // that file so a stale checkpoint can't make this fresh run look
             // resumable — leaving every other entry in place.
             if let Some(root) = &config.checkpoint_root {
-                let same_as_sink = sink
-                    .checkpoint_root()
-                    .is_some_and(|s| s == root.as_path());
+                let same_as_sink = sink.checkpoint_root().is_some_and(|s| s == root.as_path());
                 if !same_as_sink {
                     let marker = root.join(crate::resume::CHECKPOINT_FILENAME);
                     match std::fs::remove_file(&marker) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@ pub mod resize;
 pub mod resume;
 pub mod retry;
 pub mod sink;
-pub(crate) mod sync_queue;
 #[cfg(feature = "s3")]
 pub mod sink_object_store;
 #[cfg(feature = "packfile")]
@@ -73,6 +72,7 @@ pub mod source;
 pub mod stream_verify;
 pub mod streaming;
 pub mod streaming_mapreduce;
+pub(crate) mod sync_queue;
 pub mod verify;
 
 // Curated crate-root surface: types and high-level entry points only.

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -49,9 +49,7 @@ pub enum PdfError {
     },
     #[error("unsupported page /Rotate value: {0} (must be a multiple of 90)")]
     UnsupportedRotation(i64),
-    #[error(
-        "render exceeds pixel budget: {pixels} px (width × height) > {budget} px ceiling"
-    )]
+    #[error("render exceeds pixel budget: {pixels} px (width × height) > {budget} px ceiling")]
     RenderBudgetExceeded { pixels: u64, budget: u64 },
     #[error("failed to allocate {bytes} bytes for render buffer")]
     AllocationFailed { bytes: usize },
@@ -677,12 +675,12 @@ fn cmyk_to_rgb_raster(cmyk_data: &[u8], width: u32, height: u32) -> Result<Raste
     // stream can never wrap `pixel_count * 4` (guard) or `pixel_count * 3`
     // (allocation) into a small value.
     let pixel_count = width as usize * height as usize;
-    let cmyk_len = pixel_count
-        .checked_mul(4)
-        .ok_or_else(|| PdfError::UnsupportedFormat(format!("CMYK size {width}x{height} overflows")))?;
-    let rgb_len = pixel_count
-        .checked_mul(3)
-        .ok_or_else(|| PdfError::UnsupportedFormat(format!("RGB size {width}x{height} overflows")))?;
+    let cmyk_len = pixel_count.checked_mul(4).ok_or_else(|| {
+        PdfError::UnsupportedFormat(format!("CMYK size {width}x{height} overflows"))
+    })?;
+    let rgb_len = pixel_count.checked_mul(3).ok_or_else(|| {
+        PdfError::UnsupportedFormat(format!("RGB size {width}x{height} overflows"))
+    })?;
     if cmyk_data.len() < cmyk_len {
         return Err(PdfError::Decode("CMYK data too short".to_string()));
     }
@@ -1491,8 +1489,7 @@ mod tests {
     /// input.
     #[test]
     fn budgeted_render_dpi_normal_page_uses_max_dpi() {
-        let (dpi_used, capped) =
-            budgeted_render_dpi(612.0, 792.0, 300, DEFAULT_MAX_RENDER_PIXELS);
+        let (dpi_used, capped) = budgeted_render_dpi(612.0, 792.0, 300, DEFAULT_MAX_RENDER_PIXELS);
         assert_eq!(dpi_used, 300);
         assert!(!capped, "a page within budget must not be capped");
     }

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -106,11 +106,12 @@ fn alloc_zeroed_checked(
         });
     }
     let mut data: Vec<u8> = Vec::new();
-    data.try_reserve_exact(size).map_err(|_| RasterError::AllocationFailed {
-        width,
-        height,
-        bytes: size,
-    })?;
+    data.try_reserve_exact(size)
+        .map_err(|_| RasterError::AllocationFailed {
+            width,
+            height,
+            bytes: size,
+        })?;
     data.resize(size, 0);
     Ok(data)
 }

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -267,11 +267,12 @@ pub fn downscale_to(src: &Raster, dst_w: u32, dst_h: u32) -> Result<Raster, Rast
             bpp,
         })?;
     let mut dst: Vec<u8> = Vec::new();
-    dst.try_reserve(len).map_err(|_| RasterError::AllocationFailed {
-        width: dst_w,
-        height: dst_h,
-        bytes: len,
-    })?;
+    dst.try_reserve(len)
+        .map_err(|_| RasterError::AllocationFailed {
+            width: dst_w,
+            height: dst_h,
+            bytes: len,
+        })?;
     dst.resize(len, 0);
 
     for dy in 0..dst_h {

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -37,6 +37,7 @@
 //!     levels_completed: Vec::new(),
 //!     started_at: now_rfc3339(),
 //!     last_checkpoint_at: now_rfc3339(),
+//!     content_format: contract.format,
 //! };
 //! JobCheckpoint::save(output_dir, &meta)?;
 //! ```
@@ -256,6 +257,16 @@ pub struct JobMetadata {
     /// RFC 3339 timestamp of the most recent checkpoint write.
     #[serde(default)]
     pub last_checkpoint_at: String,
+    /// Tile encoding the sink committed to when this checkpoint was written,
+    /// mirroring [`PlanContract::format`]. Recorded explicitly (rather than
+    /// only being folded into `plan_hash`) so the resume gate can reproduce
+    /// the write-time hash without depending on the *live* sink to report the
+    /// format — a transparent wrapper (recording / retry / tee) may not
+    /// forward [`crate::sink::TileSink::content_format`]. Defaults to `None`
+    /// for checkpoints written before this field existed and for sinks that
+    /// do not pin a single on-disk format.
+    #[serde(default)]
+    pub content_format: Option<TileFormat>,
 }
 
 impl JobMetadata {
@@ -270,6 +281,7 @@ impl JobMetadata {
             levels_completed: Vec::new(),
             last_checkpoint_at: started_at.clone(),
             started_at,
+            content_format: None,
         }
     }
 }
@@ -566,11 +578,14 @@ pub fn is_tile_completed(meta: &JobMetadata, coord: &TileCoord) -> bool {
 /// change the bytes a resume would produce, and therefore must invalidate a
 /// checkpoint when they change.
 ///
-/// [`compute_plan_hash`] folds these into the plan hash alongside the plan
-/// geometry so that resuming a checkpoint whose format, padding colour,
-/// blank-tile handling, dedupe layout, or source content differs is rejected
+/// [`compute_plan_hash`] folds the padding colour, blank-tile handling,
+/// dedupe layout, and source content into the plan hash alongside the plan
+/// geometry so that resuming a checkpoint whose contract differs is rejected
 /// with [`crate::engine::EngineError::PlanHashMismatch`] instead of silently
-/// mixing two incompatible outputs on disk.
+/// mixing two incompatible outputs on disk. The [`format`](Self::format) is
+/// *not* hashed — it is compared separately by [`verify_checkpoint_contract`]
+/// so a transparent sink wrapper that cannot report the format does not break
+/// a legitimate resume.
 ///
 /// Build one with [`PlanContract::from_engine`] so that the value derived at
 /// checkpoint-write time and the value derived at the resume gate agree for
@@ -578,7 +593,10 @@ pub fn is_tile_completed(meta: &JobMetadata, coord: &TileCoord) -> bool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PlanContract<'a> {
     /// Tile encoding the sink commits to, when it has one. `None` for sinks
-    /// that do not pin a single on-disk format.
+    /// that do not pin a single on-disk format. Recorded in the checkpoint
+    /// (see [`JobMetadata::content_format`]) and compared by
+    /// [`verify_checkpoint_contract`], but deliberately excluded from
+    /// [`compute_plan_hash`].
     pub format: Option<TileFormat>,
     /// Background RGB used to pad edge tiles.
     pub background_rgb: [u8; 3],
@@ -625,16 +643,26 @@ impl<'a> PlanContract<'a> {
 /// enums), in the order declared below. The result is the lowercase hex
 /// Blake3 digest of those bytes.
 ///
-/// Two runs whose geometry is identical but whose format, padding colour,
-/// blank-tile strategy, dedupe layout, or source digest differ produce
-/// different hashes, so the resume gate rejects a changed content contract
-/// rather than resuming into a mixed output.
+/// Two runs whose geometry is identical but whose padding colour, blank-tile
+/// strategy, dedupe layout, or source digest differ produce different hashes,
+/// so the resume gate rejects a changed content contract rather than resuming
+/// into a mixed output.
+///
+/// The tile **format** is deliberately *not* hashed here. The format is a
+/// property of the live sink, and a legitimate resume may wrap that sink in a
+/// transparent decorator (recording / retry / tee) that does not forward
+/// [`crate::sink::TileSink::content_format`]. Baking the format into this
+/// hash would then flip a bit purely because a wrapper was added or removed,
+/// spuriously rejecting a valid checkpoint. A genuine format change is caught
+/// separately by [`verify_checkpoint_contract`], which compares the format
+/// recorded in the checkpoint against the live sink's.
 pub fn compute_plan_hash(plan: &PyramidPlan, contract: &PlanContract<'_>) -> String {
     // Domain separator — ties this hash to a specific canonicalisation so
     // the same bytes cannot accidentally match some other hash contract.
-    // Bumped to v2 when the content contract was folded in, so v1 (geometry
-    // only) checkpoints no longer match and are treated as a plan mismatch.
-    const DOMAIN: &[u8] = b"libviprs/plan/v2";
+    // Bumped to v3 when the tile format was lifted out of the hash into an
+    // explicit, wildcard-tolerant comparison (see the module docs); v1/v2
+    // checkpoints no longer match and are treated as a plan mismatch.
+    const DOMAIN: &[u8] = b"libviprs/plan/v3";
 
     let mut hasher = blake3::Hasher::new();
     hasher.update(DOMAIN);
@@ -664,10 +692,11 @@ pub fn compute_plan_hash(plan: &PyramidPlan, contract: &PlanContract<'_>) -> Str
     }
 
     // Content contract. A single tag byte (plus any payload) per field, so
-    // that changing the format, padding colour, blank-tile handling, dedupe
-    // layout, or source content changes the digest.
-    let (fmt_tag, fmt_quality) = format_tag(contract.format);
-    hasher.update(&[fmt_tag, fmt_quality]);
+    // that changing the padding colour, blank-tile handling, dedupe layout,
+    // or source content changes the digest. The tile format is intentionally
+    // excluded — it is compared separately in `verify_checkpoint_contract` so
+    // that a transparent sink wrapper that cannot report the format does not
+    // invalidate an otherwise-matching checkpoint.
     hasher.update(&contract.background_rgb);
     let (blank_tag, blank_delta) = blank_strategy_tag(contract.blank_strategy);
     hasher.update(&[blank_tag, blank_delta]);
@@ -686,18 +715,58 @@ pub fn compute_plan_hash(plan: &PyramidPlan, contract: &PlanContract<'_>) -> Str
     hasher.finalize().to_hex().to_string()
 }
 
-/// Tag byte (and quality payload) for a [`TileFormat`].
+/// Decide whether a loaded checkpoint is compatible with the current run.
 ///
-/// Kept in one place so that adding a new format forces an explicit decision
-/// about its byte, mirroring [`layout_tag`]. The second byte carries JPEG
-/// quality (0 for formats without a quality knob).
-fn format_tag(format: Option<TileFormat>) -> (u8, u8) {
-    match format {
-        None => (0, 0),
-        Some(TileFormat::Png) => (1, 0),
-        Some(TileFormat::Jpeg { quality }) => (2, quality),
-        Some(TileFormat::Raw) => (3, 0),
+/// Resume must tolerate a caller wrapping their sink in a transparent
+/// decorator (recording, retry, tee, crash-injecting, …). Such wrappers
+/// legitimately forward `write_tile` and `checkpoint_root` but often do not
+/// forward [`crate::sink::TileSink::content_format`], so the format they
+/// report is `None` even though the underlying run pins a concrete encoding.
+/// Because the format is folded into [`compute_plan_hash`], recomputing the
+/// expected hash straight from the live sink would flip the format bits and
+/// reject an otherwise valid checkpoint — the resume would fail with
+/// [`ResumeError::PlanHashMismatch`] purely because a wrapper was added or
+/// removed between the writing run and the resuming run.
+///
+/// To stay robust the geometry + content contract is re-hashed using the
+/// format that was **recorded when the checkpoint was written**
+/// ([`JobMetadata::content_format`]) rather than whatever the live sink can
+/// report now, so a legitimate resume matches regardless of wrapping. A
+/// *genuine* output-format change is still caught: when the recorded format
+/// and the live sink's format are both concrete and disagree, the checkpoint
+/// is rejected so two incompatible encodings are never mixed on disk.
+///
+/// Returns `Ok(())` when the checkpoint is compatible, or `Err(got)` carrying
+/// the freshly computed hash to surface in the resulting mismatch error.
+pub(crate) fn verify_checkpoint_contract(
+    meta: &JobMetadata,
+    plan: &PyramidPlan,
+    config: &EngineConfig,
+    sink: &dyn TileSink,
+) -> Result<(), String> {
+    let live = PlanContract::from_engine(config, sink);
+
+    // Geometry + non-format content contract. Stable regardless of how the
+    // sink is wrapped, because every field here is derived from the plan and
+    // the engine config, not from the live sink.
+    let expected = compute_plan_hash(plan, &live);
+    if meta.plan_hash != expected {
+        return Err(expected);
     }
+
+    // Genuine output-format change: only when both the checkpoint and the
+    // live sink pin a concrete — and different — encoding. Either side being
+    // `None` means "format unknown", which we treat as compatible rather than
+    // rejecting a valid resume behind a transparent wrapper.
+    if let (Some(recorded), Some(current)) = (meta.content_format, live.format) {
+        if recorded != current {
+            return Err(format!(
+                "{expected} (tile format changed from {recorded:?} to {current:?})"
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Tag byte (and tolerance payload) for a [`BlankTileStrategy`].
@@ -740,11 +809,45 @@ fn layout_tag(layout: Layout) -> u8 {
 mod tests {
     use super::*;
     use crate::planner::PyramidPlanner;
+    use crate::sink::{SinkError, Tile};
 
     fn sample_plan() -> PyramidPlan {
         PyramidPlanner::new(128, 128, 64, 0, Layout::DeepZoom)
             .unwrap()
             .plan()
+    }
+
+    /// Minimal sink whose only interesting behaviour is the tile format it
+    /// reports (or refuses to report). Lets the resume-gate tests drive
+    /// [`verify_checkpoint_contract`] without a real filesystem sink.
+    struct FormatSink(Option<TileFormat>);
+
+    impl TileSink for FormatSink {
+        fn write_tile(&self, _tile: &Tile) -> Result<(), SinkError> {
+            Ok(())
+        }
+        fn finish(&self) -> Result<(), SinkError> {
+            Ok(())
+        }
+        fn content_format(&self) -> Option<TileFormat> {
+            self.0
+        }
+    }
+
+    /// Build a checkpoint as the engine would for a run driven by `sink`:
+    /// a geometry+contract hash plus the recorded write-time format.
+    fn checkpoint_for(
+        plan: &PyramidPlan,
+        config: &EngineConfig,
+        sink: &dyn TileSink,
+    ) -> JobMetadata {
+        let contract = PlanContract::from_engine(config, sink);
+        let mut meta = JobMetadata::new(
+            compute_plan_hash(plan, &contract),
+            "1970-01-01T00:00:00Z".into(),
+        );
+        meta.content_format = contract.format;
+        meta
     }
 
     /// A baseline content contract for the plan-hash tests. Individual tests
@@ -767,6 +870,7 @@ mod tests {
             levels_completed: vec![0],
             started_at: "1970-01-01T00:00:00Z".into(),
             last_checkpoint_at: "1970-01-01T00:00:00Z".into(),
+            content_format: None,
         }
     }
 
@@ -902,7 +1006,10 @@ mod tests {
     }
 
     #[test]
-    fn plan_hash_changes_with_tile_format() {
+    fn plan_hash_ignores_tile_format() {
+        // The format is compared separately (see the resume-gate tests
+        // below), not folded into the geometry+contract hash, so two contracts
+        // that differ only in format hash identically.
         let plan = sample_plan();
         let png = PlanContract {
             format: Some(TileFormat::Png),
@@ -912,27 +1019,72 @@ mod tests {
             format: Some(TileFormat::Jpeg { quality: 80 }),
             ..sample_contract()
         };
-        assert_ne!(
+        assert_eq!(
             compute_plan_hash(&plan, &png),
             compute_plan_hash(&plan, &jpeg),
+            "tile format must not affect the plan hash"
+        );
+    }
+
+    #[test]
+    fn resume_rejects_a_changed_tile_format() {
+        // A checkpoint written by a PNG sink must not resume against a JPEG
+        // sink — that would mix two encodings in the same output tree.
+        let plan = sample_plan();
+        let config = EngineConfig::default();
+        let png = FormatSink(Some(TileFormat::Png));
+        let meta = checkpoint_for(&plan, &config, &png);
+
+        assert!(
+            verify_checkpoint_contract(&meta, &plan, &config, &png).is_ok(),
+            "same-format resume must be accepted"
+        );
+
+        let jpeg = FormatSink(Some(TileFormat::Jpeg { quality: 80 }));
+        assert!(
+            verify_checkpoint_contract(&meta, &plan, &config, &jpeg).is_err(),
             "changing the tile format must invalidate the checkpoint"
         );
     }
 
     #[test]
-    fn plan_hash_changes_with_jpeg_quality() {
+    fn resume_rejects_a_changed_jpeg_quality() {
         let plan = sample_plan();
-        let q80 = PlanContract {
-            format: Some(TileFormat::Jpeg { quality: 80 }),
-            ..sample_contract()
-        };
-        let q40 = PlanContract {
-            format: Some(TileFormat::Jpeg { quality: 40 }),
-            ..sample_contract()
-        };
-        assert_ne!(
-            compute_plan_hash(&plan, &q80),
-            compute_plan_hash(&plan, &q40)
+        let config = EngineConfig::default();
+        let q80 = FormatSink(Some(TileFormat::Jpeg { quality: 80 }));
+        let meta = checkpoint_for(&plan, &config, &q80);
+
+        let q40 = FormatSink(Some(TileFormat::Jpeg { quality: 40 }));
+        assert!(
+            verify_checkpoint_contract(&meta, &plan, &config, &q40).is_err(),
+            "changing the JPEG quality must invalidate the checkpoint"
+        );
+    }
+
+    #[test]
+    fn resume_tolerates_a_sink_that_does_not_report_its_format() {
+        // Regression: a transparent wrapper sink returns `None` from
+        // `content_format()`. Resume must still accept a checkpoint written by
+        // the concrete underlying sink instead of failing with a spurious
+        // PlanHashMismatch.
+        let plan = sample_plan();
+        let config = EngineConfig::default();
+
+        // Written by a concrete PNG sink, resumed behind a format-blind wrapper.
+        let png = FormatSink(Some(TileFormat::Png));
+        let meta = checkpoint_for(&plan, &config, &png);
+        let wrapper = FormatSink(None);
+        assert!(
+            verify_checkpoint_contract(&meta, &plan, &config, &wrapper).is_ok(),
+            "a wrapper that does not report its format must not break resume"
+        );
+
+        // Symmetric case: written behind a format-blind wrapper, resumed by
+        // the concrete sink.
+        let meta_blind = checkpoint_for(&plan, &config, &wrapper);
+        assert!(
+            verify_checkpoint_contract(&meta_blind, &plan, &config, &png).is_ok(),
+            "a checkpoint written without a format must resume against a concrete sink"
         );
     }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -2136,9 +2136,7 @@ mod tests {
 
         // Delete the recorded tile from disk, then verify again: this must be
         // reported as a failure, not silently skipped.
-        let rel = plan
-            .tile_path(coord, TileFormat::Png.extension())
-            .unwrap();
+        let rel = plan.tile_path(coord, TileFormat::Png.extension()).unwrap();
         let abs = base.join(&rel);
         assert!(abs.exists(), "recorded tile should exist before deletion");
         std::fs::remove_file(&abs).unwrap();

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -444,7 +444,7 @@ impl TileSink for SlowSink {
 /// for how the CLI maps user flags to a `TileFormat`.
 ///
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-format)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TileFormat {
     Png,
     /// JPEG-encoded tiles. The `quality` knob trades off filesize against
@@ -1384,6 +1384,7 @@ impl FsSink {
                 .collect(),
             started_at: timestamp.clone(),
             last_checkpoint_at: timestamp,
+            content_format: contract.format,
         };
 
         // Durability ordering (issue #122): fsync the tile data written since

--- a/src/stream_verify.rs
+++ b/src/stream_verify.rs
@@ -113,12 +113,10 @@ pub(crate) fn verify_from_strip_source(
     // plan divergence surface structurally instead of as per-tile byte
     // mismatches.
     if let Some(meta) = crate::resume::JobCheckpoint::load(root)? {
-        let contract = crate::resume::PlanContract::from_engine(config, sink);
-        let expected = crate::resume::compute_plan_hash(plan, &contract);
-        if meta.plan_hash != expected {
+        if let Err(got) = crate::resume::verify_checkpoint_contract(&meta, plan, config, sink) {
             return Err(EngineError::PlanHashMismatch {
                 expected: meta.plan_hash,
-                got: expected,
+                got,
             });
         }
     }

--- a/src/stream_verify.rs
+++ b/src/stream_verify.rs
@@ -156,20 +156,19 @@ pub(crate) fn verify_from_strip_source(
                 // something to silently skip — otherwise a manifest stamped
                 // with a bogus algo would pass with zero digests checked
                 // (issue #95).
-                let algo = crate::manifest::ChecksumAlgo::from_manifest_str(algo_str)
-                    .ok_or_else(|| {
+                let algo = crate::manifest::ChecksumAlgo::from_manifest_str(algo_str).ok_or_else(
+                    || {
                         EngineError::Sink(SinkError::Other(format!(
                             "Verify: unknown checksum algorithm {algo_str:?} in manifest"
                         )))
-                    })?;
+                    },
+                )?;
                 {
                     // A recorded tile that is gone from disk is a verification
                     // failure, not something to skip — unless it is a
                     // manifest-referenced blank whose content lives in
                     // `_shared/` (issue #93).
-                    let blank_refs = manifest
-                        .get("blank_references")
-                        .and_then(|v| v.as_object());
+                    let blank_refs = manifest.get("blank_references").and_then(|v| v.as_object());
                     for (rel, expected) in per_tile {
                         let Some(expected_s) = expected.as_str() else {
                             continue;
@@ -781,8 +780,7 @@ mod tests {
         let mut cfg = EngineConfig::default()
             .with_blank_tile_strategy(crate::engine::BlankTileStrategy::Placeholder);
         cfg.background_rgb = [7, 7, 7];
-        crate::engine::generate_pyramid_observed(&src, &plan, &sink, &cfg, &NoopObserver)
-            .unwrap();
+        crate::engine::generate_pyramid_observed(&src, &plan, &sink, &cfg, &NoopObserver).unwrap();
 
         // Setup sanity: at least the first tile is a 1-byte marker on disk.
         let first = plan.tile_coords().next().unwrap();

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -353,8 +353,13 @@ pub(crate) fn generate_pyramid_mapreduce(
     } else {
         0
     };
-    let inflight =
-        compute_inflight_strips(plan, format, strip_height, channel_bytes, config.memory_budget_bytes);
+    let inflight = compute_inflight_strips(
+        plan,
+        format,
+        strip_height,
+        channel_bytes,
+        config.memory_budget_bytes,
+    );
 
     let ch = plan.canvas_height;
     let top_level = plan.levels.len() - 1;
@@ -809,7 +814,10 @@ mod tests {
         let k_no_channel = compute_inflight_strips(&plan, PixelFormat::Rgb8, 512, 0, budget);
         let k_big_channel =
             compute_inflight_strips(&plan, PixelFormat::Rgb8, 512, 100_000_000, budget);
-        assert!(k_no_channel > 1, "test needs a case where several strips fit");
+        assert!(
+            k_no_channel > 1,
+            "test needs a case where several strips fit"
+        );
         assert!(k_big_channel <= k_no_channel);
         assert!(k_big_channel >= 1);
     }

--- a/tests/parallel_borrow_no_clone.rs
+++ b/tests/parallel_borrow_no_clone.rs
@@ -55,9 +55,8 @@ unsafe impl GlobalAlloc for CountingAlloc {
         let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
         if !new_ptr.is_null() {
             if new_size >= layout.size() {
-                let live =
-                    LIVE.fetch_add(new_size - layout.size(), Ordering::Relaxed) + new_size
-                        - layout.size();
+                let live = LIVE.fetch_add(new_size - layout.size(), Ordering::Relaxed) + new_size
+                    - layout.size();
                 PEAK.fetch_max(live, Ordering::Relaxed);
             } else {
                 LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);


### PR DESCRIPTION
Stabilizes `main` by clearing two pre-existing red CI jobs that every open PR inherits.

## 1. Check & Lint: `cargo fmt --check`
`main` was unformatted. Ran `cargo fmt --all`; `cargo fmt --all --check` is now clean.

## 2. Integration Tests (libviprs-tests): resume `PlanHashMismatch`
Three tests in `libviprs-tests/tests/phase3_resume.rs` failed:
`idempotent_resume_of_completed_job`, `resume_mode_continues_after_partial_run`,
`resume_survives_process_boundary` — all panicking with `PlanHashMismatch`.

### Root cause
The resume gate validated a checkpoint by recomputing the plan hash from the
*live* sink and comparing it to the stored value. The hash folded in
`sink.content_format()`, which is a property of the concrete sink object rather
than of the run. A legitimate resume commonly wraps the sink in a transparent
decorator (recording / retry / tee / crash-injecting) that does not forward
`content_format()`, so the format bit flipped between the writing run and the
resuming run and the gate rejected a valid checkpoint. The failure was
symmetric — writing behind a wrapper then resuming with the bare sink broke the
same way.

### Fix
- Lift the tile format out of `compute_plan_hash` (domain bumped `v2` -> `v3`)
  so the geometry + config-contract hash is stable regardless of how the sink
  is wrapped.
- Record the write-time format explicitly in `JobMetadata::content_format`
  (`serde(default)`, backward compatible with older checkpoints).
- Compare the format separately in a new `verify_checkpoint_contract` helper
  that every resume/verify gate now routes through. A genuine output-format
  change is still rejected, but only when both the checkpoint and the live sink
  pin a concrete, differing format; an unknown format on either side is treated
  as compatible.

### Verification
- In-repo `cargo test`: 299 lib/unit + integration tests green.
- `cargo clippy --all-targets --features pdfium -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- `libviprs-tests` default-feature `cargo test` (what the Integration job runs):
  all previously-failing tests pass; full suite 55 passed / 0 failed.

The two format-sensitivity unit tests were re-pointed at the new
`verify_checkpoint_contract` mechanism (a format change is still rejected), and
a regression test was added asserting a format-blind wrapper sink no longer
breaks resume.