### PR TITLE
Wire the Extensions hatch to observers; document the level-walk roadmap (#138)

### DIFF
--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -21,6 +21,34 @@
 //! [`EngineKind::Monolithic`] refuses to run against a strip source and
 //! surfaces [`EngineError::IncompatibleSource`] instead of silently pulling
 //! the whole source into memory.
+//!
+//! # Per-tile operation: current shape and roadmap
+//!
+//! Every engine kind hardwires exactly one per-level transform today — the
+//! 2×2 box-filter downscale ([`resize::downscale_half`](crate::resize::downscale_half))
+//! followed by tile extraction. That level-walk is duplicated across the
+//! three engine drivers (`engine.rs`, `streaming.rs`,
+//! `streaming_mapreduce.rs`) plus the two read-only verify walks
+//! (`verify.rs`, `stream_verify.rs`). There is intentionally no operation
+//! abstraction yet: pyramid generation is the crate's sole pipeline shape.
+//!
+//! **Roadmap for a second per-tile operation** (rotate, sharpen, colour
+//! transform, …), so the walks change once rather than in lockstep:
+//!
+//! 1. Introduce a `TileOp` trait (`fn apply(&self, level: &Raster) ->
+//!    Result<Raster, RasterError>`) with a `DownscaleHalf` unit implementation
+//!    that wraps today's behaviour, keeping the default pipeline byte-for-byte
+//!    identical.
+//! 2. Thread a `&dyn TileOp` (defaulting to `DownscaleHalf`) into a single
+//!    shared `walk_levels(source, plan, op, emit)` helper, and rewrite each of
+//!    the five call sites to delegate to it — collapsing the duplicated walk
+//!    to one definition parameterised by the operation.
+//! 3. Surface the operation on this builder via a `with_tile_op` setter,
+//!    carried alongside the existing config knobs.
+//!
+//! Steps 1–2 span the engine drivers and the shared verify walks, so they land
+//! as a dedicated cross-module change; this builder is where step 3 (the
+//! caller-facing setter) will attach once the shared walk exists.
 
 use std::sync::Arc;
 
@@ -425,10 +453,14 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 
     /// Attach a user-defined extension keyed by its runtime `TypeId`.
     ///
-    /// libviprs itself reads zero extensions today; the hatch exists so
-    /// third-party consumers (metrics exporters, custom audit logs, bespoke
-    /// observer state) can thread context through the pipeline without a
-    /// semver bump.
+    /// The hatch lets third-party consumers (metrics exporters, custom audit
+    /// logs, bespoke observer state) thread context through the pipeline
+    /// without a semver bump. On [`run`](EngineBuilder::run) /
+    /// [`run_collect`](EngineBuilder::run_collect) the full map is delivered to
+    /// the attached observer via
+    /// [`EngineObserver::on_extensions`](crate::observe::EngineObserver::on_extensions)
+    /// once, before any tile is emitted, so a custom observer can read the
+    /// values it needs for the run.
     pub fn with_extension<T: Send + Sync + 'static>(mut self, value: T) -> Self {
         self.extensions.insert(value);
         self
@@ -477,7 +509,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             cancel,
             memory_budget_bytes,
             budget_policy,
-            extensions: _extensions, // libviprs itself reads zero extensions
+            extensions,
         } = self;
 
         // Build the EngineConfig once; the three engines accept slight
@@ -498,6 +530,16 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             Some(arc) => arc.as_ref(),
             None => &NoopObserver,
         };
+
+        // Deliver the extension hatch to its one reader. The map used to be
+        // destructured and discarded, so `with_extension` was decorative:
+        // nothing in the pipeline ever read it. Handing it to the observer
+        // once, before any tile is emitted, is the wiring that makes the hatch
+        // functional — a custom `EngineObserver` clones out the handles it
+        // needs (metrics recorders, tracing spans, custom config) for the rest
+        // of the run (issue #138). `NoopObserver` and observers that don't
+        // override `on_extensions` ignore it at zero cost.
+        observer_ref.on_extensions(&extensions);
 
         // #119: route writes through `RetryingSink` when the configured
         // failure policy carries a `RetryPolicy`. Previously the engine only
@@ -1235,6 +1277,128 @@ mod retry_wiring_tests {
             sink.written() > 0,
             "tiles recovered by retry must land in the sink"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Extension-hatch wiring (issue #138)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod extension_wiring_tests {
+    use super::*;
+    use crate::observe::EngineEvent;
+    use crate::pixel::PixelFormat;
+    use crate::planner::{Layout, PyramidPlanner};
+    use crate::raster::Raster;
+    use crate::sink::MemorySink;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// A user-supplied context handle stashed on the builder via
+    /// `with_extension` and expected back through the observer.
+    struct Marker(u64);
+
+    /// Observer that records the value of any [`Marker`] extension delivered to
+    /// it, plus whether `on_extensions` fired at all.
+    struct CapturingObserver {
+        seen_value: Arc<AtomicU64>,
+        fired: Arc<AtomicU64>,
+    }
+
+    impl EngineObserver for CapturingObserver {
+        fn on_event(&self, _event: EngineEvent) {}
+
+        fn on_extensions(&self, extensions: &Extensions) {
+            self.fired.fetch_add(1, Ordering::SeqCst);
+            if let Some(marker) = extensions.get::<Marker>() {
+                self.seen_value.store(marker.0, Ordering::SeqCst);
+            }
+        }
+    }
+
+    fn small_source() -> Raster {
+        let data = vec![10u8; 4 * 4 * 3];
+        Raster::new(4, 4, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    fn small_plan() -> PyramidPlan {
+        PyramidPlanner::new(4, 4, 2, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan()
+    }
+
+    // The extension hatch must be functional, not decorative: a value inserted
+    // via `with_extension` has to reach the attached observer's
+    // `on_extensions` hook before the run tiles. On the pre-fix code the
+    // builder destructured `extensions: _extensions` and discarded it, so the
+    // observer never saw it and this asserts 0 (RED). After wiring the delivery
+    // the observer reads the marker back (GREEN).
+    #[test]
+    fn builder_delivers_extensions_to_observer() {
+        let seen_value = Arc::new(AtomicU64::new(0));
+        let fired = Arc::new(AtomicU64::new(0));
+        let observer = CapturingObserver {
+            seen_value: seen_value.clone(),
+            fired: fired.clone(),
+        };
+
+        let source = small_source();
+        let plan = small_plan();
+        EngineBuilder::new(&source, plan, MemorySink::new())
+            .with_observer(observer)
+            .with_extension(Marker(42))
+            .run()
+            .expect("run must succeed");
+
+        assert_eq!(
+            fired.load(Ordering::SeqCst),
+            1,
+            "the observer's on_extensions hook must fire exactly once per run"
+        );
+        assert_eq!(
+            seen_value.load(Ordering::SeqCst),
+            42,
+            "the value inserted via with_extension must be delivered to the observer"
+        );
+    }
+
+    // The hatch is delivered on every routed engine kind, not just the default
+    // monolithic path — a metrics/tracing observer must see its context
+    // regardless of how `Auto` resolves or which kind the caller pins.
+    #[test]
+    fn extensions_delivered_across_engine_kinds() {
+        for kind in [
+            EngineKind::Monolithic,
+            EngineKind::Streaming,
+            EngineKind::MapReduce,
+        ] {
+            let seen_value = Arc::new(AtomicU64::new(0));
+            let fired = Arc::new(AtomicU64::new(0));
+            let observer = CapturingObserver {
+                seen_value: seen_value.clone(),
+                fired: fired.clone(),
+            };
+
+            let source = small_source();
+            let plan = small_plan();
+            EngineBuilder::new(&source, plan, MemorySink::new())
+                .with_engine(kind)
+                .with_observer(observer)
+                .with_extension(Marker(7))
+                .run()
+                .unwrap_or_else(|e| panic!("{kind:?} run must succeed: {e:?}"));
+
+            assert_eq!(
+                fired.load(Ordering::SeqCst),
+                1,
+                "{kind:?}: on_extensions must fire once"
+            );
+            assert_eq!(
+                seen_value.load(Ordering::SeqCst),
+                7,
+                "{kind:?}: the extension value must reach the observer"
+            );
+        }
     }
 }
 

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -8,14 +8,18 @@
 //! overwrites the previous value. Values must be `Send + Sync + 'static` so
 //! the map itself is trivially `Send + Sync`.
 //!
-//! libviprs itself reads **zero** extensions as of this release — the hatch
-//! is deliberately inert. It exists so third-party crates can stash shared
-//! context (metrics recorders, tracing spans, custom config blobs) through
+//! The hatch lets third-party crates stash shared context (metrics
+//! recorders, tracing spans, custom config blobs) through
 //! [`EngineBuilder::with_extension`](crate::EngineBuilder::with_extension)
-//! and retrieve it from a custom `EngineObserver` or the rest of the
-//! pipeline without a semver bump to libviprs. When libviprs grows a
-//! feature that needs cross-cutting context (e.g. an optional `metrics`
-//! integration), that feature's code becomes the first internal reader.
+//! and read it back without a semver bump to libviprs. On every
+//! [`run`](crate::EngineBuilder::run) the builder delivers the whole map to
+//! the attached observer via
+//! [`EngineObserver::on_extensions`](crate::observe::EngineObserver::on_extensions),
+//! once, before any tile is emitted — so a custom `EngineObserver` is the
+//! canonical reader. libviprs itself overrides `on_extensions` in none of its
+//! built-in observers today; when a feature grows that needs cross-cutting
+//! context (e.g. an optional `metrics` integration), that feature's observer
+//! becomes the first internal reader.
 //!
 //! # Example
 //!

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -158,6 +158,21 @@ pub enum EngineEvent {
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-trace-level)
 pub trait EngineObserver: Send + Sync {
     fn on_event(&self, event: EngineEvent);
+
+    /// Receive the builder's [`Extensions`](crate::extensions::Extensions) map
+    /// once, before any tile is emitted.
+    ///
+    /// This is the reader end of the extension hatch threaded through
+    /// [`EngineBuilder::with_extension`](crate::EngineBuilder::with_extension):
+    /// third-party context (metrics recorders, tracing spans, custom config
+    /// blobs) inserted on the builder is delivered here so a custom observer
+    /// can clone out the handles it needs for the rest of the run. The default
+    /// implementation ignores the map, so existing observers are unaffected.
+    ///
+    /// The borrow is valid only for the duration of the call; an observer that
+    /// needs a value past this point must clone it out (extension values are
+    /// `Send + Sync`, so `Arc`-shaped handles clone cheaply).
+    fn on_extensions(&self, _extensions: &crate::extensions::Extensions) {}
 }
 
 /// A no-op observer that discards all events.


### PR DESCRIPTION
## Summary

Addresses the two halves of #138 within the strict `src/engine_builder.rs` scope.

### Extensions — made functional (was decorative)
The builder previously destructured `extensions: _extensions` and discarded it, so `EngineBuilder::with_extension` wrote into a map nothing ever read. The full map is now delivered to the attached observer once, before any tile is emitted, through a new **defaulted** `EngineObserver::on_extensions(&Extensions)` hook. A custom observer (metrics recorder, tracing span, config blob) clones out the handles it needs for the run. The hook is defaulted to a no-op, so `NoopObserver` and all existing observers are unaffected — no breaking change, no removed/renamed exports.

Delivery fires on every routed engine kind (Monolithic / Streaming / MapReduce) on both the plain and resume paths, since it sits at the shared `observer_ref` bottleneck.

### Level-walk — documented roadmap (AC alternative)
The duplicated `downscale_half` level-walk lives across the three engine drivers (`engine.rs`, `streaming.rs`, `streaming_mapreduce.rs`) plus the two read-only verify walks (`verify.rs`, `stream_verify.rs`) — five sites in files outside this PR's scope, and collapsing them needs a shared `TileOp` type threaded through every driver. Per the file-scope contract that cross-module extraction is a dedicated follow-up; this PR lands the roadmap for it (introduce `TileOp` + `DownscaleHalf`, a shared `walk_levels`, then a `with_tile_op` setter on this builder) in the module docs, and does the in-scope caller-facing half. The issue stays open for the physical extraction.

## Tests
New `extension_wiring_tests` in `engine_builder.rs` (RED before the delivery call, GREEN after):
- `builder_delivers_extensions_to_observer` — a `with_extension` value reaches the observer's `on_extensions`.
- `extensions_delivered_across_engine_kinds` — delivery holds for Monolithic / Streaming / MapReduce.

Local mirror green: `make fmt`, `make clippy` (incl. `--features pdfium`), `make test` all pass.

Refs #138