### PR TITLE
Remove dead in-engine resume plumbing; fix live-path level + byte accounting

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
@@ -427,26 +426,22 @@ pub(crate) fn generate_pyramid_observed(
     config: &EngineConfig,
     observer: &dyn EngineObserver,
 ) -> Result<EngineResult, EngineError> {
-    run_pyramid(source, plan, sink, config, observer, None, None)
+    run_pyramid(source, plan, sink, config, observer)
 }
 
-/// Internal driver shared by both `generate_pyramid_observed` and
-/// `generate_pyramid_resumable`.
+/// Internal driver behind [`generate_pyramid_observed`].
 ///
-/// `skip_coords` (optional): tiles that should not be re-emitted because they
-/// were recorded as complete in an incoming checkpoint.
-///
-/// `checkpoint_state` (optional): when supplied, the engine persists the
-/// running `JobMetadata` to `sink.checkpoint_root()/.libviprs-job.json`
-/// every `config.checkpoint_every` tiles (and once at the end).
+/// Resume is handled one layer up, in [`crate::engine_builder`]: the builder
+/// wraps the user sink in a `ResumeAwareSink` that filters already-completed
+/// coordinates and advances the on-disk [`CheckpointState`]. The engine driver
+/// itself is intentionally resume-oblivious — it walks the whole plan and hands
+/// every tile to the (possibly wrapping) sink.
 fn run_pyramid(
     source: &Raster,
     plan: &PyramidPlan,
     sink: &dyn TileSink,
     config: &EngineConfig,
     observer: &dyn EngineObserver,
-    skip_coords: Option<&HashSet<TileCoord>>,
-    checkpoint_state: Option<&CheckpointState>,
 ) -> Result<EngineResult, EngineError> {
     let started = Instant::now();
     #[cfg(feature = "tracing")]
@@ -501,8 +496,6 @@ fn run_pyramid(
         queue_pressure_peak: &queue_pressure_peak,
         stage_encode: &stage_encode,
         stage_sink: &stage_sink,
-        skip_coords,
-        checkpoint_state,
     };
 
     // Process from top level (full res) down to level 0 (1×1)
@@ -553,11 +546,6 @@ fn run_pyramid(
         tiles_produced += level_tiles;
         tiles_skipped += level_skipped;
 
-        // Record level completion into the optional checkpoint.
-        if let Some(cp) = checkpoint_state {
-            cp.mark_level_completed(level.level, level.tile_count());
-        }
-
         observer.on_event(EngineEvent::LevelCompleted {
             level: level.level,
             tiles_produced: level_tiles,
@@ -576,13 +564,6 @@ fn run_pyramid(
         sink_finish_start.elapsed().as_nanos() as u64,
         Ordering::Relaxed,
     );
-
-    // Flush a final checkpoint — ensures the on-disk `.libviprs-job.json`
-    // reflects every tile emitted by the run (not only those that landed on
-    // a `checkpoint_every` boundary).
-    if let Some(cp) = checkpoint_state {
-        cp.flush().map_err(EngineError::from)?;
-    }
 
     observer.on_event(EngineEvent::Finished {
         total_tiles: tiles_produced,
@@ -623,14 +604,6 @@ struct EmitContext<'a> {
     queue_pressure_peak: &'a AtomicU32,
     stage_encode: &'a AtomicU64,
     stage_sink: &'a AtomicU64,
-    /// Tiles that have already been written on a previous run (from a resume
-    /// checkpoint). When `Some`, tiles matching an entry are skipped without
-    /// calling the sink.
-    skip_coords: Option<&'a HashSet<TileCoord>>,
-    /// Running on-disk checkpoint. When present, each successful write is
-    /// appended to it, and when `config.checkpoint_every` is non-zero the
-    /// checkpoint is flushed to disk periodically.
-    checkpoint_state: Option<&'a CheckpointState>,
 }
 
 /// Mutable, shared state for the on-disk resume checkpoint.
@@ -695,9 +668,9 @@ impl CheckpointState {
     }
 
     /// Promote the level to `levels_completed` only when every tile in that
-    /// level is present in `completed_tiles`. Called by `run_pyramid` after
-    /// each level's inner loop returns, with `expected_tiles` set to the
-    /// level's full [`LevelPlan::tile_count`].
+    /// level is present in `completed_tiles`. Called by the builder's resume
+    /// path once the run returns, with `expected_tiles` set to the level's
+    /// full [`LevelPlan::tile_count`].
     ///
     /// A level in which [`FailurePolicy::RetryThenSkip`] dropped one or more
     /// tiles never has all of its coordinates recorded (skipped tiles call
@@ -707,7 +680,7 @@ impl CheckpointState {
     /// `completed_tiles`") would be violated, and a consumer honouring the
     /// documented "skip whole levels" resume optimisation would treat the
     /// failure-skipped tiles as done — permanently unrecoverable (issue #125).
-    fn mark_level_completed(&self, level: u32, expected_tiles: u64) {
+    pub(crate) fn mark_level_completed(&self, level: u32, expected_tiles: u64) {
         let mut meta = self.meta.lock().unwrap();
         let recorded = meta
             .completed_tiles
@@ -1286,13 +1259,6 @@ fn extract_and_emit_level(
                 // so a long single-threaded level can be stopped promptly.
                 config.check_cancelled()?;
                 let coord = TileCoord::new(level, col, row);
-                // Honor the resume checkpoint: tiles already present on disk
-                // (per an inbound `.libviprs-job.json`) are not re-emitted.
-                if let Some(skip) = ctx.skip_coords {
-                    if skip.contains(&coord) {
-                        continue;
-                    }
-                }
                 let encode_start = Instant::now();
                 let tile_raster = extract_tile(raster, plan, coord, config.background_rgb)?;
                 ctx.stage_encode
@@ -1316,9 +1282,6 @@ fn extract_and_emit_level(
                         ctx.stage_sink
                             .fetch_add(sink_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
                         ctx.bytes_written.fetch_add(tile_bytes, Ordering::Relaxed);
-                        if let Some(cp) = ctx.checkpoint_state {
-                            cp.mark_tile_completed(coord).map_err(EngineError::from)?;
-                        }
                     }
                     Err(e) => {
                         ctx.stage_sink
@@ -1470,15 +1433,12 @@ fn extract_and_emit_parallel(
     // MemoryTracker never charged); borrowing keeps the real peak in line
     // with `peak_memory_bytes`.
 
-    // Collect tile coordinates for this level, honouring the resume
-    // checkpoint: tiles flagged as already complete are elided here so
-    // neither the producer nor consumer do any work for them.
+    // Collect every tile coordinate for this level. Resume filtering happens
+    // in the builder's `ResumeAwareSink`, not here — the engine walks the
+    // whole plan and lets the wrapping sink short-circuit already-completed
+    // writes.
     let coords: Vec<TileCoord> = (0..level_plan.rows)
         .flat_map(|row| (0..level_plan.cols).map(move |col| TileCoord::new(level, col, row)))
-        .filter(|coord| match ctx.skip_coords {
-            Some(skip) => !skip.contains(coord),
-            None => true,
-        })
         .collect();
 
     if coords.is_empty() {
@@ -1570,9 +1530,6 @@ fn extract_and_emit_parallel(
                     ctx.stage_sink
                         .fetch_add(sink_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
                     ctx.bytes_written.fetch_add(tile_bytes, Ordering::Relaxed);
-                    if let Some(cp) = ctx.checkpoint_state {
-                        cp.mark_tile_completed(coord).map_err(EngineError::from)?;
-                    }
                 }
                 Err(e) => {
                     ctx.stage_sink

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -676,6 +676,20 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                 }
             };
 
+            // Advance `levels_completed` under the live resume path. The
+            // engine driver no longer touches the checkpoint (resume lives
+            // entirely in `ResumeAwareSink`), so level promotion has to happen
+            // here, once every tile the run was going to emit has passed
+            // through the wrapper. `mark_level_completed` is gated on every
+            // tile of the level being present in `completed_tiles`, so a level
+            // left partial by a failed run — or by `RetryThenSkip` dropping a
+            // tile — is withheld rather than falsely recorded (issue #125).
+            if let Some(cp) = cp.as_ref() {
+                for level in &plan.levels {
+                    cp.mark_level_completed(level.level, level.tile_count());
+                }
+            }
+
             // Persist the checkpoint whether the run succeeded or failed.
             // On the error path this is the only chance to make completed
             // tiles durable: an interrupted run (kill -9 / OOM / preemption
@@ -705,6 +719,16 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             let skipped = wrapped.skipped_count();
             if skipped > 0 {
                 result.tiles_produced = result.tiles_produced.saturating_sub(skipped);
+            }
+
+            // The monolithic engine credits `bytes_written` on every `Ok`
+            // returned by the sink, including the wrapper's short-circuited
+            // skips. Subtract the bytes of the skipped tiles so `bytes_written`
+            // counts only tiles this run actually emitted rather than every
+            // tile the engine visited.
+            let skipped_bytes = wrapped.skipped_bytes();
+            if skipped_bytes > 0 {
+                result.bytes_written = result.bytes_written.saturating_sub(skipped_bytes);
             }
             return Ok((result, sink));
         }
@@ -998,6 +1022,12 @@ mod resume {
         /// callers see "tiles actually written this run" rather than
         /// "tiles the engine visited".
         pub(super) skipped: AtomicU64,
+        /// Running sum of the payload bytes of skipped tiles. The monolithic
+        /// engine credits `bytes_written` on every `Ok` from the sink — and a
+        /// short-circuited skip returns `Ok` without writing anything — so the
+        /// engine over-counts by exactly this many bytes. The builder subtracts
+        /// it after the run so `bytes_written` reflects bytes actually emitted.
+        pub(super) skipped_bytes: AtomicU64,
     }
 
     impl<'a, S: TileSink + ?Sized> ResumeAwareSink<'a, S> {
@@ -1011,11 +1041,16 @@ mod resume {
                 skip,
                 cp,
                 skipped: AtomicU64::new(0),
+                skipped_bytes: AtomicU64::new(0),
             }
         }
 
         pub(super) fn skipped_count(&self) -> u64 {
             self.skipped.load(Ordering::Relaxed)
+        }
+
+        pub(super) fn skipped_bytes(&self) -> u64 {
+            self.skipped_bytes.load(Ordering::Relaxed)
         }
     }
 
@@ -1023,6 +1058,8 @@ mod resume {
         fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
             if self.skip.contains(&tile.coord) {
                 self.skipped.fetch_add(1, Ordering::Relaxed);
+                self.skipped_bytes
+                    .fetch_add(tile.raster.data().len() as u64, Ordering::Relaxed);
                 return Ok(());
             }
             self.inner.write_tile(tile)?;
@@ -1785,5 +1822,107 @@ mod auto_budget_routing_tests {
                  engine and surface BudgetExceeded, got {other:?}"
             ),
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Live-resume bookkeeping (issue #136)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod live_resume_bookkeeping_tests {
+    use super::*;
+    use crate::pixel::PixelFormat;
+    use crate::planner::{Layout, PyramidPlanner};
+    use crate::raster::Raster;
+    use crate::resume::{JobCheckpoint, ResumePolicy};
+    use crate::sink::FsSink;
+
+    fn solid_source() -> Raster {
+        // 8x8 RGB solid so every tile is non-blank and actually written.
+        let data = vec![10u8; 8 * 8 * 3];
+        Raster::new(8, 8, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    fn solid_plan() -> PyramidPlan {
+        PyramidPlanner::new(8, 8, 2, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan()
+    }
+
+    /// Resume is driven entirely by the builder's `ResumeAwareSink`, which used
+    /// to skip only the *write* while never touching `levels_completed` and
+    /// while the monolithic engine still credited `bytes_written` for every
+    /// short-circuited skip (it sees the wrapper's `Ok` and cannot tell a real
+    /// write from a skip).
+    ///
+    /// Before the fix (RED):
+    ///   * `levels_completed` stayed empty after a completed run — the live
+    ///     path never advanced it.
+    ///   * a fully-resumed run reported `bytes_written > 0` even though it
+    ///     emitted nothing, because the engine counted the skipped tiles.
+    ///
+    /// After the fix (GREEN): the builder promotes every fully-emitted level
+    /// and subtracts the skipped tiles' bytes, so `levels_completed` is
+    /// complete and a no-op resume reports `bytes_written == 0`.
+    #[test]
+    fn resume_advances_levels_and_excludes_skipped_bytes() {
+        let out = tempfile::tempdir().unwrap();
+        let cp = tempfile::tempdir().unwrap();
+        let source = solid_source();
+        let plan = solid_plan();
+        let level_count = plan.levels.len();
+
+        // Run 1: full render. Seeds the on-disk checkpoint (completed_tiles
+        // and, after the fix, levels_completed).
+        let sink1 = FsSink::new(out.path().to_path_buf(), plan.clone());
+        let r1 = EngineBuilder::new(&source, plan.clone(), sink1)
+            .with_engine(EngineKind::Monolithic)
+            .with_resume(
+                ResumePolicy::resume()
+                    .with_checkpoint_root(cp.path())
+                    .with_checkpoint_every(1),
+            )
+            .run()
+            .expect("initial render must succeed");
+        assert!(
+            r1.bytes_written > 0,
+            "the first run writes real tiles, so bytes_written must be non-zero"
+        );
+
+        // The live resume path must advance levels_completed for every level
+        // whose tiles were all emitted.
+        let meta = JobCheckpoint::load(cp.path())
+            .expect("checkpoint load must not error")
+            .expect("a resume run must leave a checkpoint on disk");
+        assert_eq!(
+            meta.levels_completed.len(),
+            level_count,
+            "every fully-emitted level must be recorded in levels_completed, \
+             got {:?}",
+            meta.levels_completed
+        );
+
+        // Run 2: resume over the same checkpoint. Every tile is already
+        // recorded, so ResumeAwareSink short-circuits all writes.
+        let sink2 = FsSink::new(out.path().to_path_buf(), plan.clone());
+        let r2 = EngineBuilder::new(&source, plan.clone(), sink2)
+            .with_engine(EngineKind::Monolithic)
+            .with_resume(
+                ResumePolicy::resume()
+                    .with_checkpoint_root(cp.path())
+                    .with_checkpoint_every(1),
+            )
+            .run()
+            .expect("resume run must succeed");
+
+        assert_eq!(
+            r2.tiles_produced, 0,
+            "a fully-resumed run must not report any tiles produced"
+        );
+        assert_eq!(
+            r2.bytes_written, 0,
+            "tiles skipped on resume must not be counted as bytes_written"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`run_pyramid` carried `skip_coords`/`checkpoint_state` parameters that were **always `None`** — `generate_pyramid_observed` is the only caller and passes `None, None`. Every in-engine skip filter, `mark_tile_completed` call, level promotion and final flush was therefore unreachable. Real resume runs one layer up through the builder's `ResumeAwareSink`, which only short-circuits the *write*.

This removes the dead parameters (and the now-unused `EmitContext` fields and skip filters) so the driver is honestly resume-oblivious, then fixes the two correctness gaps that lived on the actual live path:

- **`levels_completed` never advanced.** The builder now promotes every level whose tiles were all emitted, once the run returns. `mark_level_completed` remains gated on completeness, so a level left partial by a failed run or a `RetryThenSkip` drop is withheld (issue #125 invariant preserved).
- **`bytes_written` over-counted.** The monolithic engine credits bytes on every `Ok` from the sink — including the wrapper's short-circuited skips — so a resumed run reported bytes it never wrote. `ResumeAwareSink` now tracks the skipped tiles' payload bytes and the builder subtracts them.

## Test

New reproducer `resume_advances_levels_and_excludes_skipped_bytes`: a full render must record `levels_completed`; a fully-resumed run must report `tiles_produced == 0` and `bytes_written == 0`. Both assertions fail before the fix (verified RED independently: `levels_completed == []`; `bytes_written == 264`) and pass after.

Local mirror: `make fmt`, `make clippy` (both feature sets), `make test` (331 lib + integration), and `make loom` all green.

## Scope note

Extraction-skip on resume for the **streaming/mapreduce** engines would require wiring native skip into `streaming.rs`/`streaming_mapreduce.rs` (out of this PR's file scope) and those engines already report `bytes_written: 0`. This PR takes the acceptance-criteria alternative — the dead monolithic-only plumbing is removed — and fixes the live-path bookkeeping that affected every engine.

Closes #136