### PR TITLE
Bump pdfium pin to 7881 in install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ The `pdfium` feature requires `libpdfium.so` at runtime. Pre-compiled binaries b
 ```bash
 # x86_64
 curl -L -o pdfium.tgz \
-  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-x64.tgz
+  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7881/pdfium-linux-x64.tgz
 
 # arm64
 curl -L -o pdfium.tgz \
-  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-arm64.tgz
+  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7881/pdfium-linux-arm64.tgz
 
 # Extract and install
 tar xzf pdfium.tgz


### PR DESCRIPTION
Updates the libviprs-dep pdfium release URLs in the README install snippets from `pdfium-7725` to the newly published `pdfium-7881` (chromium/7881). Release asset URLs verified to resolve (302).