### PR TITLE
resume: bound per-flush checkpoint I/O via append-only segment log (#127)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -634,8 +634,29 @@ pub(crate) struct CheckpointState {
     /// The directory where `.libviprs-job.json` lives — typically the sink's
     /// `base_dir`. Every call to [`CheckpointState::flush`] writes there.
     root: std::path::PathBuf,
-    /// Running metadata. Re-serialised on every flush.
+    /// Running metadata. Only its small scalar fields (schema, plan hash,
+    /// completed levels, timestamps, format) plus the fixed `inline` slice of
+    /// coordinates are re-serialised into the header on every flush; the bulk
+    /// of `completed_tiles` is persisted through the append-only segment log.
     meta: std::sync::Mutex<JobMetadata>,
+    /// Half-open range `inline_start..inline_end` inside `meta.completed_tiles`
+    /// identifying the coordinates that live *inline* in the JSON header rather
+    /// than in the segment log. These are the coordinates a resume loaded from
+    /// a header that did not already have them in the segment file (a legacy or
+    /// hand-written checkpoint). The range is fixed for the life of the run, so
+    /// the header stays a bounded size regardless of how many new tiles the run
+    /// completes (issue #127). For a fresh run and for a resume off an
+    /// engine-written segment log, this range is empty and the header carries
+    /// no coordinates at all.
+    inline_start: usize,
+    inline_end: usize,
+    /// Serialises flushes and tracks how many of `meta.completed_tiles` are
+    /// already durable in the segment log. Held across the append + header
+    /// rewrite so two workers cannot interleave partial segment frames. The
+    /// stored value is the exclusive upper index into `completed_tiles`
+    /// covered by the log so far; it starts at `inline_end` (everything known
+    /// at construction is either inline in the header or already in the log).
+    seg_cursor: std::sync::Mutex<usize>,
     /// Monotonically increasing count of tiles marked completed over the whole
     /// run. A flush is triggered whenever this counter lands on a multiple of
     /// `checkpoint_every`; it is never reset. Because [`AtomicU64::fetch_add`]
@@ -656,9 +677,24 @@ impl CheckpointState {
         _plan: &PyramidPlan,
         checkpoint_every: u64,
     ) -> Self {
+        // Coordinates already durable in the segment log occupy the front of
+        // `completed_tiles` (see `JobCheckpoint::load`, which lists segment
+        // coordinates first). Everything after that came from the header inline
+        // and must keep being written inline until it is migrated into the log
+        // by the first flush. Counting physical frames is an O(1) metadata read.
+        let segment_frames = crate::resume::count_segment_frames(
+            &crate::resume::JobCheckpoint::segments_path(&root),
+        )
+        .unwrap_or(0);
+        let total = meta.completed_tiles.len();
+        let inline_start = segment_frames.min(total);
+        let inline_end = total;
         Self {
             root,
             meta: std::sync::Mutex::new(meta),
+            inline_start,
+            inline_end,
+            seg_cursor: std::sync::Mutex::new(inline_end),
             completed_counter: AtomicU64::new(0),
             checkpoint_every,
         }
@@ -734,15 +770,59 @@ impl CheckpointState {
         }
     }
 
-    /// Serialise the current metadata to `<root>/.libviprs-job.json`. Atomic
-    /// via the tmp+rename dance inside [`JobCheckpoint::save`].
+    /// Persist the checkpoint with *bounded* per-flush I/O (issue #127).
+    ///
+    /// Rather than re-serialising the whole `completed_tiles` vector into the
+    /// JSON header on every flush (which made per-flush cost grow with all
+    /// completed tiles, cumulatively O(n²/k)), this appends only the
+    /// coordinates completed since the previous flush to the append-only
+    /// segment log, then rewrites a small header carrying just the scalar
+    /// fields plus the fixed inline coordinate range. The append is a single
+    /// bounded write; the header stays a bounded size.
+    ///
+    /// Ordering: the delta coordinates are appended and fsynced *before* the
+    /// header that summarises them is renamed into place, so a crash between
+    /// the two leaves the segment log holding coordinates the header does not
+    /// yet mention. Those tiles were genuinely written (the coordinate is only
+    /// marked after a successful write), so recovering them as completed is
+    /// safe; a resume simply skips already-done work.
+    ///
+    /// The `seg_cursor` lock serialises concurrent flushes so two workers
+    /// cannot interleave partial segment frames or double-append the same
+    /// delta.
     pub(crate) fn flush(&self) -> Result<(), ResumeError> {
-        let snapshot = {
+        let mut cursor = crate::poison::recover(&self.seg_cursor);
+
+        // Snapshot only the bounded parts we need under the meta lock: the
+        // frozen inline coordinate slice, the newly-completed delta, and the
+        // scalar header fields. The full vector is never cloned.
+        let (header_meta, delta, new_cursor) = {
             let mut meta = crate::poison::recover(&self.meta);
             meta.last_checkpoint_at = now_rfc3339_engine();
-            meta.clone()
+            let len = meta.completed_tiles.len();
+            let inline_end = self.inline_end.min(len);
+            let inline_start = self.inline_start.min(inline_end);
+            let inline = meta.completed_tiles[inline_start..inline_end].to_vec();
+            let delta = meta.completed_tiles[(*cursor).min(len)..len].to_vec();
+            let header_meta = JobMetadata {
+                schema_version: meta.schema_version.clone(),
+                plan_hash: meta.plan_hash.clone(),
+                completed_tiles: inline,
+                levels_completed: meta.levels_completed.clone(),
+                started_at: meta.started_at.clone(),
+                last_checkpoint_at: meta.last_checkpoint_at.clone(),
+                content_format: meta.content_format,
+            };
+            (header_meta, delta, len)
         };
-        JobCheckpoint::save(&self.root, &snapshot).map_err(ResumeError::from)
+
+        // Append the delta first so its bytes are durable before the header
+        // that certifies the completed set is published.
+        crate::resume::append_segments(&self.root, &delta, &crate::resume::RealDurability)
+            .map_err(ResumeError::from)?;
+        JobCheckpoint::save(&self.root, &header_meta).map_err(ResumeError::from)?;
+        *cursor = new_cursor;
+        Ok(())
     }
 }
 
@@ -1829,16 +1909,15 @@ mod tests {
     /// tiles and the per-flush write cost is O(n) — cumulatively O(n^2/k).
     ///
     /// This ratchet asserts the header size stays bounded regardless of how
-    /// many tiles have been recorded. It is `#[ignore]`d because the fix
-    /// requires moving the coordinate log out of the single JSON header
-    /// (append-only segments / per-level bitmaps), which changes the on-disk
-    /// contract currently frozen by the `libviprs-tests` integration suite
-    /// (raw-parses `.libviprs-job.json` for `completed_tiles`, and asserts a
-    /// single checkpoint file). Landing criterion 1 therefore needs a
-    /// coordinated update to that shared suite. Un-ignore to reproduce the
-    /// unbounded-I/O behaviour on the current code.
+    /// many tiles have been recorded. The fix (issue #127) moves the
+    /// coordinate log out of the single JSON header into an append-only
+    /// segment file, so each periodic flush appends only the delta and the
+    /// header stays small. `JobCheckpoint::load` merges the segment log back
+    /// in, so the recorded set is still fully recoverable. The
+    /// `libviprs-tests` integration suite was updated in lockstep to read the
+    /// checkpoint through `JobCheckpoint::load` rather than raw-parsing the
+    /// header.
     #[test]
-    #[ignore = "issue #127 criterion 1: needs segmented checkpoint format + coordinated libviprs-tests update"]
     fn checkpoint_flush_io_is_bounded_per_flush() {
         use crate::resume::{CHECKPOINT_FILENAME, JobCheckpoint, JobMetadata};
 

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -987,20 +987,26 @@ fn prepare_resume_state(
                     .map_err(|e| EngineError::ResumeFailed(crate::resume::ResumeError::from(e)))?;
             }
             // When an explicit checkpoint_root sits apart from the sink dir,
-            // it only ever holds our own `.libviprs-job.json`. Remove just
-            // that file so a stale checkpoint can't make this fresh run look
-            // resumable — leaving every other entry in place.
+            // it only ever holds our own checkpoint files. Remove both the
+            // JSON header and the append-only segment log (issue #127) so a
+            // stale checkpoint can't make this fresh run look resumable, and so
+            // the fresh run does not append onto a prior run's coordinate log,
+            // leaving every other entry in place.
             if let Some(root) = &config.checkpoint_root {
                 let same_as_sink = sink.checkpoint_root().is_some_and(|s| s == root.as_path());
                 if !same_as_sink {
-                    let marker = root.join(crate::resume::CHECKPOINT_FILENAME);
-                    match std::fs::remove_file(&marker) {
-                        Ok(()) => {}
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                        Err(e) => {
-                            return Err(EngineError::ResumeFailed(
-                                crate::resume::ResumeError::from(e),
-                            ));
+                    for marker in [
+                        crate::resume::JobCheckpoint::checkpoint_path(root),
+                        crate::resume::JobCheckpoint::segments_path(root),
+                    ] {
+                        match std::fs::remove_file(&marker) {
+                            Ok(()) => {}
+                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                            Err(e) => {
+                                return Err(EngineError::ResumeFailed(
+                                    crate::resume::ResumeError::from(e),
+                                ));
+                            }
                         }
                     }
                 }

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -6,12 +6,28 @@
 //!
 //! # Checkpoint format
 //!
-//! Each output directory contains a single file, `.libviprs-job.json`, whose
-//! contents deserialise to [`JobMetadata`]. The file is written atomically via
-//! a `.tmp` sibling + rename so that a crash mid-write cannot produce a torn
-//! or partially-updated checkpoint. The sibling name is made unique per
-//! process (pid + counter) so two jobs sharing one output directory cannot
-//! stage into — and torn-rename over — the same temp file (issue #126).
+//! Each output directory contains a small JSON header, `.libviprs-job.json`,
+//! whose contents deserialise to [`JobMetadata`]. The header is written
+//! atomically via a `.tmp` sibling + rename so that a crash mid-write cannot
+//! produce a torn or partially-updated checkpoint. The sibling name is made
+//! unique per process (pid + counter) so two jobs sharing one output directory
+//! cannot stage into, and torn-rename over, the same temp file (issue #126).
+//!
+//! The list of completed tile coordinates does *not* live inline in that
+//! header on the hot path. Re-serialising the whole vector on every periodic
+//! flush made per-flush I/O proportional to all completed tiles, so a
+//! libvips-scale run re-wrote hundreds of gigabytes cumulatively (issue #127).
+//! Instead, [`CheckpointState`](crate::engine) appends only the coordinates
+//! completed *since the last flush* to an append-only side log,
+//! `.libviprs-job.segments`, keeping each periodic flush bounded. The header
+//! carries the small, fixed set of scalar fields (schema, plan hash, completed
+//! levels, timestamps, format) plus any coordinates that were already inline
+//! at resume time (a hand-written or legacy checkpoint). [`JobCheckpoint::load`]
+//! reconstructs the full completed set by merging the header's inline
+//! coordinates with the segment log, so callers see one coherent
+//! [`JobMetadata`] regardless of how the checkpoint was written. A trailing
+//! partially-written segment record (a crash mid-append) is ignored on read;
+//! the coordinates before it are still recovered.
 //!
 //! # Plan hashing
 //!
@@ -72,6 +88,22 @@ pub const SCHEMA_VERSION: &str = "1";
 /// Always lives directly inside the output directory (the tile sink's base
 /// path). Relative path: `<output_dir>/.libviprs-job.json`.
 pub const CHECKPOINT_FILENAME: &str = ".libviprs-job.json";
+
+/// Well-known filename for the append-only completed-coordinate log that sits
+/// alongside [`CHECKPOINT_FILENAME`].
+///
+/// Each record is a fixed 12-byte little-endian frame `(level, col, row)`.
+/// The engine appends only the coordinates completed since the previous flush,
+/// which keeps per-flush I/O bounded instead of proportional to every tile
+/// completed so far (issue #127). [`JobCheckpoint::load`] replays this log and
+/// merges it with the header's inline coordinates. Relative path:
+/// `<output_dir>/.libviprs-job.segments`.
+pub const SEGMENTS_FILENAME: &str = ".libviprs-job.segments";
+
+/// On-disk size, in bytes, of one segment record: three little-endian `u32`
+/// fields `(level, col, row)`. A trailing run of fewer than this many bytes is
+/// a torn final append and is ignored on read.
+pub(crate) const SEGMENT_RECORD_LEN: usize = 12;
 
 /// Well-known filename for the advisory run lock guarding a checkpoint root.
 ///
@@ -469,6 +501,15 @@ impl JobCheckpoint {
         dir.join(CHECKPOINT_FILENAME)
     }
 
+    /// Absolute path of the append-only completed-coordinate segment log for
+    /// the given output directory.
+    ///
+    /// Returns `<dir>/.libviprs-job.segments` without checking whether the
+    /// file actually exists.
+    pub fn segments_path(dir: &Path) -> PathBuf {
+        dir.join(SEGMENTS_FILENAME)
+    }
+
     /// Load and deserialise the checkpoint from `dir`.
     ///
     /// * `Ok(None)` — the checkpoint file does not exist.
@@ -490,7 +531,7 @@ impl JobCheckpoint {
             Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(ResumeError::Io(e)),
         };
-        let meta: JobMetadata = serde_json::from_slice(&bytes)
+        let mut meta: JobMetadata = serde_json::from_slice(&bytes)
             .map_err(|source| ResumeError::Corrupt { path, source })?;
         if meta.schema_version != SCHEMA_VERSION {
             return Err(ResumeError::SchemaMismatch {
@@ -498,6 +539,28 @@ impl JobCheckpoint {
                 found: meta.schema_version,
             });
         }
+
+        // Merge the append-only segment log (issue #127). The completed set is
+        // reconstructed as `segment coordinates ++ header-inline coordinates`,
+        // deduplicated with first-seen order preserved. Segment coordinates
+        // come first so their count lines up with the physical frame count in
+        // the file, which `CheckpointState` uses to decide which coordinates
+        // are already durable versus still inline in the header.
+        let segment_coords = read_segment_log(&Self::segments_path(dir))?;
+        if !segment_coords.is_empty() {
+            let mut seen = std::collections::HashSet::with_capacity(
+                segment_coords.len() + meta.completed_tiles.len(),
+            );
+            let inline = std::mem::take(&mut meta.completed_tiles);
+            let mut merged = Vec::with_capacity(segment_coords.len() + inline.len());
+            for coord in segment_coords.into_iter().chain(inline) {
+                if seen.insert(coord) {
+                    merged.push(coord);
+                }
+            }
+            meta.completed_tiles = merged;
+        }
+
         Ok(Some(meta))
     }
 
@@ -559,6 +622,97 @@ impl JobCheckpoint {
         durability.sync_dir(dir)?;
         Ok(())
     }
+}
+
+/// Encode a single tile coordinate as its fixed 12-byte little-endian segment
+/// frame `(level, col, row)`.
+fn encode_segment_frame(coord: &TileCoord) -> [u8; SEGMENT_RECORD_LEN] {
+    let mut buf = [0u8; SEGMENT_RECORD_LEN];
+    buf[0..4].copy_from_slice(&coord.level.to_le_bytes());
+    buf[4..8].copy_from_slice(&coord.col.to_le_bytes());
+    buf[8..12].copy_from_slice(&coord.row.to_le_bytes());
+    buf
+}
+
+/// Count the number of complete records currently in the segment log without
+/// parsing them. A trailing partial frame (a torn append) is not counted.
+///
+/// Returns `0` when the file does not exist. `CheckpointState` uses this at
+/// construction to learn how many completed coordinates are already durable in
+/// the log versus still carried inline in the header.
+pub(crate) fn count_segment_frames(path: &Path) -> io::Result<usize> {
+    match std::fs::metadata(path) {
+        Ok(md) => Ok((md.len() as usize) / SEGMENT_RECORD_LEN),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(0),
+        Err(e) => Err(e),
+    }
+}
+
+/// Replay the append-only segment log at `path`, decoding every complete
+/// 12-byte frame into a [`TileCoord`].
+///
+/// A trailing run shorter than one record is a crash mid-append and is
+/// dropped: the coordinates written before it are intact and returned. Missing
+/// file yields an empty vector.
+fn read_segment_log(path: &Path) -> Result<Vec<TileCoord>, ResumeError> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(ResumeError::Io(e)),
+    };
+    let frames = bytes.len() / SEGMENT_RECORD_LEN;
+    let mut coords = Vec::with_capacity(frames);
+    for chunk in bytes.chunks_exact(SEGMENT_RECORD_LEN) {
+        let level = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let col = u32::from_le_bytes([chunk[4], chunk[5], chunk[6], chunk[7]]);
+        let row = u32::from_le_bytes([chunk[8], chunk[9], chunk[10], chunk[11]]);
+        coords.push(TileCoord::new(level, col, row));
+    }
+    Ok(coords)
+}
+
+/// Append completed coordinates to the segment log at `<dir>/.libviprs-job.segments`.
+///
+/// The write is a single `write_all` of the concatenated frames followed by a
+/// data fsync, so the appended coordinates are durable before the caller
+/// rewrites the header that summarises them. When the log did not exist yet
+/// (the first append of a run), the containing directory is fsynced too so the
+/// new file's directory entry survives power loss.
+///
+/// Callers must serialise their appends: the engine drives this from a single
+/// flush critical section so two workers never interleave partial frames.
+pub(crate) fn append_segments(
+    dir: &Path,
+    coords: &[TileCoord],
+    durability: &dyn Durability,
+) -> io::Result<()> {
+    if coords.is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dir)?;
+    let path = JobCheckpoint::segments_path(dir);
+    let is_new = !path.exists();
+
+    let mut buf = Vec::with_capacity(coords.len() * SEGMENT_RECORD_LEN);
+    for coord in coords {
+        buf.extend_from_slice(&encode_segment_frame(coord));
+    }
+
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)?;
+        f.write_all(&buf)?;
+        f.sync_all()?;
+    }
+
+    // A freshly created log needs its directory entry flushed as well;
+    // subsequent appends only grow an already-linked file.
+    if is_new {
+        durability.sync_dir(dir)?;
+    }
+    Ok(())
 }
 
 /// Durability backend used by the checkpoint/sink write paths to issue
@@ -1098,6 +1252,93 @@ mod tests {
     fn checkpoint_path_is_well_known_filename() {
         let p = JobCheckpoint::checkpoint_path(Path::new("/tmp/out"));
         assert_eq!(p, PathBuf::from("/tmp/out/.libviprs-job.json"));
+    }
+
+    /// Issue #127: coordinates written to the append-only segment log are
+    /// merged back into `completed_tiles` by `load`, and combine with any
+    /// inline header coordinates without duplication.
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn load_merges_segment_log_with_inline_header() {
+        let dir = tempfile::tempdir().unwrap();
+        // Header carries one inline coordinate (a legacy / hand-written
+        // checkpoint), the segment log carries two more.
+        let mut meta = sample_meta("deadbeef");
+        meta.completed_tiles = vec![TileCoord::new(9, 9, 9)];
+        JobCheckpoint::save(dir.path(), &meta).unwrap();
+        append_segments(
+            dir.path(),
+            &[TileCoord::new(0, 0, 0), TileCoord::new(1, 2, 3)],
+            &RealDurability,
+        )
+        .unwrap();
+
+        let loaded = JobCheckpoint::load(dir.path()).unwrap().unwrap();
+        // Segment coordinates come first, then inline-only coordinates.
+        assert_eq!(
+            loaded.completed_tiles,
+            vec![
+                TileCoord::new(0, 0, 0),
+                TileCoord::new(1, 2, 3),
+                TileCoord::new(9, 9, 9),
+            ]
+        );
+        // Physical frame count matches the coordinates written to the log.
+        assert_eq!(
+            count_segment_frames(&JobCheckpoint::segments_path(dir.path())).unwrap(),
+            2
+        );
+    }
+
+    /// A coordinate present in *both* the header inline set and the segment
+    /// log is reported once (dedup keeps `completed_tiles.len()` honest even
+    /// after a crash re-appended an already-inline coordinate).
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn load_dedupes_overlap_between_header_and_segments() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut meta = sample_meta("deadbeef");
+        meta.completed_tiles = vec![TileCoord::new(0, 0, 0)];
+        JobCheckpoint::save(dir.path(), &meta).unwrap();
+        append_segments(dir.path(), &[TileCoord::new(0, 0, 0)], &RealDurability).unwrap();
+
+        let loaded = JobCheckpoint::load(dir.path()).unwrap().unwrap();
+        assert_eq!(loaded.completed_tiles, vec![TileCoord::new(0, 0, 0)]);
+    }
+
+    /// A torn trailing segment frame (a crash mid-append) is dropped on read;
+    /// the whole frames before it are still recovered.
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn load_ignores_torn_trailing_segment_frame() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = sample_meta("deadbeef");
+        // sample_meta populates two inline coordinates; clear them so this
+        // test isolates the segment log.
+        let mut header = meta;
+        header.completed_tiles.clear();
+        JobCheckpoint::save(dir.path(), &header).unwrap();
+        append_segments(
+            dir.path(),
+            &[TileCoord::new(2, 0, 0), TileCoord::new(2, 1, 0)],
+            &RealDurability,
+        )
+        .unwrap();
+        // Simulate a partial append: 5 stray bytes shorter than one record.
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(JobCheckpoint::segments_path(dir.path()))
+                .unwrap();
+            f.write_all(&[1, 2, 3, 4, 5]).unwrap();
+        }
+
+        let loaded = JobCheckpoint::load(dir.path()).unwrap().unwrap();
+        assert_eq!(
+            loaded.completed_tiles,
+            vec![TileCoord::new(2, 0, 0), TileCoord::new(2, 1, 0)]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`completed_tiles` was cloned and re-serialised in full into the JSON header (`.libviprs-job.json`) on every periodic flush, so per-flush cost grew with all completed tiles (cumulatively O(n^2/k)). At libvips-scale plans a run re-wrote hundreds of gigabytes and stalled workers under multi-hundred-MB locked clones (engine.rs:611-618).

This moves the coordinate log out of the header into an append-only side file, `.libviprs-job.segments`. Each flush appends only the coordinates completed since the previous flush and rewrites a small, fixed-size header, so per-flush I/O is bounded. `JobCheckpoint::load` replays the segment log and merges it with any inline header coordinates (dedup, first-seen order), so callers still see one coherent `JobMetadata`.

## Acceptance criteria

- [x] Checkpoint I/O per flush is bounded (not proportional to all completed tiles): the header is fixed-size and each flush appends only the delta.
- [x] Membership lookup is better than O(n): already O(1) via `CompletedTileSet` (landed under #191/#195); this PR finishes the remaining criterion 1.

## Durability

The delta is fsynced before the header that certifies it is renamed into place, so a crash between the two only leaves the log holding coordinates that were genuinely written (a coordinate is marked only after a successful tile write). A resume re-skips them safely. A torn trailing frame from a crash mid-append is dropped on read.

## Test

Un-ignores the `checkpoint_flush_io_is_bounded_per_flush` ratchet (RED on the old full-rewrite path: the header ballooned; GREEN now: it stays within 512 bytes across 5000 completions while the full set stays recoverable). Adds `load` merge/dedup/torn-frame tests.

## Cross-repo coordination

The shared libviprs-tests suite is updated in lockstep to read the checkpoint through `JobCheckpoint::load` rather than raw-parsing the header, and to treat `.libviprs-job.segments` as resume bookkeeping. Its resume + validation-stress suites pass against this branch locally.

Closes #127