### PR TITLE
fix(dedupe): make DedupeStrategy::None a true passthrough

### DIFF
--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -266,6 +266,21 @@ impl DedupeIndex {
         let shared_key = format!("blank_{hash_hex}");
         let shared_path = Self::shared_path(&shared_key, ext);
 
+        // `DedupeStrategy::None` is a true passthrough: every tile is written
+        // to its own file and no content is ever collapsed. We must therefore
+        // neither consult nor populate `seen`/`refs`, so two calls with
+        // identical bytes can never yield a `Reference` (issue #99). Returning
+        // `WriteNew` for every call tells the caller to write the tile verbatim
+        // at its planned path. `FsSink` guards this externally and never calls
+        // `record` under `None`, but `record` is public API and other consumers
+        // must not be silently deduplicated.
+        if self.strategy == DedupeStrategy::None {
+            return DedupeDecision::WriteNew {
+                shared_key,
+                shared_path,
+            };
+        }
+
         // Single lock: update `refs` and `seen` atomically so readers never
         // observe one populated without the other (Mara B5).
         let mut state = self.state.lock().expect("dedupe state mutex poisoned");
@@ -573,6 +588,37 @@ mod tests {
     fn shared_path_is_under_shared_dir() {
         let p = DedupeIndex::shared_path("blank_deadbeef", "png");
         assert_eq!(p, PathBuf::from("_shared").join("blank_deadbeef.png"));
+    }
+
+    #[test]
+    fn none_strategy_never_deduplicates() {
+        // Regression (issue #99): `DedupeStrategy::None` must be a true
+        // passthrough. Two tiles with byte-identical contents must each be
+        // reported as `WriteNew` — the second must NOT collapse onto the first
+        // as a `Reference` — and no internal dedupe state may be populated.
+        let idx = DedupeIndex::new(DedupeStrategy::None);
+        let bytes = b"identical tile bytes";
+
+        let d1 = idx.record("0/0_0.png", bytes);
+        let d2 = idx.record("0/0_1.png", bytes);
+
+        assert!(
+            matches!(d1, DedupeDecision::WriteNew { .. }),
+            "None must report the first tile as WriteNew; got {d1:?}"
+        );
+        assert!(
+            matches!(d2, DedupeDecision::WriteNew { .. }),
+            "None must never emit a dedupe Reference; got {d2:?}"
+        );
+        assert!(
+            idx.references().is_empty(),
+            "None must not record any manifest references"
+        );
+        assert_eq!(
+            idx.distinct_count(),
+            0,
+            "None must not populate the seen index"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem
`DedupeIndex::record` never consulted `self.strategy`: `effective_algo` maps `None` to Blake3 and the `seen`/`refs` maps were populated unconditionally. As a result `DedupeIndex::new(DedupeStrategy::None).record(..)` returned `WriteNew`/`Reference` and silently deduplicated. `FsSink` guards this externally (never builds a dedupe index for `None`), but `record` is public API and other consumers hit the footgun.

## Fix
Short-circuit `None` at the top of `record`: return `WriteNew` for every call without touching `seen`/`refs`, so two byte-identical tiles can never collapse onto a shared file. This makes `None` a true passthrough matching its documented contract ("every tile is written to its own file").

Entirely within `src/dedupe.rs`; no consumer changes needed (the `DedupeDecision` match in `sink.rs` is unaffected and `FsSink` never reaches this path under `None`).

## Test
Adds `none_strategy_never_deduplicates`: verified RED before the fix (second identical tile returned `Reference`) and GREEN after. Asserts `None` never emits a `Reference` and never populates `references()`/`distinct_count()`.

Local mirror green: `make fmt`, `make clippy`, `make test`, plus `cargo +nightly miri test` on the new reproducer.

Closes #99