### PR TITLE
resume: single checkpoint writer + atomic manifest writes (#124)

### DIFF
--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -1012,6 +1012,12 @@ fn prepare_resume_state(
                 }
             }
             let cp = crate::engine::cp_for_sink(sink, plan, config, Vec::new(), Vec::new());
+            if cp.is_some() {
+                // The engine's CheckpointState is now the checkpoint writer for
+                // this run; tell the sink not to publish its own copy too
+                // (issue #124).
+                sink.suppress_own_checkpoint();
+            }
             Ok((std::collections::HashSet::new(), cp))
         }
         ResumeMode::Resume => {
@@ -1037,6 +1043,12 @@ fn prepare_resume_state(
             let skip: std::collections::HashSet<crate::planner::TileCoord> =
                 completed.iter().copied().collect();
             let cp = crate::engine::cp_for_sink(sink, plan, config, completed, levels);
+            if cp.is_some() {
+                // The engine's CheckpointState is now the checkpoint writer for
+                // this run; tell the sink not to publish its own copy too
+                // (issue #124).
+                sink.suppress_own_checkpoint();
+            }
             Ok((skip, cp))
         }
         ResumeMode::Verify => unreachable!("Verify is rejected above for non-Monolithic engines"),
@@ -1676,6 +1688,95 @@ mod checkpoint_durability_tests {
         assert!(
             matches!(result, Err(EngineError::InvalidPlan { .. })),
             "expected InvalidPlan for an empty-levels plan, got {result:?}"
+        );
+    }
+
+    /// Counts file- and directory-fsyncs so a test can observe whether a sink
+    /// *published* a checkpoint (a directory fsync of its base dir) versus
+    /// merely fsyncing tile data.
+    #[derive(Default)]
+    struct SyncCounter {
+        files: AtomicU32,
+        dirs: AtomicU32,
+    }
+
+    impl crate::resume::Durability for SyncCounter {
+        fn sync_file(&self, _path: &std::path::Path) -> std::io::Result<()> {
+            self.files.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+        fn sync_dir(&self, _path: &std::path::Path) -> std::io::Result<()> {
+            self.dirs.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    /// Issue #124: a resume run must have exactly one component write the
+    /// checkpoint file. The engine's `CheckpointState` is that writer, so when
+    /// an `FsSink` (which has its own resume-checkpoint writer) is driven by
+    /// the builder, the sink must NOT also publish its own `.libviprs-job.json`.
+    ///
+    /// A directory fsync of the sink's base dir is how `FsSink::finish`
+    /// publishes its checkpoint (via `JobCheckpoint::save_with`). We inject a
+    /// counting durability into the sink and assert that, after a builder-driven
+    /// resume run, the sink issued zero directory fsyncs (it published nothing)
+    /// while still fsyncing tile data (issue #122 preserved). The checkpoint
+    /// nonetheless exists and records every tile, proving the engine's writer
+    /// is the single, complete source.
+    ///
+    /// Before the fix the sink also wrote the checkpoint, so its counting
+    /// durability recorded a directory fsync of the base dir (RED). After the
+    /// fix the builder suppresses the sink's writer, so that count is zero
+    /// (GREEN).
+    #[test]
+    fn resume_run_has_single_checkpoint_writer() {
+        use crate::sink::{FsSink, TileFormat};
+        use std::sync::Arc;
+
+        let source = solid_source();
+        let plan = solid_plan();
+        let total_tiles: usize = plan
+            .levels
+            .iter()
+            .map(|lp| (lp.cols as usize) * (lp.rows as usize))
+            .sum();
+
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("out_files");
+
+        let recorder = Arc::new(SyncCounter::default());
+        let sink = FsSink::new(base.clone(), plan.clone())
+            .with_format(TileFormat::Raw)
+            .with_resume(true)
+            .with_durability(recorder.clone());
+
+        // A very coarse cadence guarantees no periodic flush fires: only the
+        // builder's terminal `CheckpointState::flush` and (pre-fix) the sink's
+        // own `finish` writer could publish, isolating the double-write.
+        EngineBuilder::new(&source, plan.clone(), sink)
+            .with_resume(ResumePolicy::resume().with_checkpoint_every(1_000_000))
+            .run_collect()
+            .expect("resume run must succeed");
+
+        assert_eq!(
+            recorder.dirs.load(Ordering::Relaxed),
+            0,
+            "the sink must not publish its own checkpoint (directory fsync) when \
+             the engine's CheckpointState is the writer (issue #124)"
+        );
+        assert!(
+            recorder.files.load(Ordering::Relaxed) > 0,
+            "the sink must still fsync tile data before the checkpoint (issue #122)"
+        );
+
+        // The engine's writer is the single, complete source of the checkpoint.
+        let meta = JobCheckpoint::load(&base)
+            .expect("checkpoint load must not error")
+            .expect("the engine's CheckpointState must have published a checkpoint");
+        assert_eq!(
+            meta.completed_tiles.len(),
+            total_tiles,
+            "the sole checkpoint must record every completed tile"
         );
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -545,14 +545,13 @@ impl Manifest {
 
     /// Serialize and write this manifest to `path`, creating parent
     /// directories as needed.
+    ///
+    /// The write is atomic (staged `.tmp` sibling + rename via
+    /// [`crate::resume::atomic_write`]) so a crash mid-write cannot leave a
+    /// torn manifest, and the two on-disk copies cannot diverge (issue #124).
     pub fn write_to(&self, path: &Path) -> Result<(), ManifestError> {
-        if let Some(parent) = path.parent() {
-            if !parent.as_os_str().is_empty() {
-                fs::create_dir_all(parent)?;
-            }
-        }
         let json = self.to_json_string()?;
-        fs::write(path, json)?;
+        crate::resume::atomic_write(path, json.as_bytes())?;
         Ok(())
     }
 
@@ -846,6 +845,51 @@ mod tests {
             BlankTileStrategy::PlaceholderWithTolerance {
                 max_channel_delta: 7,
             }
+        );
+    }
+
+    /// Issue #124: manifest writes must be atomic (staged `.tmp` + rename), not
+    /// a bare `fs::write` that truncates the destination in place.
+    ///
+    /// A rename replaces the directory entry rather than opening and truncating
+    /// the existing file, so it succeeds even when the previous manifest is a
+    /// read-only regular file (as long as the parent directory is writable),
+    /// and a reader never observes a torn write. A bare `fs::write` instead
+    /// fails with `PermissionDenied` trying to truncate the read-only target.
+    ///
+    /// Before the fix `write_to` used `fs::write` and this returned an error
+    /// (RED); after it the atomic rename replaces the file cleanly (GREEN).
+    #[test]
+    #[cfg(unix)]
+    fn write_to_atomically_replaces_a_read_only_manifest() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.manifest.json");
+
+        // Pre-existing manifest that a crashed prior run left behind, made
+        // read-only so an in-place truncate would fail.
+        std::fs::write(&path, b"{\"stale\": true}").unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o444);
+        std::fs::set_permissions(&path, perms).unwrap();
+
+        let manifest = sample_manifest();
+        manifest
+            .write_to(&path)
+            .expect("atomic write must replace a read-only manifest");
+
+        // The new content fully replaced the old, and no staging temp lingers.
+        let reloaded = ManifestV1::read_from(&path).unwrap();
+        assert_eq!(reloaded, manifest);
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "no staging temp file may linger after a successful write: {leftovers:?}"
         );
     }
 }

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -784,6 +784,49 @@ fn tmp_path_for(final_path: &Path) -> PathBuf {
     PathBuf::from(s)
 }
 
+/// Atomically write `bytes` to `path` using the same staged-`.tmp` + `rename`
+/// discipline as the checkpoint writer ([`JobCheckpoint::save_with`]).
+///
+/// The payload is written to a unique sibling temp file, flushed, and then
+/// renamed over `path`. On POSIX the rename is atomic, so a concurrent reader
+/// (or a crash mid-write) never observes a truncated or half-written `path`:
+/// it sees either the previous complete contents or the new complete contents.
+/// This is what keeps the two on-disk manifest copies from diverging when a
+/// run dies partway through emitting them (issue #124).
+///
+/// Because the rename replaces the directory entry rather than truncating the
+/// existing file, it also succeeds when `path` is a read-only regular file, as
+/// long as its parent directory is writable, matching real atomic-replace
+/// semantics rather than the truncate-in-place behaviour of `fs::write`.
+///
+/// Parent directories are created as needed. The unique temp name (pid + a
+/// process-wide counter) means two writers targeting the same destination
+/// never stage into or clobber each other's temp file.
+pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let tmp = tmp_path_for(path);
+    // Scope the handle so it is closed before the rename — some filesystems
+    // refuse to rename over an open handle. Flush the payload to disk before
+    // publishing so the renamed file is not left empty on power loss.
+    if let Err(e) = (|| {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()
+    })() {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
 /// Advisory, exclusive run lock held for the lifetime of a resumable job.
 ///
 /// A resumable run takes this lock against `<dir>/.libviprs-job.lock`

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -239,6 +239,27 @@ pub trait TileSink: Send + Sync {
         self.inner_sink().and_then(|inner| inner.checkpoint_root())
     }
 
+    /// Engine hook: tell the sink that resume checkpointing is being driven
+    /// externally (by the engine's [`CheckpointState`](crate::engine)) for
+    /// this run, so the sink must NOT also publish its own `.libviprs-job.json`.
+    ///
+    /// The engine builder calls this once, before the run, whenever it stands
+    /// up a `CheckpointState` for an on-disk sink. It makes the engine's
+    /// checkpoint writer the single component that publishes the checkpoint
+    /// file: a resume run would otherwise have both [`FsSink::finish`] and the
+    /// `CheckpointState` write the file in sequence with different views, and a
+    /// crash between the two could discard prior-run completions (issue #124).
+    /// The sink still fsyncs its own tile data at `finish`, preserving the
+    /// tile-data-before-checkpoint durability ordering (issue #122).
+    ///
+    /// The default forwards to [`TileSink::inner_sink`] (a no-op for terminal
+    /// sinks that keep no resume state).
+    fn suppress_own_checkpoint(&self) {
+        if let Some(inner) = self.inner_sink() {
+            inner.suppress_own_checkpoint();
+        }
+    }
+
     /// Engine hook: tell the sink how many pyramid levels will appear in
     /// this run, so sinks that keep per-level counters can pre-size their
     /// backing storage before the tile loop starts. Default is a no-op.
@@ -612,6 +633,12 @@ pub struct FsSink {
     /// [`FsSink::dedupe_write`] and never while holding a leaf mutex.
     dedupe_promote: Mutex<()>,
     resume_enabled: bool,
+    /// Set by [`TileSink::suppress_own_checkpoint`] when the engine's
+    /// [`CheckpointState`](crate::engine) is the checkpoint writer for this
+    /// run. While set, [`FsSink::finish`] still fsyncs freshly-written tile
+    /// data (issue #122) but does NOT publish its own `.libviprs-job.json`, so
+    /// the engine's writer is the single source of the checkpoint (issue #124).
+    checkpoint_suppressed: AtomicBool,
     /// Running per-tile checksum table, populated only when `checksums` is
     /// non-[`ChecksumMode::None`]. Keyed by the relative tile path inside
     /// `base_dir`. Stores the raw 32-byte digest to keep the hot path
@@ -815,6 +842,7 @@ impl FsSink {
             dedupe_index: None,
             dedupe_promote: Mutex::new(()),
             resume_enabled: false,
+            checkpoint_suppressed: AtomicBool::new(false),
             tile_digests: Mutex::new(BTreeMap::new()),
             manifest_refs: Mutex::new(HashMap::new()),
             pending_first: Mutex::new(HashMap::new()),
@@ -1101,6 +1129,10 @@ impl TileSink for FsSink {
 
     fn checkpoint_root(&self) -> Option<&Path> {
         Some(&self.base_dir)
+    }
+
+    fn suppress_own_checkpoint(&self) {
+        self.checkpoint_suppressed.store(true, Ordering::Relaxed);
     }
 
     fn content_format(&self) -> Option<TileFormat> {
@@ -1554,21 +1586,61 @@ impl FsSink {
             let mut sibling_name = stem.to_os_string();
             sibling_name.push(".manifest.json");
             let sibling_path = parent.join(sibling_name);
-            std::fs::write(&sibling_path, &json)?;
+            atomic_write(&sibling_path, &json)?;
         }
 
         let inside_path = self.base_dir.join("manifest.json");
-        if let Some(parent) = inside_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(&inside_path, &json)?;
+        atomic_write(&inside_path, &json)?;
 
         Ok(())
     }
 
     /// Persist the completed-tile checkpoint when resume is enabled.
+    ///
+    /// Always fsyncs the tile data written since the last flush (issue #122).
+    /// It then publishes its own `.libviprs-job.json` only when checkpointing
+    /// is NOT being driven by the engine's
+    /// [`CheckpointState`](crate::engine): when the engine builder has called
+    /// [`TileSink::suppress_own_checkpoint`], that writer is the single source
+    /// of the checkpoint file, so the sink skips its own write to avoid two
+    /// writers publishing divergent views (issue #124). The tile-data fsync
+    /// still runs first, so the engine's terminal flush (which happens after
+    /// the sink's `finish`) certifies data that is already durable.
     fn write_resume_checkpoint(&self) -> Result<(), SinkError> {
         use crate::resume::{JobCheckpoint, JobMetadata, SCHEMA_VERSION, compute_plan_hash};
+
+        // Durability ordering (issue #122): fsync the tile data written since
+        // the last flush *before* the checkpoint that certifies it is
+        // published. Otherwise a power loss can leave the synced checkpoint
+        // pointing at tiles whose bytes were still in the page cache, and
+        // resume would skip those coordinates forever. This runs regardless of
+        // which component publishes the checkpoint.
+        let to_sync: Vec<PathBuf> = {
+            let mut guard = self.lock_leaf(&self.unsynced_tiles);
+            std::mem::take(&mut *guard)
+        };
+        let mut seen = std::collections::HashSet::new();
+        for path in &to_sync {
+            if !seen.insert(path.clone()) {
+                continue;
+            }
+            match self.durability.sync_file(path) {
+                Ok(()) => {}
+                // A path can legitimately be absent by flush time — e.g. a
+                // dedupe first-occurrence file promoted into `_shared/` and
+                // replaced by a hardlink. The surviving link/target is synced
+                // via its own tracked entry, so a missing path here is not a
+                // durability failure.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(SinkError::Io(e)),
+            }
+        }
+
+        // The engine's `CheckpointState` is the sole checkpoint writer when it
+        // is driving this run; the sink must not also publish (issue #124).
+        if self.checkpoint_suppressed.load(Ordering::Relaxed) {
+            return Ok(());
+        }
 
         let completed = self.lock_leaf(&self.completed_tiles).clone();
         // Derive the content contract from the same engine config the resume
@@ -1614,32 +1686,6 @@ impl FsSink {
             last_checkpoint_at: timestamp,
             content_format: contract.format,
         };
-
-        // Durability ordering (issue #122): fsync the tile data written since
-        // the last flush *before* the checkpoint that certifies it is
-        // published. Otherwise a power loss can leave the synced checkpoint
-        // pointing at tiles whose bytes were still in the page cache, and
-        // resume would skip those coordinates forever.
-        let to_sync: Vec<PathBuf> = {
-            let mut guard = self.lock_leaf(&self.unsynced_tiles);
-            std::mem::take(&mut *guard)
-        };
-        let mut seen = std::collections::HashSet::new();
-        for path in &to_sync {
-            if !seen.insert(path.clone()) {
-                continue;
-            }
-            match self.durability.sync_file(path) {
-                Ok(()) => {}
-                // A path can legitimately be absent by flush time — e.g. a
-                // dedupe first-occurrence file promoted into `_shared/` and
-                // replaced by a hardlink. The surviving link/target is synced
-                // via its own tracked entry, so a missing path here is not a
-                // durability failure.
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => return Err(SinkError::Io(e)),
-            }
-        }
 
         // `save_with` fsyncs the checkpoint payload and then its directory,
         // so the rename that publishes the checkpoint is itself durable.
@@ -1699,35 +1745,15 @@ fn secs_to_ymd_hms(secs: i64) -> (i32, u32, u32, u32, u32, u32) {
 /// Hash `bytes` with `algo` and return the raw 32-byte digest. Both
 /// supported algorithms (Blake3, SHA-256) produce exactly 32 bytes, so we
 /// can store them as fixed-size arrays on the hot path instead of paying
-/// Monotonic counter feeding the temp-file suffix in [`atomic_write`], so two
-/// writers in the same process never pick the same `.tmp` name for the same
-/// shared blob.
-static ATOMIC_WRITE_SEQ: AtomicU64 = AtomicU64::new(0);
-
 /// Write `bytes` to `path` atomically: stage them in a sibling `.tmp` file and
 /// `rename` it into place. On POSIX the rename is atomic, so a concurrent
 /// reader (or a crash) never observes a partially-written `path` — it sees
 /// either the old contents or the complete new contents, never a truncated
-/// blob (issue #97). The temp name is disambiguated by pid + a process-wide
-/// counter so parallel workers staging the same destination don't clobber each
-/// other's temp file. The temp is best-effort cleaned up if the rename fails.
+/// blob (issue #97). Delegates to [`crate::resume::atomic_write`] so shared
+/// blobs, the manifest copies, and the checkpoint all publish through one
+/// staged-`.tmp` + `rename` helper (issue #124).
 fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("blob");
-    let seq = ATOMIC_WRITE_SEQ.fetch_add(1, Ordering::Relaxed);
-    let tmp = parent.join(format!(
-        ".{file_name}.tmp.{pid}.{seq}",
-        pid = std::process::id(),
-    ));
-    if let Err(e) = std::fs::write(&tmp, bytes) {
-        let _ = std::fs::remove_file(&tmp);
-        return Err(e);
-    }
-    if let Err(e) = std::fs::rename(&tmp, path) {
-        let _ = std::fs::remove_file(&tmp);
-        return Err(e);
-    }
-    Ok(())
+    crate::resume::atomic_write(path, bytes)
 }
 
 /// for a `String` allocation per tile.


### PR DESCRIPTION
## Summary

Resolves #124. A resume run had two components publish `.libviprs-job.json` in sequence: `FsSink::finish` (recording only this-run tiles and resetting `started_at`) and then the engine's `CheckpointState::flush`. A crash between the two could silently discard prior-run completions, and the second write was redundant I/O. Separately, the two manifest copies used bare `fs::write`, so a crash mid-write could leave them torn or divergent while verify prefers the sibling.

## Changes

- **Single checkpoint writer.** The engine's `CheckpointState` is now the sole writer. The builder calls a new defaulted `TileSink::suppress_own_checkpoint` hook once, before the run, whenever it stands up a `CheckpointState` for an on-disk sink. While suppressed, `FsSink::finish` still fsyncs its freshly-written tile data first (the sink's finish runs before the builder's terminal flush, so the issue #122 tile-data-before-checkpoint ordering is preserved) but no longer publishes its own checkpoint. A standalone `FsSink` with resume, driven without the builder, is unchanged.
- **Atomic manifest writes.** All three manifest writes (the two `FsSink` copies and `Manifest::write_to`) now go through a shared `resume::atomic_write` helper that stages a unique `.tmp` sibling and renames it into place, the same tmp+rename discipline the checkpoint uses. The sink's existing shared-blob `atomic_write` delegates to it.

## Tests (RED before, GREEN after)

- `resume_run_has_single_checkpoint_writer`: a builder-driven resume run asserts the sink issues zero directory fsyncs (publishes no checkpoint) while still fsyncing tile data, and the sole checkpoint on disk records every completed tile.
- `write_to_atomically_replaces_a_read_only_manifest`: writing a manifest over a read-only prior copy succeeds via rename, which a bare `fs::write` (in-place truncate) cannot.

Both were confirmed to fail on the pre-fix code and pass after.

## Acceptance criteria

- [x] Exactly one component writes the checkpoint file.
- [x] Manifest writes are atomic (tmp+rename).

## Local mirror

`make fmt`, `make clippy` (default + pdfium), and `make test` (401 passed, 0 failed) all green, including the two reproducers.