### PR TITLE
Declare the pdfium-render fork as a direct git dependency, not a [patch]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,34 @@ libfuzzer-sys = "0.4"
 libviprs = { path = "." }
 loom = "0.7"
 lopdf = "0.36"
-pdfium-render = { version = "0.8", features = ["sync"] }
+# Direct git dependency on the libviprs/pdfium-render fork, which adds
+# proper per-call thread-safety locking in `ThreadSafePdfiumBindings`.
+# Upstream pdfium-render 0.8.37's wrapper acquires the pdfium global
+# mutex only once on `FPDF_InitLibrary` and bypasses it for every other
+# method, which segfaults under any concurrent access pattern when a
+# single `Pdfium` instance is shared across threads (the common pattern
+# when callers use a process-wide singleton). The fork rewrites every
+# method to acquire the lock per-call.
+#
+# This used to be a `[patch.crates-io]` entry, but a [patch] table only
+# takes effect from the build root: consumers of libviprs (by git or
+# path) silently resolved the unpatched registry wrapper unless they
+# replicated the patch (issue #149). As a direct dependency the fork is
+# an ordinary edge in the graph, so every git/path consumer inherits it
+# with no [patch] hygiene required.
+#
+# The `version` key is a fallback for `cargo publish`: crates.io strips
+# git sources, so the PUBLISHED libviprs still depends on the registry
+# `pdfium-render ^0.8` and crates.io consumers still link the unpatched
+# wrapper. libviprs's own FPDF calls stay safe there via the internal
+# process-wide lock (`src/pdf.rs::pdfium_lock`), but the wrapper's
+# `Send + Sync` remains unsound for direct use. The remaining paths to
+# fix that are tracked in issue #149: upstream the per-call locking
+# (ajrcarey/pdfium-render#262) or publish the fork under a distinct
+# crate name and depend on it by version.
+pdfium-render = { version = "0.8", features = [
+	"sync",
+], git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/per-call-thread-safety" }
 proptest = "1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
@@ -89,20 +116,3 @@ zip = { workspace = true, optional = true }
 loom = { workspace = true }
 proptest = { workspace = true }
 tempfile = { workspace = true }
-
-# Use libviprs/pdfium-render with proper per-call thread-safety locking
-# in `ThreadSafePdfiumBindings`. Upstream pdfium-render 0.8.37's
-# wrapper acquires the pdfium global mutex only once on
-# `FPDF_InitLibrary` and bypasses it for every other method, which
-# segfaults under any concurrent access pattern when a single
-# `Pdfium` instance is shared across threads (the common pattern when
-# callers use a process-wide singleton). The fork rewrites every
-# method to acquire the lock per-call.
-#
-# Tracking issue: ajrcarey/pdfium-render upstream PR pending. Once
-# merged + released, this patch can be dropped.
-#
-# Because this table lives at the workspace root, it applies to every
-# workspace member; cargo ignores [patch] tables in member manifests.
-[patch.crates-io]
-pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/per-call-thread-safety" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 # Versions are single-sourced in [workspace.dependencies] at the repo root
 # (issue #151). This crate is a workspace member, so it shares the root
-# lockfile and the root [patch.crates-io] table.
+# lockfile and the root dependency pins (including the pdfium-render fork).
 [dependencies]
 libfuzzer-sys = { workspace = true }
 arbitrary = { workspace = true }

--- a/scripts/audit-pdfium-source.sh
+++ b/scripts/audit-pdfium-source.sh
@@ -3,11 +3,12 @@
 # audit-pdfium-source.sh — release gate for issue #149.
 #
 # The `pdfium-render` thread-safety fork (per-call locking in
-# `ThreadSafePdfiumBindings`) is applied via `[patch.crates-io]` in this
-# crate's `Cargo.toml`. A `[patch]` table only takes effect from the root
-# of the workspace performing the build, so any sibling crate or crates.io
-# consumer that does NOT replicate the patch silently links the unpatched
-# `pdfium-render 0.8.x` wrapper, which segfaults under concurrent access.
+# `ThreadSafePdfiumBindings`) is a direct git dependency of this crate,
+# so git/path consumers of libviprs inherit it. But cargo strips git
+# sources on publish, so crates.io consumers of the PUBLISHED libviprs
+# still resolve the unpatched `pdfium-render 0.8.x` wrapper, which
+# segfaults under concurrent direct access. Sibling repos that depend on
+# `pdfium-render` directly must pin the fork themselves.
 #
 # This script resolves the dependency graph for a given manifest and fails
 # if `pdfium-render` is sourced from the crates.io registry instead of the
@@ -69,6 +70,7 @@ case "$source_field" in
     echo "audit-pdfium-source: FAIL — pdfium-render does NOT resolve from the libviprs fork (issue #149)." >&2
     echo "  resolved source: ${source_field:-<empty/registry>}" >&2
     echo "  expected a git source containing: $EXPECTED_HOST" >&2
-    echo "  add the [patch.crates-io] pdfium-render fork to this manifest's workspace root." >&2
+    echo "  depend on libviprs by git/path (it pins the fork directly), or pin the" >&2
+    echo "  fork yourself: pdfium-render = { git = \"https://github.com/libviprs/pdfium-render.git\", branch = \"libviprs/per-call-thread-safety\" }" >&2
     exit 1 ;;
 esac

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -980,20 +980,21 @@ fn obj_to_f64(obj: &lopdf::Object) -> Option<f64> {
 ///
 /// pdfium itself is not thread-safe at the C library level. The
 /// `pdfium-render` `sync` feature wraps every FPDF call in a global
-/// mutex, but **only** when libviprs's `[patch.crates-io]` directive
-/// is honoured, which requires the consumer crate (libviprs-tests,
-/// libviprs-cli, downstream users) to either share a workspace with
-/// libviprs or replicate the patch directive. Cargo does not
-/// propagate `[patch.crates-io]` from a path-dependency.
+/// mutex, but **only** in the per-call locking fork that libviprs
+/// declares as a direct git dependency. Consumers that build libviprs
+/// from git or a path inherit that edge, but the crates.io-published
+/// libviprs cannot carry a git source (cargo strips it on publish),
+/// so registry consumers link the upstream wrapper whose locking is
+/// broken (issue #149; upstream ajrcarey/pdfium-render#262).
 ///
-/// To keep libviprs correct without depending on consumer-side
-/// patch hygiene, every FPDF entry point in this crate acquires this
-/// process-wide lock first. If the consumer also has the patched
-/// fork active (the recommended setup), the result is double-locking
-/// — a few extra nanoseconds per call, no correctness or deadlock
-/// concern (the locks are independent `Mutex<()>` instances acquired
-/// in a fixed order). If the patch is missing, this lock alone keeps
-/// concurrent renders safe.
+/// To keep libviprs correct without depending on which wrapper the
+/// consumer's build resolved, every FPDF entry point in this crate
+/// acquires this process-wide lock first. If the fork is also active
+/// (the recommended setup), the result is double-locking: a few extra
+/// nanoseconds per call, no correctness or deadlock concern (the
+/// locks are independent `Mutex<()>` instances acquired in a fixed
+/// order). If the fork is missing, this lock alone keeps concurrent
+/// renders safe.
 ///
 /// **Performance note:** With this lock held, multi-threaded
 /// `render_strip` calls serialise. That matches the underlying
@@ -1351,8 +1352,8 @@ pub(crate) fn strip_matrix(
 ///
 /// FPDF calls underneath this function are serialised by
 /// `pdfium-render`'s `ThreadSafePdfiumBindings` (active via the
-/// `sync` feature plus the `[patch.crates-io]` directive in
-/// `libviprs/Cargo.toml`).
+/// `sync` feature plus the direct git dependency on the per-call
+/// locking fork in `libviprs/Cargo.toml`).
 ///
 /// `dpi`, `rotation`, `y_offset`, `strip_height` semantics match the
 /// matrix derivation documented at [`strip_matrix`].

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -271,8 +271,8 @@ enum PdfiumSourceState {
 /// FPDF synchronisation that protects `FPDF_CloseDocument` against
 /// concurrent renders lives in `pdfium-render`'s
 /// `ThreadSafePdfiumBindings` wrapper (active via the `sync` feature
-/// plus the `[patch.crates-io]` patched fork pinned in
-/// `libviprs/Cargo.toml`).
+/// plus the per-call locking fork declared as a direct git dependency
+/// in `libviprs/Cargo.toml`).
 ///
 /// Lifetime is `'static` because the document borrows from
 /// [`crate::pdf::init_pdfium`]'s `OnceLock`-backed `&'static Pdfium`.
@@ -297,9 +297,10 @@ impl Drop for StreamingState {
         // other FPDF entry point in this crate (see the invariant at
         // `crate::pdf::pdfium_lock`), teardown must acquire the
         // process-wide lock first: with the unpatched `pdfium-render`
-        // (Cargo does not propagate `[patch.crates-io]` downstream), a
-        // close racing a concurrent render inside the non-thread-safe C
-        // library corrupts the heap.
+        // (crates.io builds of libviprs resolve the upstream wrapper,
+        // since cargo strips the git source on publish), a close racing
+        // a concurrent render inside the non-thread-safe C library
+        // corrupts the heap.
         //
         // Checklist: any pdfium-render object whose `Drop` issues FPDF
         // calls must die inside a `pdfium_lock()` scope.

--- a/tests/pdfium_source_audit.rs
+++ b/tests/pdfium_source_audit.rs
@@ -1,17 +1,23 @@
 //! Regression coverage for issue #149.
 //!
-//! The `pdfium-render` per-call thread-safety fork is applied through this
-//! crate's `[patch.crates-io]` table. A `[patch]` only takes effect from the
-//! build root, so any consumer that omits it silently links the unpatched
-//! `pdfium-render 0.8.x` wrapper (documented to segfault under concurrent
-//! access in `src/streaming.rs`). These tests exercise the release gate that
-//! detects that condition, `scripts/audit-pdfium-source.sh`:
+//! The `pdfium-render` per-call thread-safety fork is a direct git
+//! dependency of this crate (it used to be a `[patch.crates-io]` entry,
+//! which only takes effect from the build root, so consumers that omitted
+//! it silently linked the unpatched `pdfium-render 0.8.x` wrapper that is
+//! documented to segfault under concurrent access in `src/streaming.rs`).
+//! These tests exercise the release gate that detects a registry-sourced
+//! wrapper, `scripts/audit-pdfium-source.sh`:
 //!
 //!   1. `audit_gate_accepts_patched_core` — this crate carries the fork, so
-//!      the gate must pass. Guards against the patch being dropped/renamed.
+//!      the gate must pass. Guards against the pin being dropped/renamed.
 //!   2. `audit_gate_rejects_unpatched_consumer` — a synthesized sibling that
-//!      depends on `pdfium-render` without the patch resolves the crates.io
-//!      registry crate; the gate must reject it (this is the #149 defect).
+//!      depends on `pdfium-render` directly from the registry, with no fork
+//!      pin; the gate must reject it (this is the #149 defect).
+//!   3. `patchless_downstream_consumer_resolves_the_fork` — a synthesized
+//!      downstream crate that depends on `libviprs` itself, with NO `[patch]`
+//!      table, must still resolve the fork. This is #149 part 2: the fork
+//!      must propagate to consumers as an ordinary dependency edge instead
+//!      of relying on build-root-only `[patch]` hygiene.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -92,5 +98,56 @@ fn audit_gate_rejects_unpatched_consumer() {
     assert!(
         stderr.contains("does NOT resolve from the libviprs fork"),
         "audit gate rejected for the wrong reason.\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn patchless_downstream_consumer_resolves_the_fork() {
+    // Issue #149 part 2. A downstream crate that depends on libviprs the way
+    // an external git/path consumer does, with no [patch.crates-io] table of
+    // its own, must still resolve the per-call-locking pdfium-render fork.
+    // With the fork applied only via [patch] this fails: cargo ignores a
+    // dependency's [patch] table, so the consumer links the unpatched
+    // registry wrapper. Declaring the fork as a direct git dependency of
+    // libviprs makes it an ordinary edge in the graph, which every git/path
+    // consumer inherits.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    let libviprs_path = repo_root();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        format!(
+            "[package]\n\
+             name = \"vip149-patchless-consumer\"\n\
+             version = \"0.0.0\"\n\
+             edition = \"2021\"\n\
+             \n\
+             [dependencies]\n\
+             libviprs = {{ path = {:?}, features = [\"pdfium\"] }}\n",
+            libviprs_path.display().to_string(),
+        ),
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("src").join("lib.rs"), "").unwrap();
+
+    let out = run_audit(dir.path(), &[]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // Tooling error (exit 2) means we couldn't resolve the graph (e.g. no
+    // network in a sandbox); don't turn that into a false failure.
+    if out.status.code() == Some(2) {
+        eprintln!("skipping: could not resolve consumer graph\nstderr: {stderr}");
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "a patch-less downstream consumer of libviprs must resolve the \
+         pdfium-render fork (issue #149 part 2).\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("github.com/libviprs/pdfium-render"),
+        "audit did not confirm the libviprs fork source for the downstream \
+         consumer.\nstdout: {stdout}"
     );
 }

--- a/tests/workspace_layout.rs
+++ b/tests/workspace_layout.rs
@@ -3,9 +3,10 @@
 //! The repo used to have two disjoint cargo roots: the `libviprs` package and
 //! a `fuzz/` crate detached by an empty `[workspace]` table. The detached
 //! crate resolved dependencies on its own, with its own lockfile, and never
-//! saw the root `[patch.crates-io]` that pins `pdfium-render` to the
-//! thread-safety fork. These tests assert the unified layout: one workspace,
-//! one lockfile, and a `[patch]` table that applies to every member.
+//! saw the root pin of `pdfium-render` to the thread-safety fork (then a
+//! `[patch.crates-io]` entry, now a direct git dependency). These tests
+//! assert the unified layout: one workspace, one lockfile, and dependency
+//! pins that apply to every member.
 
 use std::path::Path;
 use std::process::Command;
@@ -63,7 +64,8 @@ fn fuzz_crate_is_a_member_of_the_root_workspace() {
 }
 
 /// Both crates seen from the root manifest: same workspace, so the single
-/// root lockfile and the single `[patch.crates-io]` table govern them all.
+/// root lockfile and the single set of workspace dependency pins govern
+/// them all.
 #[test]
 fn root_workspace_contains_both_crates() {
     let root = repo_root();
@@ -76,9 +78,10 @@ fn root_workspace_contains_both_crates() {
     );
 }
 
-/// The shared `[patch.crates-io]` must still pin `pdfium-render` to the
-/// libviprs fork (per-call thread-safety locking). The workspace lockfile is
-/// the single source of truth for that resolution.
+/// The workspace must still pin `pdfium-render` to the libviprs fork
+/// (per-call thread-safety locking), now as a direct git dependency rather
+/// than a `[patch.crates-io]` entry. The workspace lockfile is the single
+/// source of truth for that resolution.
 #[test]
 fn workspace_lockfile_pins_pdfium_render_to_the_fork() {
     let lock = std::fs::read_to_string(repo_root().join("Cargo.lock"))


### PR DESCRIPTION
## What

I moved the pdfium-render per-call thread-safety fork from the root `[patch.crates-io]` table to a direct git dependency in `[workspace.dependencies]`, with a `version = "0.8"` fallback so `cargo package`/`cargo publish` keep working.

## Why

Issue #149, remaining part 2 (the consumer path). A `[patch]` table only takes effect from the build root, so any consumer of libviprs by git or path that did not replicate the patch silently linked the unpatched registry wrapper. As a direct dependency, the fork is an ordinary edge in the dependency graph, so every git/path consumer now inherits it with no `[patch]` hygiene at all.

## What this does NOT fix (and why the issue stays open)

crates.io consumers of the PUBLISHED libviprs are still on the unpatched wrapper: cargo strips git sources at publish time and keeps the registry `^0.8` requirement. I verified the packaged manifest is byte-for-byte what 0.3.1 already ships, so this PR causes no publish regression, but it also cannot fix that path. The two remaining options are documented in the manifest comment and in the #149 remainder:

1. Upstream the per-call locking (ajrcarey/pdfium-render#262, still open with no maintainer response) and depend on the released version.
2. Publish the fork under a distinct crate name (for example `libviprs-pdfium-render` with `[lib] name = "pdfium_render"`) and depend on it via a `package =` rename. This needs a fork-repo manifest change plus a crates.io publish decision, both outside this repo.

libviprs's own FPDF calls remain safe on the registry wrapper regardless, via the internal process-wide `pdfium_lock` (defence in depth in `src/pdf.rs`); what stays unsound there is the wrapper's `Send + Sync` for direct consumer use.

## Evidence

- New regression test `patchless_downstream_consumer_resolves_the_fork` in `tests/pdfium_source_audit.rs`: a synthesized downstream crate depending on libviprs with no `[patch]` table must resolve the fork. RED before this change (registry source), GREEN after.
- `Cargo.lock` is byte-identical: resolution in this repo is unchanged, only its propagation semantics changed.
- `cargo package --no-verify` succeeds; the packaged manifest keeps `pdfium-render = { version = "0.8", features = ["sync"] }`, same as the published 0.3.1.
- Local mirror green: `make fmt`, `make clippy` (both feature sets), `make test` (all suites incl. the new reproducer and the existing audit-gate tests), `make doc`, and the merge-gate audit `scripts/audit-pdfium-source.sh . -- --features pdfium`.

Refs #149