### PR TITLE
Adopt a root cargo workspace with a shared [patch] and a single lockfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,35 @@
+# Root workspace (issue #151). Every crate in this repo is a member, so the
+# repo has one lockfile and one [patch.crates-io] table. The fuzz crate used
+# to be detached by its own empty [workspace] table, which gave it a private
+# lockfile and silently dropped the pdfium-render fork patch.
+[workspace]
+members = ["fuzz"]
+# Stated explicitly for clarity; this is already the edition-2024 default
+# (MSRV-aware resolver v3), so resolution behavior is unchanged.
+resolver = "3"
+
+# Single-sourced version pins shared by every workspace member. Members
+# inherit with `{ workspace = true }` so versions cannot drift per crate.
+[workspace.dependencies]
+arbitrary = { version = "1", features = ["derive"] }
+blake3 = "1.8.4"
+flate2 = "1"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "tiff"] }
+libfuzzer-sys = "0.4"
+libviprs = { path = "." }
+loom = "0.7"
+lopdf = "0.36"
+pdfium-render = { version = "0.8", features = ["sync"] }
+proptest = "1"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+sha2 = "0.11.0"
+tar = "0.4.45"
+tempfile = "3"
+thiserror = "2"
+tracing = "0.1"
+zip = "7.2.0"
+
 [package]
 name = "libviprs"
 version = "0.3.1"
@@ -40,23 +72,23 @@ tracing = ["dep:tracing"]
 packfile = ["dep:tar", "dep:zip"]
 
 [dependencies]
-blake3 = "1.8.4"
-flate2 = "1"
-image = { version = "0.25", default-features = false, features = ["jpeg", "png", "tiff"] }
-lopdf = "0.36"
-pdfium-render = { version = "0.8", optional = true, features = ["sync"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-sha2 = "0.11.0"
-tar = { version = "0.4.45", optional = true }
-thiserror = "2"
-tracing = { version = "0.1", optional = true }
-zip = { version = "7.2.0", optional = true }
+blake3 = { workspace = true }
+flate2 = { workspace = true }
+image = { workspace = true }
+lopdf = { workspace = true }
+pdfium-render = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tar = { workspace = true, optional = true }
+thiserror = { workspace = true }
+tracing = { workspace = true, optional = true }
+zip = { workspace = true, optional = true }
 
 [dev-dependencies]
-loom = "0.7"
-proptest = "1"
-tempfile = "3"
+loom = { workspace = true }
+proptest = { workspace = true }
+tempfile = { workspace = true }
 
 # Use libviprs/pdfium-render with proper per-call thread-safety locking
 # in `ThreadSafePdfiumBindings`. Upstream pdfium-render 0.8.37's
@@ -69,5 +101,8 @@ tempfile = "3"
 #
 # Tracking issue: ajrcarey/pdfium-render upstream PR pending. Once
 # merged + released, this patch can be dropped.
+#
+# Because this table lives at the workspace root, it applies to every
+# workspace member; cargo ignores [patch] tables in member manifests.
 [patch.crates-io]
 pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/per-call-thread-safety" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,12 +8,13 @@ authors = ["Roman Goldmann <roman@devshell.org>"]
 [package.metadata]
 cargo-fuzz = true
 
+# Versions are single-sourced in [workspace.dependencies] at the repo root
+# (issue #151). This crate is a workspace member, so it shares the root
+# lockfile and the root [patch.crates-io] table.
 [dependencies]
-libfuzzer-sys = "0.4"
-arbitrary = { version = "1", features = ["derive"] }
-
-[dependencies.libviprs]
-path = ".."
+libfuzzer-sys = { workspace = true }
+arbitrary = { workspace = true }
+libviprs = { workspace = true }
 
 [[bin]]
 name = "fuzz_decode"
@@ -24,5 +25,3 @@ doc = false
 name = "fuzz_pdf_render"
 path = "fuzz_targets/fuzz_pdf_render.rs"
 doc = false
-
-[workspace]

--- a/tests/workspace_layout.rs
+++ b/tests/workspace_layout.rs
@@ -1,0 +1,115 @@
+//! Guards for the cargo-workspace layout adopted in issue #151.
+//!
+//! The repo used to have two disjoint cargo roots: the `libviprs` package and
+//! a `fuzz/` crate detached by an empty `[workspace]` table. The detached
+//! crate resolved dependencies on its own, with its own lockfile, and never
+//! saw the root `[patch.crates-io]` that pins `pdfium-render` to the
+//! thread-safety fork. These tests assert the unified layout: one workspace,
+//! one lockfile, and a `[patch]` table that applies to every member.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Repo root (the directory containing the root `Cargo.toml`).
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Run `cargo metadata --no-deps` against the given manifest and parse it.
+fn metadata_no_deps(manifest: &Path) -> serde_json::Value {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+    let out = Command::new(cargo)
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .arg("--manifest-path")
+        .arg(manifest)
+        .output()
+        .expect("failed to spawn cargo metadata");
+    assert!(
+        out.status.success(),
+        "cargo metadata failed for {}:\n{}",
+        manifest.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("cargo metadata emitted invalid JSON")
+}
+
+/// The fuzz crate must be a member of the root workspace, not a detached
+/// cargo root with its own lockfile and its own (patch-less) resolution.
+#[test]
+fn fuzz_crate_is_a_member_of_the_root_workspace() {
+    let root = repo_root();
+    let meta = metadata_no_deps(&root.join("fuzz").join("Cargo.toml"));
+
+    let workspace_root = Path::new(meta["workspace_root"].as_str().unwrap());
+    assert_eq!(
+        workspace_root.canonicalize().unwrap(),
+        root.canonicalize().unwrap(),
+        "fuzz/Cargo.toml must resolve to the repo-root workspace, \
+         not act as its own cargo root"
+    );
+
+    let names: Vec<&str> = meta["packages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    for expected in ["libviprs", "libviprs-fuzz"] {
+        assert!(
+            names.contains(&expected),
+            "workspace members must include {expected}, got: {names:?}"
+        );
+    }
+}
+
+/// Both crates seen from the root manifest: same workspace, so the single
+/// root lockfile and the single `[patch.crates-io]` table govern them all.
+#[test]
+fn root_workspace_contains_both_crates() {
+    let root = repo_root();
+    let meta = metadata_no_deps(&root.join("Cargo.toml"));
+    let members = meta["workspace_members"].as_array().unwrap();
+    assert_eq!(
+        members.len(),
+        2,
+        "expected exactly the libviprs and libviprs-fuzz members, got: {members:?}"
+    );
+}
+
+/// The shared `[patch.crates-io]` must still pin `pdfium-render` to the
+/// libviprs fork (per-call thread-safety locking). The workspace lockfile is
+/// the single source of truth for that resolution.
+#[test]
+fn workspace_lockfile_pins_pdfium_render_to_the_fork() {
+    let lock = std::fs::read_to_string(repo_root().join("Cargo.lock"))
+        .expect("workspace Cargo.lock must exist at the repo root");
+
+    // Find the [[package]] block for pdfium-render and inspect its source.
+    let mut source_lines: Vec<&str> = Vec::new();
+    let mut in_block = false;
+    for line in lock.lines() {
+        if line == "[[package]]" {
+            in_block = false;
+        }
+        if line == "name = \"pdfium-render\"" {
+            in_block = true;
+        }
+        if in_block && line.starts_with("source = ") {
+            source_lines.push(line);
+        }
+    }
+    assert_eq!(
+        source_lines.len(),
+        1,
+        "expected exactly one pdfium-render entry in Cargo.lock, got: {source_lines:?}"
+    );
+    let source = source_lines[0];
+    assert!(
+        source.contains("git+https://github.com/libviprs/pdfium-render.git"),
+        "pdfium-render must resolve from the fork, got: {source}"
+    );
+    assert!(
+        source.contains("per-call-thread-safety"),
+        "pdfium-render must track the per-call-thread-safety branch, got: {source}"
+    );
+}


### PR DESCRIPTION
## What

The fuzz crate detached itself from the repo with an empty `[workspace]` table in `fuzz/Cargo.toml`. That gave it a private lockfile and, worse, dropped the `pdfium-render` fork patch for its resolution, because cargo ignores `[patch]` tables anywhere but the workspace root. This PR makes the repo a single cargo workspace:

- Root `Cargo.toml` declares `[workspace]` with `members = ["fuzz"]` and `resolver = "3"` (stated explicitly; it is already the edition-2024 default, so resolution behavior is unchanged).
- Shared version pins move to `[workspace.dependencies]`; both crates inherit with `{ workspace = true }`, so versions cannot drift per crate.
- `fuzz/Cargo.toml` loses its detaching `[workspace]` table and inherits its pins, including the `libviprs` path dependency.
- The root `[patch.crates-io]` now governs every member, and the repo has exactly one lockfile.

## Safety

- The root package dependency tree is byte-identical before and after (verified with `cargo tree --all-features -e normal,build`, sorted diff empty).
- Default package selection is the root package for a non-virtual workspace, so `make fmt/clippy/test/doc` and every CI job still build exactly what they built before. Features (`pdfium`/`pdfium-static`), MSRV 1.85, and the fork patch resolution are unchanged.
- `cargo check -p libviprs-fuzz` fails on my machine inside libfuzzer-sys's C++ build; I confirmed the identical failure standalone at origin/main, so it is a pre-existing local SDK issue, not a regression (the fuzz crate is not a default member and no Makefile or CI target builds it).

## Test

`tests/workspace_layout.rs` (runs under `make test`):
- `fuzz_crate_is_a_member_of_the_root_workspace` and `root_workspace_contains_both_crates` fail on the old two-root layout (verified red before the manifest change, green after).
- `workspace_lockfile_pins_pdfium_render_to_the_fork` guards that the shared lockfile resolves `pdfium-render` from the libviprs fork on the per-call-thread-safety branch, with exactly one lock entry.

## Local mirror

`make fmt`, `make clippy` (default and `--features pdfium`), `make test` (391 lib tests plus integration tests, all green), `make doc` all pass.

## Remainder (why this does not close #151)

The cross-repo half stays open: `libviprs-cli`, `libviprs-tests`, and `libviprs-bench` live in sibling repos stitched by branch-name convention in CI, and unifying them needs a thin workspace repo of git submodules (plus deciding the org-copy question). This PR delivers the in-repo foundation: one workspace, one lockfile, one `[patch]` table, single-sourced pins ready for future members.

Refs #151