### PR TITLE
Export verify entry points so pub modules are usable

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -860,7 +860,7 @@ pub(crate) fn cp_for_sink(
 /// events so progress observers see verify runs as first-class.
 ///
 /// Strip-source equivalents live in [`crate::stream_verify`].
-pub(crate) fn raster_verify(
+pub fn raster_verify(
     source: &Raster,
     plan: &PyramidPlan,
     sink: &dyn TileSink,

--- a/src/stream_verify.rs
+++ b/src/stream_verify.rs
@@ -129,7 +129,7 @@ fn strip_layout_error(reason: String) -> EngineError {
 /// plan.levels.len()`, `duration = started.elapsed()`, every other counter
 /// zero. Verify never writes to the sink and never retries, so the
 /// write-side counters have no meaningful value to report.
-pub(crate) fn verify_from_strip_source(
+pub fn verify_from_strip_source(
     source: &dyn StripSource,
     plan: &PyramidPlan,
     sink: &dyn TileSink,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -14,5 +14,5 @@
 //! Both emit the same `LevelStarted` / `TileCompleted` / `LevelCompleted`
 //! / `Finished` event stream so observers see verify runs as first-class.
 
-pub(crate) use crate::engine::raster_verify;
-pub(crate) use crate::stream_verify::verify_from_strip_source;
+pub use crate::engine::raster_verify;
+pub use crate::stream_verify::verify_from_strip_source;

--- a/tests/verify_module_public_api.rs
+++ b/tests/verify_module_public_api.rs
@@ -1,0 +1,70 @@
+//! The `verify` and `stream_verify` modules are declared `pub mod` in the
+//! crate root, and their module docs advertise `raster_verify` /
+//! `verify_from_strip_source` as verify-mode entry points. This test compiles
+//! as an *external* crate, so it can only name items that are genuinely part
+//! of the public API — before issue #144 both entry points were `pub(crate)`,
+//! leaving the public modules with nothing a downstream caller could reach,
+//! and the very functions their docs linked to were unnameable from here.
+//!
+//! Each call below both (a) proves the public path resolves at compile time
+//! and (b) exercises the real early-return contract: verify against a sink
+//! with no on-disk checkpoint root must fail structurally with
+//! [`EngineError::VerifyRequiresOnDiskSink`] rather than walking any tiles.
+
+use libviprs::observe::NoopObserver;
+use libviprs::{
+    EngineConfig, EngineError, Layout, MemorySink, PixelFormat, PyramidPlanner, Raster,
+    RasterStripSource,
+};
+
+fn tiny_raster() -> Raster {
+    Raster::new(64, 64, PixelFormat::Rgb8, vec![0u8; 64 * 64 * 3]).unwrap()
+}
+
+/// `libviprs::verify::raster_verify` is reachable as public API and honours
+/// the "verify needs an on-disk sink" contract.
+#[test]
+fn raster_verify_is_public_and_requires_on_disk_sink() {
+    let src = tiny_raster();
+    let plan = PyramidPlanner::new(64, 64, 32, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    let sink = MemorySink::new();
+    let config = EngineConfig::default();
+    let observer = NoopObserver;
+
+    let result = libviprs::verify::raster_verify(&src, &plan, &sink, &config, &observer);
+
+    assert!(
+        matches!(result, Err(EngineError::VerifyRequiresOnDiskSink)),
+        "raster_verify against a checkpoint-less sink must fail structurally, got {result:?}"
+    );
+}
+
+/// `verify_from_strip_source` is reachable both through the `verify` façade
+/// module and its home `stream_verify` module, and honours the same contract.
+#[test]
+fn verify_from_strip_source_is_public_and_requires_on_disk_sink() {
+    let src = tiny_raster();
+    let plan = PyramidPlanner::new(64, 64, 32, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    let strip = RasterStripSource::new(&src);
+    let sink = MemorySink::new();
+    let config = EngineConfig::default();
+    let observer = NoopObserver;
+
+    let via_facade =
+        libviprs::verify::verify_from_strip_source(&strip, &plan, &sink, &config, &observer);
+    assert!(
+        matches!(via_facade, Err(EngineError::VerifyRequiresOnDiskSink)),
+        "verify::verify_from_strip_source against a checkpoint-less sink must fail structurally, got {via_facade:?}"
+    );
+
+    let via_home =
+        libviprs::stream_verify::verify_from_strip_source(&strip, &plan, &sink, &config, &observer);
+    assert!(
+        matches!(via_home, Err(EngineError::VerifyRequiresOnDiskSink)),
+        "stream_verify::verify_from_strip_source against a checkpoint-less sink must fail structurally, got {via_home:?}"
+    );
+}


### PR DESCRIPTION
## Problem
`pub mod verify` and `pub mod stream_verify` exported nothing usable: `raster_verify` and `verify_from_strip_source` were `pub(crate)`, and the module docs linked users to functions they could not call (lib.rs:71,74).

## Fix
Export the documented verify-mode entry points, consistent with the crate-root's stated convention of keeping helpers reachable behind their module path (`libviprs::module::fn`):
- `engine::raster_verify` and `stream_verify::verify_from_strip_source` are now `pub` (every type in their signatures was already public).
- `verify` re-exports both as `pub use`, so `libviprs::verify::{raster_verify, verify_from_strip_source}` resolve to the functions the module docs advertise.

No symbols removed or renamed; visibility is only widened, so existing consumers (`engine_builder`) are unaffected.

## Test
`tests/verify_module_public_api.rs` compiles as an external crate and invokes both entry points through their public paths, asserting the on-disk-sink contract (`EngineError::VerifyRequiresOnDiskSink`). Before the fix this test failed to compile with `E0603: function is private`; after, it passes.

Local mirror green: `make fmt && make clippy && make test` (all suites pass, incl. the new reproducer).

Closes #144