### PR TITLE
Remove dead ResumeError::PlanHashMismatch and VerifyError::Mismatch variants

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -223,9 +223,10 @@ pub enum VerifyError {
     /// oracle.
     #[error("manifest tile path escapes pyramid directory: {0}")]
     UnsafePath(String),
-
-    #[error("checksum mismatch")]
-    Mismatch,
+    // NOTE: per-tile checksum mismatches are *not* errors — `verify_output`
+    // records them in [`VerifyReport::tiles_mismatched`] and still returns
+    // `Ok`. `VerifyError` is reserved for structural failures (manifest
+    // missing, unparseable, malformed, or an unsafe tile path).
 }
 
 // ---------------------------------------------------------------------------
@@ -447,6 +448,52 @@ mod tests {
         let missing = dir.path().join("nope.raw");
         let err = hash_file(&missing, ChecksumAlgo::Blake3).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn verify_output_reports_tile_mismatch_in_report_not_as_error() {
+        // The "real condition" the removed `VerifyError::Mismatch` variant was
+        // meant to represent: a tile whose on-disk bytes do not hash to the
+        // recorded digest. By design that is NOT an error — `verify_output`
+        // returns `Ok` and records the offending tile in
+        // `VerifyReport::tiles_mismatched`. This pins that contract so no one
+        // re-introduces a context-free error variant for a per-tile mismatch.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // A tile whose bytes match its recorded digest, and one whose do not.
+        let ok_bytes = b"good tile bytes";
+        let bad_bytes = b"actual bytes on disk";
+        std::fs::create_dir_all(root.join("0")).unwrap();
+        std::fs::write(root.join("0/0_0.raw"), ok_bytes).unwrap();
+        std::fs::write(root.join("0/1_0.raw"), bad_bytes).unwrap();
+
+        let ok_digest = hash_tile(ok_bytes, ChecksumAlgo::Blake3);
+        // A digest that deliberately disagrees with `bad_bytes`.
+        let wrong_digest = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert_ne!(hash_tile(bad_bytes, ChecksumAlgo::Blake3), wrong_digest);
+
+        let manifest = serde_json::json!({
+            "checksums": {
+                "algo": "blake3",
+                "per_tile": {
+                    "0/0_0.raw": ok_digest,
+                    "0/1_0.raw": wrong_digest,
+                }
+            }
+        });
+        std::fs::write(
+            root.join("manifest.json"),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let report =
+            verify_output(root).expect("a per-tile mismatch must not be a structural error");
+        assert_eq!(report.tiles_checked, 2);
+        assert_eq!(report.tiles_ok, 1);
+        assert!(report.tiles_missing.is_empty());
+        assert_eq!(report.tiles_mismatched, vec![PathBuf::from("0/1_0.raw")]);
     }
 
     #[test]

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -368,22 +368,19 @@ pub(super) mod tile_coord_vec_serde {
 /// Errors that can occur while reading, writing, or validating a checkpoint.
 ///
 /// `Io(io::Error)` wraps filesystem failures from the underlying
-/// [`std::fs`] calls; `PlanHashMismatch` and `SchemaMismatch` surface
-/// semantic incompatibilities that make it unsafe to resume.
+/// [`std::fs`] calls; `SchemaMismatch` surfaces a semantic incompatibility
+/// that makes it unsafe to resume.
+///
+/// A checkpoint whose `plan_hash` disagrees with the current plan is *not*
+/// reported here: that divergence is detected at the resume gate
+/// ([`verify_checkpoint_contract`]) and surfaced to callers as
+/// [`crate::engine::EngineError::PlanHashMismatch`], which carries the
+/// additional format-change context a fixed-field checkpoint error could not.
 ///
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-resume)
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ResumeError {
-    /// The checkpoint's `plan_hash` disagrees with the current plan's hash.
-    /// Resuming would produce incoherent output, so the engine refuses.
-    #[error("plan hash mismatch: checkpoint records {expected}, current plan hashes to {actual}")]
-    PlanHashMismatch {
-        /// Hash stored in the checkpoint file.
-        expected: String,
-        /// Hash freshly computed from the current plan.
-        actual: String,
-    },
     /// The checkpoint's `schema_version` does not match [`SCHEMA_VERSION`].
     #[error("checkpoint schema mismatch: binary speaks version {expected}, file declares {found}")]
     SchemaMismatch {
@@ -801,8 +798,8 @@ pub fn compute_plan_hash(plan: &PyramidPlan, contract: &PlanContract<'_>) -> Str
 /// Because the format is folded into [`compute_plan_hash`], recomputing the
 /// expected hash straight from the live sink would flip the format bits and
 /// reject an otherwise valid checkpoint — the resume would fail with
-/// [`ResumeError::PlanHashMismatch`] purely because a wrapper was added or
-/// removed between the writing run and the resuming run.
+/// [`crate::engine::EngineError::PlanHashMismatch`] purely because a wrapper
+/// was added or removed between the writing run and the resuming run.
 ///
 /// To stay robust the geometry + content contract is re-hashed using the
 /// format that was **recorded when the checkpoint was written**
@@ -1222,6 +1219,34 @@ mod tests {
             verify_checkpoint_contract(&meta, &plan, &config, &jpeg).is_err(),
             "changing the tile format must invalidate the checkpoint"
         );
+    }
+
+    #[test]
+    fn plan_hash_divergence_surfaces_as_engine_error_not_a_resume_variant() {
+        // A checkpoint whose recorded `plan_hash` does not match the current
+        // plan is the "real condition" the removed `ResumeError::PlanHashMismatch`
+        // variant was documented to carry. It is NOT reported through
+        // `ResumeError`: the resume gate returns the freshly-computed hash and
+        // the engine layer maps it to `EngineError::PlanHashMismatch`. This
+        // test pins that boundary so nobody re-introduces a redundant
+        // checkpoint-error variant for a condition the engine already owns.
+        let plan = sample_plan();
+        let config = EngineConfig::default();
+        let png = FormatSink(Some(TileFormat::Png));
+
+        // A metadata blob whose plan_hash is garbage relative to the live plan.
+        let meta = sample_meta("0000000000000000000000000000000000000000000000000000000000000000");
+
+        let got = verify_checkpoint_contract(&meta, &plan, &config, &png)
+            .expect_err("a divergent plan_hash must be rejected by the resume gate");
+        // The gate hands back the *actual* hash for the engine to embed in
+        // `EngineError::PlanHashMismatch { expected, got }`.
+        assert_eq!(
+            got,
+            compute_plan_hash(&plan, &PlanContract::from_engine(&config, &png)),
+            "the resume gate must return the freshly computed hash for the engine error",
+        );
+        assert_ne!(got, meta.plan_hash, "the two hashes must actually differ");
     }
 
     #[test]

--- a/tests/non_exhaustive_enums.rs
+++ b/tests/non_exhaustive_enums.rs
@@ -110,7 +110,6 @@ fn assert_manifest_error_non_exhaustive(v: &ManifestError) {
 #[allow(dead_code)]
 fn assert_resume_error_non_exhaustive(v: &ResumeError) {
     match v {
-        ResumeError::PlanHashMismatch { .. } => {}
         ResumeError::SchemaMismatch { .. } => {}
         ResumeError::Corrupt { .. } => {}
         ResumeError::Io(..) => {}
@@ -129,7 +128,6 @@ fn assert_verify_error_non_exhaustive(v: &VerifyError) {
         VerifyError::BadField { .. } => {}
         VerifyError::UnknownAlgo(..) => {}
         VerifyError::UnsafePath(..) => {}
-        VerifyError::Mismatch => {}
         _ => {}
     }
 }


### PR DESCRIPTION
## Summary
Both `ResumeError::PlanHashMismatch` (resume.rs) and `VerifyError::Mismatch` (checksum.rs) were public enum variants that are **never constructed** anywhere in `src/`. This removes them, aligning the code with how the two conditions actually surface.

## Why removal (not production)
- **Plan-hash divergence** is detected at the resume gate (`verify_checkpoint_contract`) and surfaced to callers as `EngineError::PlanHashMismatch`, which carries extra format-change context a fixed-field `ResumeError` variant could not. The `ResumeError` variant duplicated that condition but was dead; its doc even claimed it was the surfaced error when reality uses the engine error.
- **Per-tile checksum mismatches** are recorded in `VerifyReport::tiles_mismatched` and are *not* errors — `verify_output` returns `Ok` on a mismatch by design. `VerifyError::Mismatch` had no real condition to attach to and carried no context.

Both enums are `#[non_exhaustive]`, so dropping a variant is not a breaking change for external matchers (they already need a `_` arm).

## Changes
- Remove the two dead variants.
- Realign the misleading `ResumeError` doc + intra-doc link to `EngineError::PlanHashMismatch`.
- Update the `tests/non_exhaustive_enums.rs` exhaustiveness guard.
- Add characterization tests pinning each removed variant's real condition: a divergent `plan_hash` is rejected by the resume gate (returning the freshly-computed hash for the engine error), and a per-tile byte mismatch lands in `VerifyReport::tiles_mismatched` with `verify_output` returning `Ok`.

## Testing
- `make fmt` clean
- `make clippy` clean (default + `pdfium`)
- `make test` green (343 lib + all integration incl. `non_exhaustive_enums`)

Closes #142