### PR TITLE
Batch four [Low] engine cleanups: worker panics, verify gaps, PlanHashMismatch, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,19 @@ jobs:
       - run: cargo check --all-targets
       - run: cargo check --all-targets --features pdfium
 
+  docs:
+    name: Docs (deny broken intra-doc links)
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # All features so the gated surface resolves instead of reading as broken
+      # links; docs.rs itself builds with `all-features` (issue #146).
+      - run: cargo doc --no-deps --all-features
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,14 @@ keywords = ["image", "pyramid", "tiles", "deepzoom", "pdf"]
 categories = ["multimedia::images", "graphics"]
 readme = "README.md"
 
+# Build docs.rs with every feature enabled and the `docsrs` cfg set, so the
+# hosted documentation renders the feature-gated surface (render_page_pdfium,
+# PdfiumStripSource, ObjectStoreSink, PackfileSink) with feature badges instead
+# of advertising it as broken intra-doc links (issue #146).
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
 deprecated = "deny"

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
-.PHONY: ci fmt clippy test miri loom
+.PHONY: ci fmt clippy test miri loom doc
 
 ## Run all CI workflows locally (mirrors .github/workflows/ci.yml)
-ci: fmt clippy test miri loom
+ci: fmt clippy test doc miri loom
 	@echo ""
 	@echo "All CI checks passed."
+
+## Build the docs and fail on any broken intra-doc link (Docs job).
+## Runs with every feature so the gated surface resolves (issue #146).
+doc:
+	@echo "==> cargo doc (deny broken intra-doc links)"
+	RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features
 
 ## Check formatting (Check & Lint job)
 fmt:

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -18,8 +18,8 @@ use crate::sink::{SinkError, Tile, TileSink};
 /// Errors that can occur during pyramid generation.
 ///
 /// Wraps lower-level raster and sink errors into a single error type so that
-/// callers of [`generate_pyramid`] and [`generate_pyramid_observed`] can handle
-/// all failure modes uniformly. Also covers engine-specific conditions such as
+/// callers of [`EngineBuilder::run`](crate::EngineBuilder::run) can handle all
+/// failure modes uniformly. Also covers engine-specific conditions such as
 /// cancellation and worker panics.
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -49,8 +49,18 @@ pub enum EngineError {
         got: String,
     },
     /// The resumed job checkpoint's plan hash does not match the current plan.
-    #[error("plan hash mismatch (expected {expected}, got {got})")]
-    PlanHashMismatch { expected: String, got: String },
+    ///
+    /// `expected` is the hash the current run computes from its live plan and
+    /// content contract (what a resume-compatible checkpoint must carry);
+    /// `actual` is the hash the on-disk checkpoint actually recorded. The two
+    /// fields follow the same `{expected, actual}` convention as the resume
+    /// layer so the reading is unambiguous: the run expected one hash and found
+    /// a different one on disk (issue #145).
+    #[error(
+        "plan hash mismatch: current plan hashes to {expected}, \
+         but the checkpoint on disk recorded {actual}"
+    )]
+    PlanHashMismatch { expected: String, actual: String },
     /// A resumable job could not be initialised or advanced.
     #[error("resume failed: {0}")]
     ResumeFailed(#[from] ResumeError),
@@ -130,7 +140,7 @@ pub enum BlankTileStrategy {
 
 /// Configuration for the pyramid generation engine.
 ///
-/// Groups every tunable knob that affects how [`generate_pyramid`] runs:
+/// Groups every tunable knob that affects how [`EngineBuilder::run`](crate::EngineBuilder::run) runs:
 /// thread count, channel buffer depth, edge-tile background color, and
 /// blank-tile handling. The [`Default`] implementation provides sensible
 /// values for single-threaded operation.
@@ -281,8 +291,8 @@ impl EngineConfig {
     /// [`FsSink::should_dedupe_tile`](crate::sink::FsSink)); they differ only in
     /// the sink-side shared-key hash algorithm, which does not change the
     /// engine's emit decision. Sinks that were themselves given a
-    /// [`DedupeStrategy`] continue to apply their own per-sink dedupe on top of
-    /// this.
+    /// [`DedupeStrategy`](crate::dedupe::DedupeStrategy) continue to apply their
+    /// own per-sink dedupe on top of this.
     ///
     /// **See also:** [interactive example](https://libviprs.org/cli/#flag-dedupe-blanks)
     /// (and the related [`--dedupe-all`](https://libviprs.org/cli/#flag-dedupe-all) flag).
@@ -369,8 +379,8 @@ pub struct StageDurations {
 ///
 /// Captures tile counts, level counts, and peak memory so that callers can
 /// log, display progress, or assert correctness without inspecting the sink
-/// directly. Every field is populated by [`generate_pyramid`] /
-/// [`generate_pyramid_observed`].
+/// directly. Every field is populated by a run through
+/// [`EngineBuilder::run`](crate::EngineBuilder::run).
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct EngineResult {
@@ -400,31 +410,16 @@ pub struct EngineResult {
     pub skipped_due_to_failure: u64,
 }
 
-/// Generates a complete tile pyramid from a source raster.
-///
-/// This is the primary entry point for pyramid generation. It processes levels
-/// from full resolution (top) down to 1x1, extracting tiles at each level and
-/// writing them to the provided [`TileSink`]. When
-/// [`EngineConfig::concurrency`] is greater than zero, tiles within each level
-/// are produced in parallel using scoped threads with bounded-channel
-/// backpressure.
-///
-/// For progress reporting, use [`generate_pyramid_observed`] instead.
-///
-/// See the
-/// [pyramid_fs_sink tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pyramid_fs_sink.rs)
-/// for filesystem output,
-/// [pdf_to_pyramid tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_to_pyramid.rs)
-/// for PDF-sourced pyramids, and the
-/// [CLI pyramid command](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
-/// for end-to-end CLI usage.
 /// Generates a tile pyramid with an [`EngineObserver`] for progress events.
 ///
-/// Behaves identically to [`generate_pyramid`] but emits [`EngineEvent`]s
-/// (level started/completed, tile completed, finished) to the supplied
-/// observer. This is the function used by the
+/// Processes levels from full resolution (top) down to 1x1, extracting tiles at
+/// each level and writing them to the provided [`TileSink`], and emits
+/// [`EngineEvent`]s (level started/completed, tile completed, finished) to the
+/// supplied observer. When [`EngineConfig::concurrency`] is greater than zero,
+/// tiles within each level are produced in parallel using scoped threads with
+/// bounded-channel backpressure. This is the function the
 /// [CLI pyramid command](https://github.com/libviprs/libviprs-cli/blob/main/src/main.rs)
-/// to drive its progress bar.
+/// drives to power its progress bar.
 ///
 /// See the
 /// [observability tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/observability.rs)
@@ -890,6 +885,29 @@ pub(crate) fn promote_sink_error(err: SinkError) -> EngineError {
     }
 }
 
+/// Run a parallel worker's tile-extraction body, converting a panic into
+/// [`EngineError::WorkerPanic`] so a contained worker fault surfaces as a
+/// typed error on the tile channel instead of unwinding out of
+/// [`std::thread::scope`] and re-raising as a raw panic through the engine
+/// entry point.
+///
+/// Before this, the monolithic producer pool and the MapReduce tile-emission
+/// pool spawned their workers without collecting the join handles, so a panic
+/// in one worker (for example a broken tiling invariant) escaped the scope and
+/// propagated as an uncontained panic, poisoning the sink/observer mutexes on
+/// the way out. The MapReduce *map* phase already gets this right by joining
+/// its handles and mapping a panicked join to [`EngineError::WorkerPanic`];
+/// this helper gives the emission pools the same contract so a worker panic on
+/// every parallel path returns the typed error (issue #118).
+pub(crate) fn catch_worker_panic<T>(
+    body: impl FnOnce() -> Result<T, EngineError>,
+) -> Result<T, EngineError> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(body)) {
+        Ok(result) => result,
+        Err(_) => Err(EngineError::WorkerPanic),
+    }
+}
+
 /// Best-effort reverse-parse of a tile relative path back into a [`TileCoord`].
 ///
 /// Understands the DeepZoom (`<level>/<col>_<row>.<ext>`) and XYZ /
@@ -920,6 +938,30 @@ fn parse_tile_rel_path(rel: &str) -> Option<TileCoord> {
         }
         _ => None,
     }
+}
+
+/// Resolve the [`TileCoord`] a manifest tile key refers to, so a checksum
+/// mismatch is attributed to the *offending* tile rather than a fabricated
+/// `TileCoord(0, 0, 0)` (or, worse, a coordinate with its col/row transposed).
+///
+/// The authoritative match scans the plan for the coordinate whose
+/// [`PyramidPlan::tile_path`] equals the key under any known extension. This is
+/// exact for every layout, including [`Layout::Google`](crate::planner::Layout),
+/// whose on-disk order is `{level}/{row}/{col}` and would otherwise be
+/// mis-parsed as `{level}/{col}/{row}` by the layout-agnostic
+/// [`parse_tile_rel_path`], swapping the reported col and row. The structural
+/// parse is kept only as a fallback for a foreign key the plan does not
+/// produce; if that also fails we surface `TileCoord(0, 0, 0)` (issue #139).
+fn coord_for_manifest_rel(plan: &PyramidPlan, rel: &str) -> TileCoord {
+    let normalized = rel.replace('\\', "/");
+    for coord in plan.tile_coords() {
+        for ext in ["raw", "png", "jpeg", "jpg"] {
+            if plan.tile_path(coord, ext).is_some_and(|p| p == normalized) {
+                return coord;
+            }
+        }
+    }
+    parse_tile_rel_path(rel).unwrap_or_else(|| TileCoord::new(0, 0, 0))
 }
 
 /// Resolve the on-disk checkpoint root. Prefers the explicit
@@ -996,19 +1038,27 @@ pub fn raster_verify(
     // byte mismatch on the first one, which is strictly less useful than
     // failing fast with the structural error.
     if let Some(meta) = JobCheckpoint::load(root)? {
-        if let Err(got) = crate::resume::verify_checkpoint_contract(&meta, plan, config, sink) {
+        if let Err(current) = crate::resume::verify_checkpoint_contract(&meta, plan, config, sink) {
             return Err(EngineError::PlanHashMismatch {
-                expected: meta.plan_hash,
-                got,
+                expected: current,
+                actual: meta.plan_hash,
             });
         }
     }
 
-    // Try every known tile-file extension until we find one that matches.
-    // The sink's active format isn't visible from this layer, so we probe
-    // the common extensions produced by `TileFormat::extension` before
-    // declaring a tile missing.
-    let candidate_exts = ["raw", "png", "jpeg", "jpg"];
+    // Probe only the sink's *active* on-disk format. A previous run in a
+    // different format can leave a stale file at a sibling extension (e.g. a
+    // leftover `.png` when this run writes `.raw`); probing every extension and
+    // accepting the first hit would silently validate that stale file and let a
+    // missing active-format tile pass. A sink that pins a concrete format
+    // reports it through `content_format`; when the format is unknown (a
+    // transparent wrapper returns `None`) we fall back to probing every known
+    // extension as before (issue #139).
+    let candidate_exts: Vec<&'static str> = match sink.content_format() {
+        Some(crate::sink::TileFormat::Jpeg { .. }) => vec!["jpeg", "jpg"],
+        Some(fmt) => vec![fmt.extension()],
+        None => vec!["raw", "png", "jpeg", "jpg"],
+    };
 
     for coord in plan.tile_coords() {
         let mut found: Option<std::path::PathBuf> = None;
@@ -1089,8 +1139,7 @@ pub fn raster_verify(
                         };
                         if !got.eq_ignore_ascii_case(expected_s) {
                             return Err(EngineError::ChecksumMismatch {
-                                tile: parse_tile_rel_path(rel)
-                                    .unwrap_or_else(|| TileCoord::new(0, 0, 0)),
+                                tile: coord_for_manifest_rel(plan, rel),
                                 expected: expected_s.to_string(),
                                 got,
                             });
@@ -1613,17 +1662,22 @@ fn extract_and_emit_parallel(
                         break;
                     }
                     let extract_start = Instant::now();
-                    let result = extract_tile(raster, plan, coord, bg)
-                        .map(|tile_raster| {
-                            let blank =
-                                blank_for_output(&tile_raster, blank_strategy, dedupe_strategy);
-                            Tile {
-                                coord,
-                                raster: tile_raster,
-                                blank,
-                            }
-                        })
-                        .map_err(EngineError::from);
+                    // Contain a worker panic (e.g. a broken tiling invariant)
+                    // as a typed `WorkerPanic` on the channel rather than
+                    // letting it unwind out of `thread::scope` (issue #118).
+                    let result = catch_worker_panic(|| {
+                        extract_tile(raster, plan, coord, bg)
+                            .map(|tile_raster| {
+                                let blank =
+                                    blank_for_output(&tile_raster, blank_strategy, dedupe_strategy);
+                                Tile {
+                                    coord,
+                                    raster: tile_raster,
+                                    blank,
+                                }
+                            })
+                            .map_err(EngineError::from)
+                    });
                     stage_extract
                         .fetch_add(extract_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
 
@@ -3312,6 +3366,273 @@ mod tests {
             matches!(err, EngineError::PlanHashMismatch { .. }),
             "expected PlanHashMismatch on tile-format change, got {err:?}"
         );
+    }
+
+    /// `PlanHashMismatch` must name the CURRENT run's hash as `expected` and the
+    /// on-disk checkpoint's recorded hash as `actual`, so the rendered message
+    /// is unambiguous about which side is which. Before issue #145 the fields
+    /// were swapped (and named `{expected, got}`), so "expected X" pointed at the
+    /// checkpoint rather than the plan the caller is running now.
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn plan_hash_mismatch_names_current_expected_and_checkpoint_actual() {
+        use crate::resume::{JobCheckpoint, PlanContract, ResumePolicy, compute_plan_hash};
+        use crate::sink::{FsSink, TileFormat};
+        use crate::{EngineBuilder, EngineKind};
+        use tempfile::tempdir;
+
+        let src = gradient_raster(96, 96);
+        let plan = PyramidPlanner::new(96, 96, 64, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+        let dir = tempdir().unwrap();
+        let root = dir.path().join("tiles");
+
+        // Run 1: write a Raw pyramid + checkpoint under a white background.
+        let cfg1 = EngineConfig {
+            background_rgb: [255, 255, 255],
+            ..EngineConfig::default()
+        };
+        let sink1 = FsSink::new(root.clone(), plan.clone()).with_format(TileFormat::Raw);
+        EngineBuilder::new(&src, plan.clone(), &sink1)
+            .with_engine(EngineKind::Monolithic)
+            .with_config(cfg1)
+            .with_resume(ResumePolicy::overwrite())
+            .run()
+            .unwrap();
+
+        // The hash the checkpoint recorded on disk.
+        let checkpoint_hash = JobCheckpoint::load(&root)
+            .unwrap()
+            .expect("run 1 must have written a checkpoint")
+            .plan_hash;
+
+        // Run 2: resume the SAME directory with a different background. The
+        // padding colour is part of the hashed content contract, so the resume
+        // gate must reject it.
+        let cfg2 = EngineConfig {
+            background_rgb: [0, 0, 0],
+            ..EngineConfig::default()
+        };
+        let sink2 = FsSink::new(root.clone(), plan.clone()).with_format(TileFormat::Raw);
+        let current_hash = compute_plan_hash(&plan, &PlanContract::from_engine(&cfg2, &sink2));
+
+        let err = EngineBuilder::new(&src, plan.clone(), &sink2)
+            .with_engine(EngineKind::Monolithic)
+            .with_config(cfg2)
+            .with_resume(ResumePolicy::resume())
+            .run()
+            .expect_err("resume with a changed background must be rejected");
+
+        let (expected, actual) = match &err {
+            EngineError::PlanHashMismatch { expected, actual } => {
+                (expected.clone(), actual.clone())
+            }
+            other => panic!("expected PlanHashMismatch, got {other:?}"),
+        };
+        assert_ne!(
+            expected, actual,
+            "a genuine mismatch must carry two different hashes"
+        );
+        assert_eq!(
+            actual, checkpoint_hash,
+            "`actual` must be the hash the on-disk checkpoint recorded"
+        );
+        assert_eq!(
+            expected, current_hash,
+            "`expected` must be the hash the current run computes for its plan"
+        );
+
+        // The rendered message must attribute each hash to the correct side.
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&format!("current plan hashes to {current_hash}")),
+            "message must name the current plan hash as expected: {msg}"
+        );
+        assert!(
+            msg.contains(&format!("checkpoint on disk recorded {checkpoint_hash}")),
+            "message must name the checkpoint hash as actual: {msg}"
+        );
+    }
+
+    /// `catch_worker_panic` must convert a panicking body into the typed
+    /// [`EngineError::WorkerPanic`] and pass `Ok` / `Err` through unchanged, so
+    /// a worker fault surfaces on the tile channel instead of unwinding out of
+    /// `thread::scope` (issue #118).
+    #[test]
+    fn catch_worker_panic_maps_panic_and_passes_through() {
+        // Pass-through: Ok and Err are returned verbatim.
+        let ok: Result<u32, EngineError> = catch_worker_panic(|| Ok(7));
+        assert!(matches!(ok, Ok(7)));
+        let err: Result<u32, EngineError> = catch_worker_panic(|| Err(EngineError::Cancelled));
+        assert!(matches!(err, Err(EngineError::Cancelled)));
+
+        // A panic is contained and mapped to WorkerPanic. Silence the default
+        // hook so the intentional panic does not spam test output.
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let panicked: Result<u32, EngineError> =
+            catch_worker_panic(|| panic!("simulated broken tiling invariant"));
+        std::panic::set_hook(prev);
+        assert!(
+            matches!(panicked, Err(EngineError::WorkerPanic)),
+            "a panicking worker body must map to EngineError::WorkerPanic, got {panicked:?}"
+        );
+    }
+
+    /// Reproduces the parallel emission-pool structure: a worker panics inside
+    /// `std::thread::scope` while its peers make progress. The panic must reach
+    /// the consumer as [`EngineError::WorkerPanic`] rather than re-raise out of
+    /// the scope, and a sink guarded by a `Mutex` must stay usable afterwards
+    /// because the fault was contained, not unwound (issue #118).
+    #[test]
+    fn contained_worker_panic_surfaces_as_error_without_poisoning() {
+        use std::sync::Mutex;
+
+        let (tx, rx) = crate::sync_queue::bounded::<Result<u32, EngineError>>(4);
+        let sink: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let outcome: Result<(), EngineError> = std::thread::scope(|s| {
+            for wid in 0..4u32 {
+                let tx = tx.clone();
+                s.spawn(move || {
+                    let r = catch_worker_panic(|| {
+                        if wid == 2 {
+                            panic!("worker {wid} hit a broken invariant");
+                        }
+                        Ok(wid)
+                    });
+                    let _ = tx.send(r);
+                });
+            }
+            drop(tx);
+            for msg in rx {
+                // A contained worker panic arrives here as a plain `Err`.
+                let v = msg?;
+                sink.lock().unwrap().push(v);
+            }
+            Ok(())
+        });
+        std::panic::set_hook(prev);
+
+        assert!(
+            matches!(outcome, Err(EngineError::WorkerPanic)),
+            "a contained worker panic must surface as WorkerPanic, got {outcome:?}"
+        );
+        // The consumer never unwound while holding the lock, so the sink mutex
+        // is not poisoned and remains usable.
+        assert!(
+            sink.lock().is_ok(),
+            "the sink mutex was poisoned by a contained worker fault"
+        );
+    }
+
+    /// Verify must probe only the sink's active on-disk format. A stale sibling
+    /// file of a *different* format left by a previous run must not stand in for
+    /// a missing active-format tile (issue #139).
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn verify_uses_active_format_and_rejects_stale_sibling() {
+        use crate::sink::{FsSink, TileFormat};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("tiles");
+        let src = gradient_raster(128, 128);
+        let plan = PyramidPlanner::new(128, 128, 64, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+        let sink = FsSink::new(&root, plan.clone()).with_format(TileFormat::Raw);
+        let cfg = EngineConfig::default();
+        generate_pyramid_observed(&src, &plan, &sink, &cfg, &NoopObserver).unwrap();
+
+        // Baseline: a clean raw pyramid verifies.
+        raster_verify(&src, &plan, &sink, &cfg, &NoopObserver)
+            .expect("a clean raw pyramid must verify");
+
+        // Remove the active-format (.raw) tile and drop a stale .png of a
+        // different format at the same coordinate, as a previous run would.
+        let coord = plan.tile_coords().next().unwrap();
+        let raw_rel = plan.tile_path(coord, "raw").unwrap();
+        let png_rel = plan.tile_path(coord, "png").unwrap();
+        std::fs::remove_file(root.join(&raw_rel)).unwrap();
+        std::fs::write(root.join(&png_rel), b"\x89PNG stale bytes from an old run").unwrap();
+
+        let err = raster_verify(&src, &plan, &sink, &cfg, &NoopObserver).expect_err(
+            "a missing active-format tile must fail Verify even when a stale sibling exists",
+        );
+        assert!(
+            err.to_string().contains("missing tile"),
+            "expected a missing-tile error for the absent .raw tile, got {err:?}"
+        );
+    }
+
+    /// A manifest checksum mismatch must be attributed to the offending tile,
+    /// not a col/row-transposed coordinate. Google layout stores tiles at
+    /// `{level}/{row}/{col}`, which the layout-agnostic path parser transposes;
+    /// the plan-scan attribution keeps the reported coordinate correct (issue
+    /// #139).
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn verify_attributes_google_checksum_mismatch_to_correct_tile() {
+        use crate::manifest::ChecksumAlgo;
+        use crate::sink::{FsSink, TileFormat};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("tiles");
+        let src = gradient_raster(300, 300);
+        let plan = PyramidPlanner::new(300, 300, 64, 0, Layout::Google)
+            .unwrap()
+            .plan();
+        let sink = FsSink::new(&root, plan.clone()).with_format(TileFormat::Raw);
+        let cfg = EngineConfig::default();
+        generate_pyramid_observed(&src, &plan, &sink, &cfg, &NoopObserver).unwrap();
+
+        // A `col != row` tile exposes the transposition, since its on-disk path
+        // `{level}/{row}/{col}` parses to the swapped coordinate.
+        let target = plan
+            .tile_coords()
+            .find(|c| c.col != c.row)
+            .expect("Google plan must contain a col != row tile");
+        let transposed = TileCoord::new(target.level, target.row, target.col);
+        assert_ne!(target, transposed);
+
+        // Record every tile's pristine digest into a manifest next to the tiles.
+        let mut per_tile = serde_json::Map::new();
+        for coord in plan.tile_coords() {
+            let rel = plan.tile_path(coord, "raw").unwrap();
+            let digest =
+                crate::checksum::hash_file(&root.join(&rel), ChecksumAlgo::Blake3).unwrap();
+            per_tile.insert(rel, serde_json::Value::String(digest));
+        }
+        let manifest = serde_json::json!({
+            "checksums": { "algo": "blake3", "per_tile": serde_json::Value::Object(per_tile) }
+        });
+        std::fs::write(
+            root.join("manifest.json"),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        // Corrupt ONLY the target tile so it is the single digest mismatch.
+        let target_abs = root.join(plan.tile_path(target, "raw").unwrap());
+        let mut bytes = std::fs::read(&target_abs).unwrap();
+        bytes[0] ^= 0xFF;
+        std::fs::write(&target_abs, &bytes).unwrap();
+
+        let err = raster_verify(&src, &plan, &sink, &cfg, &NoopObserver)
+            .expect_err("a corrupted tile must fail manifest verification");
+        match err {
+            EngineError::ChecksumMismatch { tile, .. } => {
+                assert_eq!(
+                    tile, target,
+                    "mismatch must be attributed to the corrupted tile, not its transpose"
+                );
+                assert_ne!(tile, transposed);
+            }
+            other => panic!("expected ChecksumMismatch, got {other:?}"),
+        }
     }
 
     /**

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -1,12 +1,10 @@
 //! Unified fluent entry point for pyramid generation.
 //!
-//! [`EngineBuilder`] collapses the five free-function entry points
-//! ([`generate_pyramid`](crate::generate_pyramid),
-//! [`generate_pyramid_observed`](crate::generate_pyramid_observed),
-//! [`generate_pyramid_streaming`](crate::generate_pyramid_streaming),
-//! [`generate_pyramid_mapreduce`](crate::generate_pyramid_mapreduce),
-//! [`generate_pyramid_mapreduce_auto`](crate::generate_pyramid_mapreduce_auto))
-//! behind a single typed builder. Call
+//! [`EngineBuilder`] is the single typed entry point for pyramid generation.
+//! It folds what used to be a family of monolithic, streaming, and MapReduce
+//! free functions behind one fluent builder, so callers pick the engine through
+//! [`with_engine`](EngineBuilder::with_engine) (see [`EngineKind`]) rather than
+//! by choosing a function name. Call
 //! [`EngineBuilder::new(source, plan, sink)`](EngineBuilder::new), chain any
 //! combination of `with_*` setters, then [`EngineBuilder::run`] or
 //! [`EngineBuilder::run_collect`].
@@ -1054,12 +1052,12 @@ fn prepare_resume_state(
                 if let Some(root) = crate::engine::resolve_checkpoint_root(config, sink) {
                     match crate::resume::JobCheckpoint::load(&root)? {
                         Some(meta) => {
-                            if let Err(got) =
+                            if let Err(current) =
                                 crate::resume::verify_checkpoint_contract(&meta, plan, config, sink)
                             {
                                 return Err(EngineError::PlanHashMismatch {
-                                    expected: meta.plan_hash.clone(),
-                                    got,
+                                    expected: current,
+                                    actual: meta.plan_hash.clone(),
                                 });
                             }
                             (meta.completed_tiles, meta.levels_completed)

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -3,7 +3,7 @@
 //! [`EngineObserver`](crate::observe::EngineObserver),
 //! [`StripSource`](crate::streaming::StripSource)).
 //!
-//! The shape mirrors [`http::Extensions`]: a `TypeId`-keyed map of
+//! The shape mirrors `http::Extensions`: a `TypeId`-keyed map of
 //! `Box<dyn Any + Send + Sync>`. One slot per `TypeId`; re-inserting a type
 //! overwrites the previous value. Values must be `Send + Sync + 'static` so
 //! the map itself is trivially `Send + Sync`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! # libviprs — High-performance tile pyramid generation
 //!
 //! libviprs converts large raster images and PDF documents into multi-resolution
@@ -66,8 +67,10 @@ pub mod resume;
 pub mod retry;
 pub mod sink;
 #[cfg(feature = "s3")]
+#[cfg_attr(docsrs, doc(cfg(feature = "s3")))]
 pub mod sink_object_store;
 #[cfg(feature = "packfile")]
+#[cfg_attr(docsrs, doc(cfg(feature = "packfile")))]
 pub mod sink_packfile;
 pub mod source;
 pub mod stream_verify;
@@ -94,6 +97,7 @@ pub use manifest::{
 };
 pub use observe::{CollectingObserver, EngineEvent, EngineObserver, MemoryTracker};
 #[cfg(feature = "pdfium")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pdfium")))]
 pub use pdf::{BudgetRenderResult, render_page_pdfium, render_page_pdfium_budgeted};
 pub use pdf::{PageRotation, PdfError, PdfInfo, PdfPageInfo, extract_page_image, pdf_info};
 pub use pixel::PixelFormat;
@@ -109,8 +113,10 @@ pub use sink::{
     BLANK_TILE_MARKER, CollectedTile, FsSink, MemorySink, SinkError, Tile, TileFormat, TileSink,
 };
 #[cfg(feature = "s3")]
+#[cfg_attr(docsrs, doc(cfg(feature = "s3")))]
 pub use sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 #[cfg(feature = "packfile")]
+#[cfg_attr(docsrs, doc(cfg(feature = "packfile")))]
 pub use sink_packfile::{PackfileFormat, PackfileSink, PackfileSinkBuilder};
 pub use source::{SourceError, decode_bytes, decode_file, generate_test_raster};
 pub use streaming::{
@@ -118,5 +124,6 @@ pub use streaming::{
     estimate_streaming_memory,
 };
 #[cfg(feature = "pdfium")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pdfium")))]
 pub use streaming::{PdfiumRenderMode, PdfiumStripSource};
 pub use streaming_mapreduce::MapReduceConfig;

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -66,7 +66,7 @@ pub enum EngineEvent {
     /// A tile was produced and sent to the sink.
     TileCompleted { coord: TileCoord },
     /// A tile failed terminally and was skipped under
-    /// [`FailurePolicy::RetryThenSkip`](crate::engine::FailurePolicy).
+    /// [`FailurePolicy::RetryThenSkip`](crate::retry::FailurePolicy::RetryThenSkip).
     ///
     /// Emitted *instead of* [`TileCompleted`](Self::TileCompleted): a tile
     /// that failed every retry produced no output, so reporting it as

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -277,14 +277,14 @@ impl PyramidPlanner {
         }
     }
 
-    /// Estimates the peak heap memory (in bytes) that
-    /// [`generate_pyramid_observed`](crate::generate_pyramid_observed) will
-    /// consume for this planner configuration.
+    /// Estimates the peak heap memory (in bytes) that a monolithic pyramid run
+    /// through [`EngineBuilder::run`](crate::EngineBuilder::run) will consume for
+    /// this planner configuration.
     ///
     /// The estimate covers the two largest allocations that coexist at peak:
     ///
     /// 1. **Source raster** — the caller-owned RGBA8 image passed by reference
-    ///    to `generate_pyramid_observed`. Size: `image_width × image_height × 4`.
+    ///    to the engine. Size: `image_width × image_height × 4`.
     ///
     /// 2. **Canvas raster** — when centring is enabled, the engine embeds the
     ///    source into a padded canvas before downscaling. For `Google` layout
@@ -687,7 +687,7 @@ impl PyramidPlan {
     /// `peak = canvas_bytes + canvas_bytes / 4`
     ///
     /// This estimate is conservative — it ignores smaller intermediate buffers
-    /// that are freed quickly. Used by [`generate_pyramid_auto`](crate::streaming::generate_pyramid_auto)
+    /// that are freed quickly. Used by [`EngineKind::Auto`](crate::EngineKind::Auto)
     /// to decide whether the monolithic path fits within the memory budget.
     ///
     /// **See also:** [interactive example](https://libviprs.org/cli/#flag-memory-limit)

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -1768,8 +1768,10 @@ mod tests {
 
         let got = verify_checkpoint_contract(&meta, &plan, &config, &png)
             .expect_err("a divergent plan_hash must be rejected by the resume gate");
-        // The gate hands back the *actual* hash for the engine to embed in
-        // `EngineError::PlanHashMismatch { expected, got }`.
+        // The gate hands back the freshly computed hash of the current plan,
+        // which the engine embeds as the `expected` field of
+        // `EngineError::PlanHashMismatch { expected, actual }` (the `actual`
+        // field carries the divergent hash recorded in the checkpoint).
         assert_eq!(
             got,
             compute_plan_hash(&plan, &PlanContract::from_engine(&config, &png)),

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -582,8 +582,8 @@ impl TileFormat {
 ///
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-sink)
 ///
-/// `Debug` is implemented manually because the internal [`DedupeIndex`] does
-/// not derive `Debug`.
+/// `Debug` is implemented manually because the internal
+/// [`DedupeIndex`](crate::dedupe::DedupeIndex) does not derive `Debug`.
 ///
 /// # Lock discipline
 ///

--- a/src/stream_verify.rs
+++ b/src/stream_verify.rs
@@ -28,10 +28,12 @@ use crate::streaming::{StripSource, obtain_canvas_strip};
 
 /// Candidate tile file extensions probed when looking for a tile on disk.
 ///
-/// The sink's active format is not visible from this layer (the `TileSink`
-/// trait object doesn't expose it), so we probe the extensions produced by
-/// every [`TileFormat`](crate::sink::TileFormat) variant before declaring a
-/// tile missing. This matches the behaviour of `engine::run_verify`.
+/// Fallback probe set used only when the sink does not pin a concrete format
+/// (a transparent wrapper that returns `None` from
+/// [`TileSink::content_format`](crate::sink::TileSink::content_format)). When
+/// the format *is* known, [`active_candidate_exts`] narrows the probe to the
+/// active format so Verify does not validate a stale sibling file (issue #139).
+/// This matches the behaviour of `engine::raster_verify`.
 const CANDIDATE_EXTS: [&str; 4] = ["raw", "png", "jpeg", "jpg"];
 
 /// A [`StripSource`](crate::streaming::StripSource) (or the canvas-embedding
@@ -140,16 +142,19 @@ pub fn verify_from_strip_source(
     let root_buf = resolve_root(config, sink).ok_or(EngineError::VerifyRequiresOnDiskSink)?;
     let root = root_buf.as_path();
     let bg = config.background_rgb;
+    // Probe only the sink's active on-disk format so a stale sibling file from
+    // a previous run in a different format cannot pass Verify (issue #139).
+    let active_exts = active_candidate_exts(sink);
 
     // Fast-fail when the on-disk checkpoint was produced from a different
     // plan. Mirrors the Monolithic raster_verify path so verify errors on
     // plan divergence surface structurally instead of as per-tile byte
     // mismatches.
     if let Some(meta) = crate::resume::JobCheckpoint::load(root)? {
-        if let Err(got) = crate::resume::verify_checkpoint_contract(&meta, plan, config, sink) {
+        if let Err(current) = crate::resume::verify_checkpoint_contract(&meta, plan, config, sink) {
             return Err(EngineError::PlanHashMismatch {
-                expected: meta.plan_hash,
-                got,
+                expected: current,
+                actual: meta.plan_hash,
             });
         }
     }
@@ -163,7 +168,7 @@ pub fn verify_from_strip_source(
     // (e.g. pointed at a stale run) before we spend time re-rendering.
     // ------------------------------------------------------------------
     for coord in plan.tile_coords() {
-        if find_tile_on_disk(root, plan, coord).is_none() {
+        if find_tile_on_disk(root, plan, coord, &active_exts).is_none() {
             return Err(EngineError::Sink(SinkError::Other(format!(
                 "Verify: missing tile for coord {coord:?}"
             ))));
@@ -229,8 +234,7 @@ pub fn verify_from_strip_source(
                         };
                         if !got.eq_ignore_ascii_case(expected_s) {
                             return Err(EngineError::ChecksumMismatch {
-                                tile: parse_tile_rel_path(rel)
-                                    .unwrap_or_else(|| TileCoord::new(0, 0, 0)),
+                                tile: coord_for_manifest_rel(plan, rel),
                                 expected: expected_s.to_string(),
                                 got,
                             });
@@ -381,7 +385,7 @@ pub fn verify_from_strip_source(
                     crate::streaming::extract_tile_from_strip(&current, plan, coord, 0, bg)?;
                 let expected_bytes = expected.data();
 
-                let (abs, ext) = match find_tile_on_disk(root, plan, coord) {
+                let (abs, ext) = match find_tile_on_disk(root, plan, coord, &active_exts) {
                     Some(found) => found,
                     None => {
                         return Err(EngineError::Sink(SinkError::Other(format!(
@@ -462,7 +466,23 @@ pub fn verify_from_strip_source(
 // kept file-local so this module can be built without touching the engine.
 // ---------------------------------------------------------------------------
 
-/// Locate a tile on disk by probing the candidate extensions.
+/// The tile-file extensions to probe for the sink's active on-disk format.
+///
+/// A previous run in a different format can leave a stale sibling file (e.g. a
+/// `.png` when this run writes `.raw`); probing every extension and taking the
+/// first hit would validate that stale file and let a missing active-format
+/// tile pass. When the sink pins a concrete format we probe only it; a
+/// transparent wrapper that reports `None` falls back to every known extension
+/// (issue #139).
+fn active_candidate_exts(sink: &dyn TileSink) -> Vec<&'static str> {
+    match sink.content_format() {
+        Some(crate::sink::TileFormat::Jpeg { .. }) => vec!["jpeg", "jpg"],
+        Some(fmt) => vec![fmt.extension()],
+        None => CANDIDATE_EXTS.to_vec(),
+    }
+}
+
+/// Locate a tile on disk by probing `exts` in order.
 ///
 /// Returns `Some((absolute_path, extension))` for the first candidate that
 /// exists as a regular file, or `None` if none match.
@@ -470,8 +490,9 @@ fn find_tile_on_disk(
     root: &std::path::Path,
     plan: &PyramidPlan,
     coord: TileCoord,
+    exts: &[&'static str],
 ) -> Option<(PathBuf, &'static str)> {
-    for ext in &CANDIDATE_EXTS {
+    for ext in exts {
         if let Some(rel) = plan.tile_path(coord, ext) {
             let abs = root.join(&rel);
             if abs.is_file() {
@@ -480,6 +501,28 @@ fn find_tile_on_disk(
         }
     }
     None
+}
+
+/// Resolve the [`TileCoord`] a manifest tile key refers to, so a checksum
+/// mismatch is attributed to the offending tile instead of a fabricated
+/// `TileCoord(0, 0, 0)` (or a col/row-transposed coordinate).
+///
+/// The authoritative match scans the plan for the coordinate whose
+/// [`PyramidPlan::tile_path`] equals the key; this is exact for every layout,
+/// including Google (`{level}/{row}/{col}`), which the layout-agnostic
+/// [`parse_tile_rel_path`] would otherwise transpose. The structural parse is
+/// kept only as a fallback for a foreign key the plan does not produce (issue
+/// #139).
+fn coord_for_manifest_rel(plan: &PyramidPlan, rel: &str) -> TileCoord {
+    let normalized = rel.replace('\\', "/");
+    for coord in plan.tile_coords() {
+        for ext in CANDIDATE_EXTS {
+            if plan.tile_path(coord, ext).is_some_and(|p| p == normalized) {
+                return coord;
+            }
+        }
+    }
+    parse_tile_rel_path(rel).unwrap_or_else(|| TileCoord::new(0, 0, 0))
 }
 
 /// Resolve the on-disk checkpoint root, preferring the config override.

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -36,9 +36,12 @@
 //!
 //! ## Entry points
 //!
-//! - [`generate_pyramid_streaming`] — explicit streaming with a [`StripSource`].
-//! - [`generate_pyramid_auto`] — auto-selects monolithic or streaming based on
-//!   the budget vs. estimated monolithic peak memory.
+//! Streaming is reached through the fluent
+//! [`EngineBuilder`](crate::EngineBuilder). Select it explicitly with
+//! [`EngineKind::Streaming`](crate::EngineKind::Streaming) over a
+//! [`StripSource`], or let [`EngineKind::Auto`](crate::EngineKind::Auto)
+//! choose monolithic vs. streaming based on the budget vs. the estimated
+//! monolithic peak memory.
 
 use crate::engine::{
     BlankTileStrategy, EngineConfig, EngineError, EngineResult, promote_sink_error,
@@ -175,8 +178,9 @@ pub trait StripSource: Send + Sync {
 /// Extracts row bands via [`Raster::extract`], which copies the requested
 /// rows into a new buffer without touching the rest of the source.
 ///
-/// This is the default source used by [`generate_pyramid_auto`] when the
-/// monolithic path would exceed the memory budget. The source raster still
+/// This is the default source used by
+/// [`EngineKind::Auto`](crate::EngineKind::Auto) when the monolithic path would
+/// exceed the memory budget. The source raster still
 /// lives in memory, but the pyramid generation pipeline avoids the large
 /// canvas-sized working allocation that the monolithic engine requires.
 pub struct RasterStripSource<'a> {

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -23,9 +23,12 @@
 //!
 //! ## Entry points
 //!
-//! - [`generate_pyramid_mapreduce`] — explicit MapReduce with a [`StripSource`].
-//! - [`generate_pyramid_mapreduce_auto`] — auto-selects monolithic or MapReduce
-//!   based on the budget vs. estimated monolithic peak memory.
+//! MapReduce is reached through the fluent
+//! [`EngineBuilder`](crate::EngineBuilder). Select it explicitly with
+//! [`EngineKind::MapReduce`](crate::EngineKind::MapReduce) over a
+//! [`StripSource`], or let [`EngineKind::Auto`](crate::EngineKind::Auto)
+//! choose monolithic vs. MapReduce based on the budget vs. the estimated
+//! monolithic peak memory.
 
 use crate::engine::{
     BlankTileStrategy, EngineConfig, EngineError, EngineResult, is_blank_for_strategy,
@@ -159,8 +162,8 @@ fn estimate_mono_buffer_cost(plan: &PyramidPlan, format: PixelFormat) -> u64 {
 /// plus the channel could push the peak toward 2× budget.
 ///
 /// Returns at least 1. When even a single strip does not fit, callers rely on
-/// the pre-flight [`EngineError::BudgetExceeded`] check in
-/// [`generate_pyramid_mapreduce`] to reject the budget up front.
+/// the pre-flight [`EngineError::BudgetExceeded`] check in the MapReduce engine
+/// to reject the budget up front.
 ///
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-parallel)
 pub fn compute_inflight_strips(
@@ -290,22 +293,27 @@ fn emit_strip_tiles_parallel(
 
             s.spawn(move || {
                 for coord in chunk {
-                    let result = crate::streaming::extract_tile_from_strip(
-                        strip,
-                        plan,
-                        coord,
-                        strip_canvas_y,
-                        bg,
-                    )
-                    .map(|tile_raster| {
-                        let blank = is_blank_for_strategy(&tile_raster, blank_strategy);
-                        Tile {
+                    // Contain a worker panic as a typed `WorkerPanic` on the
+                    // channel rather than letting it unwind out of
+                    // `thread::scope`, matching the map phase (issue #118).
+                    let result = crate::engine::catch_worker_panic(|| {
+                        crate::streaming::extract_tile_from_strip(
+                            strip,
+                            plan,
                             coord,
-                            raster: tile_raster,
-                            blank,
-                        }
-                    })
-                    .map_err(EngineError::from);
+                            strip_canvas_y,
+                            bg,
+                        )
+                        .map(|tile_raster| {
+                            let blank = is_blank_for_strategy(&tile_raster, blank_strategy);
+                            Tile {
+                                coord,
+                                raster: tile_raster,
+                                blank,
+                            }
+                        })
+                        .map_err(EngineError::from)
+                    });
                     if tx.send(result).is_err() {
                         break;
                     }


### PR DESCRIPTION
Batches four small [Low] engine cleanups that all live in `engine.rs` and its neighbours into one PR.

## #118: Unify worker-panic handling across all parallel paths
Add `catch_worker_panic`, a shared containment helper that maps a panicking tile-extraction body to the typed `EngineError::WorkerPanic`, and route both the monolithic producer pool (`engine.rs`) and the MapReduce tile-emission pool (`streaming_mapreduce.rs`) through it. Those pools previously spawned workers without collecting the join handles, so a worker panic re-raised out of `std::thread::scope` and propagated as a raw panic through the engine entry point, poisoning the sink/observer mutexes on the way out. Every parallel path now surfaces a contained worker fault as the same typed error the MapReduce map phase already returns.
Tests: `catch_worker_panic_maps_panic_and_passes_through` (mapping + pass-through) and `contained_worker_panic_surfaces_as_error_without_poisoning` (a worker panics inside `thread::scope`; the consumer receives `WorkerPanic` and the sink mutex is not poisoned).

## #139: Fix verify-mode gaps
Probe only the sink's active on-disk format so a stale sibling file of a different format left by a previous run can no longer stand in for a missing active-format tile, in both `raster_verify` and `verify_from_strip_source`. Attribute a manifest checksum mismatch to the offending tile by scanning the plan for the coordinate whose `tile_path` matches the key, which is exact for every layout including Google (`{level}/{row}/{col}`) that the layout-agnostic path parser would otherwise transpose; the structural parse is kept only as a fallback.
Tests: `verify_uses_active_format_and_rejects_stale_sibling` and `verify_attributes_google_checksum_mismatch_to_correct_tile`.

## #145: Unify PlanHashMismatch field naming and wording
Rename the `{expected, got}` fields to `{expected, actual}` to match the resume layer's convention, and correct the assignment so `expected` carries the current run's plan hash and `actual` carries the hash the on-disk checkpoint recorded. The rendered message now reads unambiguously instead of naming the checkpoint hash as "expected". All three construction sites (`engine.rs`, `engine_builder.rs`, `stream_verify.rs`) and the `Display` are updated together. The checksum-mismatch representations were reviewed and kept as distinct typed layers (`SinkError` carries a rel-path, `EngineError` a `TileCoord`) since each already renders consistent `expected`/`got` wording.
Test: `plan_hash_mismatch_names_current_expected_and_checkpoint_actual`.

## #146: Fix broken intra-doc links, add docs.rs metadata, deny broken links in CI
Repair the broken intra-doc links (stale `generate_pyramid*` references, the removed `http::Extensions` external link, the wrong `FailurePolicy` and `DedupeStrategy` paths), delete the orphaned `generate_pyramid` doc block that had concatenated onto `generate_pyramid_observed`, and reword the stale streaming/MapReduce entry-point docs to describe the `EngineBuilder` / `EngineKind` reality. Add `[package.metadata.docs.rs]` (`all-features = true`, `--cfg docsrs`) with `#[cfg_attr(docsrs, doc(cfg(...)))]` on the feature-gated surface, plus a Makefile `doc` target and a CI `docs` job that deny broken intra-doc links with all features enabled.
Verification: `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features` is clean.

## Local mirror
`make fmt`, `make clippy` (both variants), `make test`, and `make doc` are green, including the new reproducers.

Closes #118, Closes #139, Closes #145, Closes #146