### PR TITLE
Promote stream_verify strip-blit debug_asserts to hard checks

### DIFF
--- a/src/stream_verify.rs
+++ b/src/stream_verify.rs
@@ -34,6 +34,39 @@ use crate::streaming::{StripSource, obtain_canvas_strip};
 /// tile missing. This matches the behaviour of `engine::run_verify`.
 const CANDIDATE_EXTS: [&str; 4] = ["raw", "png", "jpeg", "jpg"];
 
+/// A [`StripSource`](crate::streaming::StripSource) (or the canvas-embedding
+/// helper it is routed through) returned a strip whose layout does not match
+/// the top-level canvas the verify walker is assembling.
+///
+/// The strip → canvas blit in Phase 3 trusts three invariants: the strip
+/// width equals the canvas width, the strip pixel format equals the source
+/// format, and the strip yields no more rows than were requested for the
+/// current band. Every in-tree layout upholds them, but a third-party
+/// `StripSource` implementation can violate them. These invariants were once
+/// guarded only by `debug_assert_eq!`, which compiles out in release builds —
+/// turning a violation into either a release-build panic (a slice index runs
+/// past the canvas buffer) or silent cross-row corruption of the canvas
+/// `Vec`. Surfacing the mismatch as a typed [`EngineError::Source`] keeps the
+/// blit's load-bearing layout invariant enforced in every build profile
+/// (issue #81).
+#[derive(Debug)]
+struct StripLayoutMismatch(String);
+
+impl std::fmt::Display for StripLayoutMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for StripLayoutMismatch {}
+
+/// Build the typed error returned when a strip violates a Phase-3 blit
+/// invariant. Wraps the human-readable reason in [`EngineError::Source`],
+/// attributing the failure to the strip source rather than to storage.
+fn strip_layout_error(reason: String) -> EngineError {
+    EngineError::Source(Box::new(StripLayoutMismatch(reason)))
+}
+
 /// Verify an on-disk pyramid against a streaming source.
 ///
 /// Walks every tile listed in `plan`, reads the corresponding file from the
@@ -260,9 +293,39 @@ pub(crate) fn verify_from_strip_source(
         // `canvas_width` for Google / centred layouts. For DeepZoom/Xyz
         // the strip width equals the source width, which also equals
         // `canvas_width` in those layouts (no canvas padding is applied).
-        debug_assert_eq!(strip.width(), cw);
-        debug_assert_eq!(strip.format(), format);
+        //
+        // These are the load-bearing invariants of the row-by-row blit below:
+        // a strip wider than the canvas, in a different pixel format, or with
+        // more rows than this band requested would drive `dst_start +
+        // src_row_bytes` past the canvas length (a release-build panic) or
+        // spill rows into the neighbouring band (silent canvas corruption).
+        // Slice bounds keep the operation memory-safe, but nothing else
+        // enforces the layout contract for a third-party `StripSource`, so the
+        // former `debug_assert_eq!` guards are promoted to hard checks that
+        // return a typed error in every build profile (issue #81).
         let strip_rows = strip.height() as usize;
+        if strip.width() != cw {
+            return Err(strip_layout_error(format!(
+                "strip source returned a strip {} px wide but the canvas is {} px \
+                 wide; the strip-to-canvas blit requires them equal",
+                strip.width(),
+                cw
+            )));
+        }
+        if strip.format() != format {
+            return Err(strip_layout_error(format!(
+                "strip source returned a strip in pixel format {:?} but the source \
+                 format is {:?}",
+                strip.format(),
+                format
+            )));
+        }
+        if strip_rows > sh as usize {
+            return Err(strip_layout_error(format!(
+                "strip source returned {strip_rows} rows for a band of at most {sh} \
+                 rows; the surplus rows would overrun the canvas"
+            )));
+        }
         let src_row_bytes = strip.width() as usize * bpp;
         let src_stride = strip.stride();
         let data = strip.data();
@@ -793,5 +856,115 @@ mod tests {
         let strip_src = RasterStripSource::new(&src);
         verify_from_strip_source(&strip_src, &plan, &sink, &cfg, &NoopObserver)
             .expect("raw placeholder pyramid must verify via strip path");
+    }
+
+    /// A [`StripSource`] whose `render_strip` deliberately violates the
+    /// strip → canvas blit contract. The trait's `width` / `height` / `format`
+    /// accessors report the true, plan-matching dimensions (so plan validation
+    /// and the strip-request arithmetic behave normally), while `render_strip`
+    /// returns a raster that is either wider than the canvas, in the wrong
+    /// pixel format, or taller than the requested band. This is exactly the
+    /// shape of a buggy or adversarial third-party source. Issue #81.
+    struct MalformedStripSource {
+        w: u32,
+        h: u32,
+        format: PixelFormat,
+        strip_format: PixelFormat,
+        extra_width: u32,
+        extra_rows: u32,
+    }
+
+    impl MalformedStripSource {
+        fn new(w: u32, h: u32) -> Self {
+            Self {
+                w,
+                h,
+                format: PixelFormat::Rgb8,
+                strip_format: PixelFormat::Rgb8,
+                extra_width: 0,
+                extra_rows: 0,
+            }
+        }
+    }
+
+    impl StripSource for MalformedStripSource {
+        fn render_strip(&self, _y: u32, height: u32) -> Result<Raster, EngineError> {
+            let w = self.w + self.extra_width;
+            let h = height + self.extra_rows;
+            let bpp = self.strip_format.bytes_per_pixel();
+            let data = vec![0u8; w as usize * h as usize * bpp];
+            Raster::new(w, h, self.strip_format, data).map_err(EngineError::from)
+        }
+        fn width(&self) -> u32 {
+            self.w
+        }
+        fn height(&self) -> u32 {
+            self.h
+        }
+        fn format(&self) -> PixelFormat {
+            self.format
+        }
+    }
+
+    /// Assert that streaming verify rejects `bad` with the typed strip-layout
+    /// error rather than panicking or corrupting the canvas. Builds a valid
+    /// raw pyramid up front (so the existence pass passes) and then replays
+    /// verify against the non-conforming source.
+    fn assert_strip_layout_rejected(bad: MalformedStripSource, expect_substr: &str) {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("tiles");
+        let (sink, plan, _src) = build_raw_pyramid(&out, bad.w, bad.h, 128);
+
+        let err =
+            verify_from_strip_source(&bad, &plan, &sink, &EngineConfig::default(), &NoopObserver)
+                .expect_err("verify must reject a strip that violates the canvas layout");
+
+        match err {
+            EngineError::Source(inner) => {
+                let msg = inner.to_string();
+                assert!(
+                    msg.contains(expect_substr),
+                    "unexpected strip-layout error message: {msg}"
+                );
+            }
+            other => {
+                panic!("expected EngineError::Source for strip layout mismatch, got {other:?}")
+            }
+        }
+    }
+
+    /// Issue #81: a strip whose width exceeds the canvas width must surface a
+    /// typed error in release, not a slice-bounds panic / silent corruption
+    /// that the old `debug_assert_eq!` masked away outside debug builds.
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn stream_verify_rejects_overwide_strip() {
+        let mut bad = MalformedStripSource::new(256, 256);
+        bad.extra_width = 1;
+        assert_strip_layout_rejected(bad, "wide");
+    }
+
+    /// Issue #81: a strip in a different pixel format than the source must be
+    /// rejected — a wider bpp would read/write a different number of bytes per
+    /// row and desynchronise the whole canvas.
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn stream_verify_rejects_wrong_format_strip() {
+        let mut bad = MalformedStripSource::new(256, 256);
+        // Same declared width, different (wider) pixel format.
+        bad.strip_format = PixelFormat::Rgba8;
+        assert_strip_layout_rejected(bad, "pixel format");
+    }
+
+    /// Issue #81: a strip that returns more rows than the band requested must
+    /// be rejected. The surplus rows would drive `dst_start` past the canvas
+    /// buffer on the final band (a release panic) or overwrite the following
+    /// band's rows.
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn stream_verify_rejects_overtall_strip() {
+        let mut bad = MalformedStripSource::new(256, 256);
+        bad.extra_rows = 1;
+        assert_strip_layout_rejected(bad, "rows");
     }
 }


### PR DESCRIPTION
## Problem

The strip → canvas blit in the streaming verify path (`src/stream_verify.rs`) validated strip width and pixel format only with `debug_assert_eq!`, which compiles out in release. A `StripSource` returning a strip whose width != canvas width, in a different pixel format, or with more rows than the requested band, made `src_row_bytes` exceed `dst_stride` or `dst_start` exceed the canvas length. Slice bounds kept it memory-safe, but the outcome was a release-build panic or silent cross-row corruption of the canvas `Vec` — the load-bearing layout invariant had no enforcement in release.

## Fix

- Promote the two `debug_assert_eq!` guards (strip width, strip format) to hard checks that return a typed error in every build profile.
- Add a row-count check (`strip_rows <= band height`) before the blit loop so a strip taller than the requested band cannot overrun the canvas.
- Violations now return `EngineError::Source` wrapping a descriptive `StripLayoutMismatch`, attributing the failure to the strip source rather than to storage.

## Tests

Three reproducers drive a non-conforming `StripSource` for each case — over-wide, wrong-format, over-tall — and assert the typed error with no panic and no corruption. Verified RED before the fix (two hit the `debug_assert` panic, the over-tall case hit the real out-of-bounds slice panic) and GREEN after.

Local mirror green: `make fmt`, `make clippy`, `make test` (324 lib tests). Strictly scoped to `src/stream_verify.rs`.

Closes #81