### PR TITLE
Unify the mutex-poison policy across sink/engine/dedupe/observe

### DIFF
--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -282,8 +282,10 @@ impl DedupeIndex {
         }
 
         // Single lock: update `refs` and `seen` atomically so readers never
-        // observe one populated without the other (Mara B5).
-        let mut state = self.state.lock().expect("dedupe state mutex poisoned");
+        // observe one populated without the other (Mara B5). Poison is
+        // recovered (crate::poison policy): the maps are structurally valid
+        // between operations, so a panicked prior holder must not cascade.
+        let mut state = crate::poison::recover(&self.state);
         state.refs.insert(path.to_string(), shared_key.clone());
 
         match state.seen.entry((algo_tag(algo), digest)) {
@@ -316,7 +318,7 @@ impl DedupeIndex {
     /// a symlink / hardlink and no manifest pointer is required). No-op if
     /// the path was never recorded.
     pub fn forget_reference(&self, path: &str) {
-        let mut state = self.state.lock().expect("dedupe state mutex poisoned");
+        let mut state = crate::poison::recover(&self.state);
         state.refs.remove(path);
     }
 
@@ -333,21 +335,13 @@ impl DedupeIndex {
     /// Returns a `BTreeMap` so callers that serialize the result get
     /// deterministic key order (dtolnay #5).
     pub fn references(&self) -> BTreeMap<String, String> {
-        self.state
-            .lock()
-            .expect("dedupe state mutex poisoned")
-            .refs
-            .clone()
+        crate::poison::recover(&self.state).refs.clone()
     }
 
     /// Total number of distinct content hashes seen so far. Useful for
     /// diagnostics and tests.
     pub fn distinct_count(&self) -> usize {
-        self.state
-            .lock()
-            .expect("dedupe state mutex poisoned")
-            .seen
-            .len()
+        crate::poison::recover(&self.state).seen.len()
     }
 }
 
@@ -618,6 +612,37 @@ mod tests {
             idx.distinct_count(),
             0,
             "None must not populate the seen index"
+        );
+    }
+
+    /// Reproducer for #117: a poisoned dedupe-state lock must not cascade a
+    /// second panic into every later `record` / `references` / `distinct_count`
+    /// call. We poison the state mutex under `catch_unwind`, then keep using the
+    /// index. Before the fix (`.lock().expect(...)`) each of these re-panicked
+    /// on the poison (RED); after it they recover the guard and preserve the
+    /// already-seen entries (GREEN).
+    #[test]
+    fn poisoned_dedupe_state_recovers_without_cascade() {
+        let idx = DedupeIndex::new(DedupeStrategy::Blanks);
+        let bytes = b"content that gets deduplicated";
+        let d1 = idx.record("0/0_0.png", bytes);
+        assert!(matches!(d1, DedupeDecision::WriteNew { .. }));
+
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = idx.state.lock().unwrap();
+            panic!("worker panic while holding the dedupe state lock");
+        }));
+        assert!(poisoned.is_err());
+        assert!(idx.state.is_poisoned());
+
+        // Recovered reads see the pre-poison entry, and a duplicate still
+        // resolves to a Reference — none of these may panic.
+        assert_eq!(idx.distinct_count(), 1);
+        assert_eq!(idx.references().len(), 1);
+        let d2 = idx.record("0/0_1.png", bytes);
+        assert!(
+            matches!(d2, DedupeDecision::Reference { .. }),
+            "duplicate must still dedupe after poison recovery; got {d2:?}"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -669,7 +669,7 @@ impl CheckpointState {
     /// checkpoint to disk so a crash can resume from the latest boundary.
     pub(crate) fn mark_tile_completed(&self, coord: TileCoord) -> Result<(), ResumeError> {
         {
-            let mut meta = self.meta.lock().unwrap();
+            let mut meta = crate::poison::recover(&self.meta);
             meta.completed_tiles.push(coord);
         }
         // Flush periodically. `checkpoint_every == 0` disables this path and
@@ -720,7 +720,7 @@ impl CheckpointState {
     /// documented "skip whole levels" resume optimisation would treat the
     /// failure-skipped tiles as done — permanently unrecoverable (issue #125).
     pub(crate) fn mark_level_completed(&self, level: u32, expected_tiles: u64) {
-        let mut meta = self.meta.lock().unwrap();
+        let mut meta = crate::poison::recover(&self.meta);
         let recorded = meta
             .completed_tiles
             .iter()
@@ -738,7 +738,7 @@ impl CheckpointState {
     /// via the tmp+rename dance inside [`JobCheckpoint::save`].
     pub(crate) fn flush(&self) -> Result<(), ResumeError> {
         let snapshot = {
-            let mut meta = self.meta.lock().unwrap();
+            let mut meta = crate::poison::recover(&self.meta);
             meta.last_checkpoint_at = now_rfc3339_engine();
             meta.clone()
         };
@@ -1870,6 +1870,44 @@ mod tests {
         // And the recorded set must still be fully recoverable.
         let loaded = JobCheckpoint::load(dir.path()).unwrap().unwrap();
         assert!(loaded.completed_tiles.len() >= 5_000);
+    }
+
+    /// Reproducer for #117: a poisoned checkpoint-`meta` lock must not cascade
+    /// a second panic into every later `mark_tile_completed` — which, on the
+    /// write path, would also abort the final checkpoint flush. We poison the
+    /// meta mutex under `catch_unwind`, then keep marking tiles. Before the fix
+    /// (`.lock().unwrap()`) the next mark panicked (RED); after it the guard is
+    /// recovered and the pre-poison completions survive (GREEN).
+    #[test]
+    fn poisoned_checkpoint_meta_recovers_without_cascade() {
+        use crate::resume::JobMetadata;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plan = PyramidPlanner::new(64, 64, 32, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+        let meta = JobMetadata::new("deadbeef".to_string(), "1970-01-01T00:00:00Z".into());
+        // checkpoint_every = 0 keeps the test off the disk-flush path so it
+        // isolates the in-memory `meta` lock recovery.
+        let cp = CheckpointState::new(dir.path().to_path_buf(), meta, &plan, 0);
+
+        cp.mark_tile_completed(TileCoord::new(0, 0, 0)).unwrap();
+
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = cp.meta.lock().unwrap();
+            panic!("worker panic while holding the checkpoint meta lock");
+        }));
+        assert!(poisoned.is_err());
+        assert!(cp.meta.is_poisoned());
+
+        // The lifecycle bookkeeping must keep working after the poison.
+        cp.mark_tile_completed(TileCoord::new(0, 1, 0)).unwrap();
+        cp.mark_level_completed(0, 1);
+        let recorded = crate::poison::recover(&cp.meta).completed_tiles.len();
+        assert_eq!(
+            recorded, 2,
+            "recovered meta must retain the pre-poison completion and accept new ones"
+        );
     }
 
     /// Issue #140: a checkpoint-write failure must surface as *one* variant

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod observe;
 pub mod pdf;
 pub mod pixel;
 pub mod planner;
+pub(crate) mod poison;
 pub mod raster;
 pub mod resize;
 pub mod resume;

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -230,12 +230,12 @@ impl CollectingObserver {
     /// Return a snapshot of all collected events so far, cloned from the
     /// internal mutex-protected buffer.
     pub fn events(&self) -> Vec<EngineEvent> {
-        self.events.lock().unwrap().clone()
+        crate::poison::recover(&self.events).clone()
     }
 
     /// Return the number of events collected so far.
     pub fn event_count(&self) -> usize {
-        self.events.lock().unwrap().len()
+        crate::poison::recover(&self.events).len()
     }
 }
 
@@ -247,7 +247,7 @@ impl Default for CollectingObserver {
 
 impl EngineObserver for CollectingObserver {
     fn on_event(&self, event: EngineEvent) {
-        self.events.lock().unwrap().push(event);
+        crate::poison::recover(&self.events).push(event);
     }
 }
 
@@ -395,6 +395,41 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /**
+     * Reproducer for #117: one panicking holder must not cascade its poison
+     * into a second panic on every later observer call. We poison the events
+     * mutex by panicking under `catch_unwind` while holding the guard, then
+     * exercise the public read/write surface.
+     *
+     * Before the fix (`.lock().unwrap()`), `event_count`, `events` and
+     * `on_event` all re-`unwrap()` the poisoned lock and panic (RED). After
+     * the fix they recover the guard via `crate::poison::recover` and keep the
+     * already-collected events, so the count grows past the poison (GREEN).
+     */
+    #[test]
+    fn poisoned_events_lock_recovers_without_cascade() {
+        let obs = CollectingObserver::new();
+        obs.on_event(EngineEvent::TileCompleted {
+            coord: TileCoord::new(0, 0, 0),
+        });
+
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = obs.events.lock().unwrap();
+            panic!("worker panic while holding the events lock");
+        }));
+        assert!(poisoned.is_err(), "the injected panic must unwind");
+        assert!(obs.events.is_poisoned(), "the lock must now be poisoned");
+
+        // None of these may panic under the recovered poison policy.
+        assert_eq!(obs.event_count(), 1);
+        assert_eq!(obs.events().len(), 1);
+        obs.on_event(EngineEvent::Finished {
+            total_tiles: 1,
+            levels: 1,
+        });
+        assert_eq!(obs.event_count(), 2);
     }
 
     /**

--- a/src/poison.rs
+++ b/src/poison.rs
@@ -1,0 +1,57 @@
+//! Crate-wide mutex-poison policy.
+//!
+//! A `std::sync::Mutex` becomes *poisoned* when a thread panics while holding
+//! its guard. By default the next `lock()` returns `Err(PoisonError)`, and the
+//! common `.lock().unwrap()` / `.expect(...)` idioms turn that into a *second*
+//! panic. In a tile run the worker threads all share the same sink / engine /
+//! dedupe / observer locks, so one panicking worker used to cascade: its poison
+//! re-panicked every subsequent `write_tile`, checkpoint append and observer
+//! callback, tearing down the whole run and losing the final checkpoint on the
+//! write path (issue #117).
+//!
+//! # The single policy
+//!
+//! **A poisoned lock is never re-raised as a panic.** How the poison is handled
+//! depends on whether the guarded state stays usable after a holder panics:
+//!
+//! * **Consistent-state locks — recover.** When the data behind the lock is a
+//!   plain in-memory collection, counter, or bookkeeping map (event logs,
+//!   collected tiles, checkpoint metadata, the dedupe `refs`/`seen` maps, the
+//!   `FsSink` leaf fields), a panic can only leave it *logically incomplete*,
+//!   never structurally corrupt — a `Vec`/`BTreeMap` is still a valid
+//!   `Vec`/`BTreeMap` between operations. These sites recover the guard via
+//!   [`recover`] (`unwrap_or_else(|p| p.into_inner())`) and carry on. Any
+//!   semantic gap (a missing digest, a not-yet-recorded reference) is caught
+//!   downstream by on-disk digest verification and checkpoint validation rather
+//!   than by aborting the run.
+//!
+//! * **Fragile write-path locks — fail cleanly.** When a panic can leave the
+//!   guarded state part-way through a mutation that later operations cannot
+//!   safely build on — the packfile's sequential archive writer, where a
+//!   half-written tar/zip entry would corrupt every subsequent append — the
+//!   poison is surfaced as a typed error on the fallible path
+//!   (`SinkError::Other`, see [`crate::sink_packfile`]) so the operation aborts
+//!   cleanly instead of recovering onto an unusable writer.
+//!
+//! Either way the outcome is the same: **one worker's panic can no longer
+//! cascade into unrelated panics elsewhere in the run.**
+//!
+//! New lock sites in `sink`/`engine`/`dedupe`/`observe` must follow this
+//! policy: call [`recover`] for consistent state, or convert the poison to a
+//! typed error on a fragile write path. Never `.lock().unwrap()` /
+//! `.lock().expect(...)`.
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Acquire `mutex`, recovering the guard if the lock is poisoned.
+///
+/// This is the [consistent-state](self#the-single-policy) half of the crate
+/// poison policy: a prior holder's panic leaves the guarded value logically
+/// incomplete but structurally valid, so we take the inner guard via
+/// [`std::sync::PoisonError::into_inner`] and continue instead of re-panicking.
+#[inline]
+pub(crate) fn recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -429,11 +429,11 @@ impl MemorySink {
     }
 
     pub fn tiles(&self) -> Vec<CollectedTile> {
-        self.tiles.lock().unwrap().clone()
+        crate::poison::recover(&self.tiles).clone()
     }
 
     pub fn tile_count(&self) -> usize {
-        self.tiles.lock().unwrap().len()
+        crate::poison::recover(&self.tiles).len()
     }
 }
 
@@ -445,7 +445,7 @@ impl Default for MemorySink {
 
 impl TileSink for MemorySink {
     fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
-        self.tiles.lock().unwrap().push(CollectedTile {
+        crate::poison::recover(&self.tiles).push(CollectedTile {
             coord: tile.coord,
             width: tile.raster.width(),
             height: tile.raster.height(),
@@ -696,10 +696,14 @@ impl<'a, T> LeafGuard<'a, T> {
             );
             d.set(1);
         });
-        // Poisoning propagates as before: a panicked writer leaves the sink's
-        // bookkeeping in an unknown state, so surfacing it is correct.
+        // Poison recovery (crate::poison policy): the leaf fields are plain
+        // in-memory collections that stay structurally valid between
+        // operations, so a panicked writer must not cascade its poison into a
+        // second panic on every subsequent tile write. We recover the guard and
+        // continue; any bookkeeping gap left by the panicked holder is caught
+        // downstream by on-disk digest verification, not by tearing down the run.
         LeafGuard {
-            inner: m.lock().unwrap(),
+            inner: crate::poison::recover(m),
         }
     }
 }
@@ -1214,7 +1218,7 @@ impl FsSink {
         // leave the first tile as a full private copy — breaking the
         // at-least-one-hardlink invariant (issue #111). Serialising here
         // makes the promote-on-2nd-hit sequence atomic.
-        let _promote = self.dedupe_promote.lock().unwrap();
+        let _promote = crate::poison::recover(&self.dedupe_promote);
 
         let decision = idx.record(rel_string, bytes);
         match decision {
@@ -1840,6 +1844,62 @@ mod tests {
             raster: Raster::zeroed(8, 8, PixelFormat::Rgb8).unwrap(),
             blank: false,
         }
+    }
+
+    /// Reproducer for #117: a poisoned `MemorySink` buffer must not cascade a
+    /// second panic into every later `write_tile` / `tiles` / `tile_count`.
+    /// Before the fix (`.lock().unwrap()`) the poison re-panicked (RED); after
+    /// it the guard is recovered and the already-collected tiles survive (GREEN).
+    #[test]
+    fn poisoned_memory_sink_recovers_without_cascade() {
+        let sink = MemorySink::new();
+        sink.write_tile(&make_tile(0, 0, 0)).unwrap();
+
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = sink.tiles.lock().unwrap();
+            panic!("worker panic while holding the MemorySink buffer lock");
+        }));
+        assert!(poisoned.is_err());
+        assert!(sink.tiles.is_poisoned());
+
+        assert_eq!(sink.tile_count(), 1);
+        assert_eq!(sink.tiles().len(), 1);
+        sink.write_tile(&make_tile(0, 1, 0)).unwrap();
+        assert_eq!(sink.tile_count(), 2);
+    }
+
+    /// Reproducer for #117 on the primary cascade site: the `FsSink` leaf-lock
+    /// chokepoint. One worker panic that poisons a leaf field mutex must not
+    /// turn every subsequent `write_tile` into a second panic (which, on the
+    /// write path, would also drop the final checkpoint). We poison the
+    /// `completed_tiles` leaf, then keep writing tiles. Before the fix
+    /// (`m.lock().unwrap()` in `LeafGuard::new`) the next write panicked (RED);
+    /// after it the guard recovers and the run continues (GREEN).
+    #[test]
+    fn poisoned_fs_sink_leaf_recovers_without_cascade() {
+        let planner = PyramidPlanner::new(8, 8, 256, 0, Layout::DeepZoom).unwrap();
+        let plan = planner.plan();
+        let dir = tempfile::tempdir().unwrap();
+        // Resume-enabled so `write_tile` records each coord into the
+        // `completed_tiles` leaf through the `lock_leaf` chokepoint.
+        let sink = FsSink::new(dir.path().join("out_files"), plan).with_resume(true);
+
+        sink.write_tile(&make_tile(0, 0, 0)).unwrap();
+
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = sink.completed_tiles.lock().unwrap();
+            panic!("worker panic while holding an FsSink leaf lock");
+        }));
+        assert!(poisoned.is_err());
+        assert!(sink.completed_tiles.is_poisoned());
+
+        // The write path must not cascade the poison into a second panic.
+        sink.write_tile(&make_tile(0, 0, 0)).unwrap();
+        let recorded = crate::poison::recover(&sink.completed_tiles).len();
+        assert_eq!(
+            recorded, 2,
+            "recovered leaf must retain the pre-poison bookkeeping and accept new writes"
+        );
     }
 
     // -- Transparent-decorator bookkeeping (issue #137) --

--- a/src/sink_packfile.rs
+++ b/src/sink_packfile.rs
@@ -228,6 +228,12 @@ impl PackfileSink {
 
     /// Append raw `bytes` to the archive under `archive_path`.
     fn append_bytes(&self, archive_path: &str, bytes: &[u8]) -> Result<(), SinkError> {
+        // Fragile-write-path branch of the crate poison policy (crate::poison):
+        // the archive writer appends sequentially, so a holder that panicked
+        // mid-entry leaves a half-written tar/zip that every later append would
+        // corrupt. We therefore do NOT recover the guard; we surface the poison
+        // as a typed error so the run aborts cleanly instead of building on an
+        // unusable writer.
         let mut guard = self
             .writer
             .lock()


### PR DESCRIPTION
## Problem

The mutex-poison policy was inconsistent across the crate: some sites recovered, some converted poison into a typed `SinkError`, and many `.lock().unwrap()`/`.expect(...)` cascade-panicked. One panicking worker poisoned a shared lock and turned every subsequent tile write / checkpoint append / observer call into a *second* panic, aborting the run (and, on the write path, dropping the final checkpoint).

## Fix

Introduce one documented policy in `src/poison.rs`: **a poisoned lock is never re-raised as a panic.**

- **Consistent-state locks recover.** Event logs, collected tiles, checkpoint metadata, the dedupe `refs`/`seen` maps, and the `FsSink` leaf fields are plain in-memory collections that stay structurally valid between operations, so they take the inner guard via `crate::poison::recover` (`into_inner`) and continue. Any semantic gap is caught downstream by on-disk digest verification / checkpoint validation.
- **Fragile write-path locks fail cleanly.** The packfile's sequential archive writer (a half-written tar/zip entry would corrupt every later append) keeps surfacing poison as a typed `SinkError` on the fallible path.

Applied at the `FsSink::lock_leaf` chokepoint (covers all leaf mutexes) plus `MemorySink`, `CheckpointState::meta`, `DedupeIndex::state`, and `CollectingObserver::events`.

## Tests

Reproducers in `observe`, `dedupe`, `engine`, and `sink` (both `MemorySink` and the `FsSink` write path) poison the lock under `catch_unwind`, then assert the public surface recovers instead of cascading a second panic. Verified RED before the fix (5 reproducers panic on the poison) and GREEN after.

Local mirror: `make fmt`, `make clippy`, `make test` all green (376 lib + integration tests).

Closes #117