### PR TITLE
Extract the one shared level walk and fold the streaming flush phases (#138)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -463,7 +463,6 @@ fn run_pyramid(
     // trait impl is a no-op, so unaware sinks silently ignore the hint.
     sink.init_level_count(plan.levels.len());
 
-    let top_level = plan.levels.len() - 1;
     let mut tiles_produced: u64 = 0;
     let mut tiles_skipped: u64 = 0;
     let bytes_read = source.data().len() as u64;
@@ -483,7 +482,7 @@ fn run_pyramid(
     // downscaled level-by-level. This ensures boundary pixels are averaged
     // correctly instead of computing per-level offsets that diverge due to
     // integer rounding.
-    let mut current = if plan.centre && (plan.centre_offset_x > 0 || plan.centre_offset_y > 0) {
+    let current = if plan.centre && (plan.centre_offset_x > 0 || plan.centre_offset_y > 0) {
         let canvas = embed_in_canvas(source, plan, config.background_rgb)?;
         let canvas_bytes = canvas.data().len() as u64;
         tracker.alloc(canvas_bytes);
@@ -503,59 +502,76 @@ fn run_pyramid(
         stage_sink: &stage_sink,
     };
 
-    // Process from top level (full res) down to level 0 (1×1)
-    for level_idx in (0..plan.levels.len()).rev() {
-        // Cooperative cancellation: stop cleanly at the level boundary before
-        // committing to (potentially expensive) downscale + tile emission.
-        config.check_cancelled()?;
-        let level = &plan.levels[level_idx];
-        #[cfg(feature = "tracing")]
-        let _level_span = tracing::info_span!(
-            target: "libviprs",
-            "level",
-            level_index = level.level
-        )
-        .entered();
+    // Process from top level (full res) down to level 0 (1×1). The walk
+    // skeleton (descending levels, one tile-op step between adjacent levels,
+    // top level never stepped) lives in `level_walk::walk_levels_down`,
+    // shared with the verify walks and the streaming engines' monolithic
+    // flush. This site parameterizes it with the timed, memory-tracked
+    // downscale and live tile emission.
+    let current = crate::level_walk::walk_levels_down::<EngineError, _, _, _, _>(
+        current,
+        plan.levels.len(),
+        // Enter: cooperative cancellation at the level boundary (before
+        // committing to a potentially expensive downscale + tile emission),
+        // then LevelStarted. The tracing span rides in the returned guard so
+        // it covers the step and emit phases exactly as before.
+        |level_idx| {
+            config.check_cancelled()?;
+            let level = &plan.levels[level_idx];
+            #[cfg(feature = "tracing")]
+            let level_span = tracing::info_span!(
+                target: "libviprs",
+                "level",
+                level_index = level.level
+            )
+            .entered();
 
-        observer.on_event(EngineEvent::LevelStarted {
-            level: level.level,
-            width: level.width,
-            height: level.height,
-            tile_count: level.tile_count(),
-        });
-
-        // Downscale if not at the top level.
-        // Uses downscale_half (2x2 box filter) to match libvips's
-        // region-shrink=mean algorithm. Each level is ceil(prev/2).
-        if level_idx < top_level {
-            let old_bytes = current.data().len() as u64;
+            observer.on_event(EngineEvent::LevelStarted {
+                level: level.level,
+                width: level.width,
+                height: level.height,
+                tile_count: level.tile_count(),
+            });
+            #[cfg(feature = "tracing")]
+            return Ok(level_span);
+            #[cfg(not(feature = "tracing"))]
+            Ok(())
+        },
+        // Step: the tile operation. Uses downscale_half (2x2 box filter) to
+        // match libvips's region-shrink=mean algorithm. Each level is
+        // ceil(prev/2).
+        |_, prev| {
+            let old_bytes = prev.data().len() as u64;
             let resize_start = Instant::now();
-            current = resize::downscale_half(&current)?;
+            let next = resize::downscale_half(&prev)?;
             stage_resize.fetch_add(resize_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
-            let new_bytes = current.data().len() as u64;
+            let new_bytes = next.data().len() as u64;
             // Track: freed old level, allocated new
             tracker.dealloc(old_bytes);
             tracker.alloc(new_bytes);
-        }
+            Ok(next)
+        },
+        // Emit: extract and emit tiles for this level.
+        |level_idx, current| {
+            let (level_tiles, level_skipped) = extract_and_emit_level(
+                current,
+                plan,
+                level_idx as u32,
+                sink,
+                config,
+                observer,
+                &ctx,
+            )?;
+            tiles_produced += level_tiles;
+            tiles_skipped += level_skipped;
 
-        // Extract and emit tiles for this level
-        let (level_tiles, level_skipped) = extract_and_emit_level(
-            &current,
-            plan,
-            level_idx as u32,
-            sink,
-            config,
-            observer,
-            &ctx,
-        )?;
-        tiles_produced += level_tiles;
-        tiles_skipped += level_skipped;
-
-        observer.on_event(EngineEvent::LevelCompleted {
-            level: level.level,
-            tiles_produced: level_tiles,
-        });
-    }
+            observer.on_event(EngineEvent::LevelCompleted {
+                level: plan.levels[level_idx].level,
+                tiles_produced: level_tiles,
+            });
+            Ok(())
+        },
+    )?;
 
     // Free last raster from tracking
     tracker.dealloc(current.data().len() as u64);
@@ -1172,96 +1188,105 @@ pub fn raster_verify(
         })
         .unwrap_or_default();
 
-    let mut current = if plan.centre && (plan.centre_offset_x > 0 || plan.centre_offset_y > 0) {
+    let current = if plan.centre && (plan.centre_offset_x > 0 || plan.centre_offset_y > 0) {
         embed_in_canvas(source, plan, bg)?
     } else {
         source.clone()
     };
-    let top_level = plan.levels.len() - 1;
 
-    for level_idx in (0..plan.levels.len()).rev() {
-        let level = &plan.levels[level_idx];
-        if level_idx < top_level {
-            current = resize::downscale_half(&current)?;
-        }
-        observer.on_event(EngineEvent::LevelStarted {
-            level: level.level,
-            width: level.width,
-            height: level.height,
-            tile_count: level.tile_count(),
-        });
-        for row in 0..level.rows {
-            for col in 0..level.cols {
-                let coord = TileCoord::new(level_idx as u32, col, row);
-                observer.on_event(EngineEvent::TileCompleted { coord });
-                let expected = extract_tile(&current, plan, coord, bg)?;
-                let expected_bytes = expected.data();
+    // The walk skeleton is the shared `level_walk::walk_levels_down`; this
+    // verify site parameterizes it with the plain (untimed, untracked)
+    // downscale and a per-tile byte comparison instead of tile emission.
+    crate::level_walk::walk_levels_down::<EngineError, _, _, _, _>(
+        current,
+        plan.levels.len(),
+        |_| Ok(()),
+        // Step: the same tile op the live run applies, so the regenerated
+        // pyramid is byte-identical to what the engine wrote.
+        |_, prev| Ok(resize::downscale_half(&prev)?),
+        |level_idx, current| {
+            let level = &plan.levels[level_idx];
+            observer.on_event(EngineEvent::LevelStarted {
+                level: level.level,
+                width: level.width,
+                height: level.height,
+                tile_count: level.tile_count(),
+            });
+            for row in 0..level.rows {
+                for col in 0..level.cols {
+                    let coord = TileCoord::new(level_idx as u32, col, row);
+                    observer.on_event(EngineEvent::TileCompleted { coord });
+                    let expected = extract_tile(current, plan, coord, bg)?;
+                    let expected_bytes = expected.data();
 
-                // Find the on-disk file via the candidate extensions.
-                let mut found: Option<(std::path::PathBuf, String)> = None;
-                for ext in &candidate_exts {
-                    if let Some(rel) = plan.tile_path(coord, ext) {
-                        let abs = root.join(&rel);
-                        if abs.is_file() {
-                            found = Some((abs, (*ext).to_string()));
-                            break;
+                    // Find the on-disk file via the candidate extensions.
+                    let mut found: Option<(std::path::PathBuf, String)> = None;
+                    for ext in &candidate_exts {
+                        if let Some(rel) = plan.tile_path(coord, ext) {
+                            let abs = root.join(&rel);
+                            if abs.is_file() {
+                                found = Some((abs, (*ext).to_string()));
+                                break;
+                            }
                         }
                     }
-                }
-                let (abs, ext) = match found {
-                    Some(f) => f,
-                    None => {
-                        return Err(EngineError::Sink(SinkError::Other(format!(
-                            "Verify: missing tile for coord {:?}",
-                            coord
-                        ))));
-                    }
-                };
+                    let (abs, ext) = match found {
+                        Some(f) => f,
+                        None => {
+                            return Err(EngineError::Sink(SinkError::Other(format!(
+                                "Verify: missing tile for coord {:?}",
+                                coord
+                            ))));
+                        }
+                    };
 
-                let on_disk =
-                    std::fs::read(&abs).map_err(|e| EngineError::Sink(SinkError::Io(e)))?;
+                    let on_disk =
+                        std::fs::read(&abs).map_err(|e| EngineError::Sink(SinkError::Io(e)))?;
 
-                if ext == "raw" {
-                    if on_disk.len() == 1 && on_disk[0] == crate::sink::BLANK_TILE_MARKER {
-                        // A 1-byte placeholder: either a blank-tile marker
-                        // (`BlankTileStrategy::Placeholder*`) or a dedupe
-                        // reference whose payload lives in `_shared/`. Validate
-                        // the regenerated tile's blankness / manifest reference
-                        // instead of byte-comparing the marker (issue #94).
-                        let is_dedupe_ref = plan
-                            .tile_path(coord, &ext)
-                            .is_some_and(|rel| blank_ref_paths.contains(&rel));
-                        if !is_dedupe_ref && !regenerated_tile_matches_marker(&expected, config) {
+                    if ext == "raw" {
+                        if on_disk.len() == 1 && on_disk[0] == crate::sink::BLANK_TILE_MARKER {
+                            // A 1-byte placeholder: either a blank-tile marker
+                            // (`BlankTileStrategy::Placeholder*`) or a dedupe
+                            // reference whose payload lives in `_shared/`. Validate
+                            // the regenerated tile's blankness / manifest reference
+                            // instead of byte-comparing the marker (issue #94).
+                            let is_dedupe_ref = plan
+                                .tile_path(coord, &ext)
+                                .is_some_and(|rel| blank_ref_paths.contains(&rel));
+                            if !is_dedupe_ref && !regenerated_tile_matches_marker(&expected, config)
+                            {
+                                return Err(EngineError::ChecksumMismatch {
+                                    tile: coord,
+                                    expected: "blank tile (placeholder marker)".to_string(),
+                                    got: "regenerated tile is not blank".to_string(),
+                                });
+                            }
+                        } else if on_disk != expected_bytes {
+                            // Raw tiles are byte-exact: any mismatch (truncation,
+                            // flipped byte, padding drift) is corruption.
                             return Err(EngineError::ChecksumMismatch {
                                 tile: coord,
-                                expected: "blank tile (placeholder marker)".to_string(),
-                                got: "regenerated tile is not blank".to_string(),
+                                expected: format!("{} bytes (raw)", expected_bytes.len()),
+                                got: format!(
+                                    "{} bytes on disk differ from regenerated tile",
+                                    on_disk.len()
+                                ),
                             });
                         }
-                    } else if on_disk != expected_bytes {
-                        // Raw tiles are byte-exact: any mismatch (truncation,
-                        // flipped byte, padding drift) is corruption.
-                        return Err(EngineError::ChecksumMismatch {
-                            tile: coord,
-                            expected: format!("{} bytes (raw)", expected_bytes.len()),
-                            got: format!(
-                                "{} bytes on disk differ from regenerated tile",
-                                on_disk.len()
-                            ),
-                        });
                     }
+                    // Encoded tiles (png/jpeg) are not byte-exact against a fresh
+                    // encode due to encoder-state nondeterminism, so we keep the
+                    // existence check above and defer deep verification to the
+                    // manifest-checksum branch.
                 }
-                // Encoded tiles (png/jpeg) are not byte-exact against a fresh
-                // encode due to encoder-state nondeterminism, so we keep the
-                // existence check above and defer deep verification to the
-                // manifest-checksum branch.
             }
-        }
-        observer.on_event(EngineEvent::LevelCompleted {
-            level: level.level,
-            tiles_produced: level.tile_count(),
-        });
-    }
+            observer.on_event(EngineEvent::LevelCompleted {
+                level: level.level,
+                tiles_produced: level.tile_count(),
+            });
+            Ok(())
+        },
+    )?;
 
     observer.on_event(EngineEvent::Finished {
         total_tiles: plan.total_tile_count(),

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -22,31 +22,28 @@
 //!
 //! # Per-tile operation: current shape and roadmap
 //!
-//! Every engine kind hardwires exactly one per-level transform today — the
+//! Every engine kind applies exactly one per-level transform today: the
 //! 2×2 box-filter downscale ([`resize::downscale_half`](crate::resize::downscale_half))
-//! followed by tile extraction. That level-walk is duplicated across the
-//! three engine drivers (`engine.rs`, `streaming.rs`,
-//! `streaming_mapreduce.rs`) plus the two read-only verify walks
-//! (`verify.rs`, `stream_verify.rs`). There is intentionally no operation
-//! abstraction yet: pyramid generation is the crate's sole pipeline shape.
+//! followed by tile extraction. The full-level cascade that applies it lives
+//! in one place, the crate-internal `level_walk::walk_levels_down`, whose
+//! `step` closure is the tile-operation parameter (issue #138). The live
+//! monolithic run, both read-only verify walks, and the streaming engines'
+//! monolithic flush (shared by the sequential and MapReduce drivers via
+//! `streaming::flush_monolithic_levels` / `flush_unpaired_accumulators`) all
+//! delegate to it; the per-strip halving inside the streaming strip loops
+//! and `streaming::propagate_down` is a strip transform and intentionally
+//! stays separate.
 //!
-//! **Roadmap for a second per-tile operation** (rotate, sharpen, colour
-//! transform, …), so the walks change once rather than in lockstep:
+//! **Remaining roadmap for a second per-tile operation** (rotate, sharpen,
+//! colour transform, …):
 //!
-//! 1. Introduce a `TileOp` trait (`fn apply(&self, level: &Raster) ->
-//!    Result<Raster, RasterError>`) with a `DownscaleHalf` unit implementation
-//!    that wraps today's behaviour, keeping the default pipeline byte-for-byte
-//!    identical.
-//! 2. Thread a `&dyn TileOp` (defaulting to `DownscaleHalf`) into a single
-//!    shared `walk_levels(source, plan, op, emit)` helper, and rewrite each of
-//!    the five call sites to delegate to it — collapsing the duplicated walk
-//!    to one definition parameterised by the operation.
-//! 3. Surface the operation on this builder via a `with_tile_op` setter,
+//! 1. Name the operation as a `TileOp` trait (`fn apply(&self, level:
+//!    &Raster) -> Result<Raster, RasterError>`) with a `DownscaleHalf` unit
+//!    implementation wrapping today's behaviour, and pass it through the
+//!    existing `step` hook of `walk_levels_down` (plus the strip-transform
+//!    sites, which must apply the same operation for parity).
+//! 2. Surface the operation on this builder via a `with_tile_op` setter,
 //!    carried alongside the existing config knobs.
-//!
-//! Steps 1–2 span the engine drivers and the shared verify walks, so they land
-//! as a dedicated cross-module change; this builder is where step 3 (the
-//! caller-facing setter) will attach once the shared walk exists.
 
 use std::sync::Arc;
 

--- a/src/level_walk.rs
+++ b/src/level_walk.rs
@@ -1,0 +1,303 @@
+//! The one shared top-down pyramid level walk (issue #138).
+//!
+//! Every full-level pyramid cascade in this crate has the same skeleton:
+//! start from the full-resolution raster, visit level indices in descending
+//! order, and between levels apply a per-tile operation (today always the
+//! 2×2 box-filter half downscale, [`crate::resize::downscale_half`]) to
+//! produce the next level's raster. Before this module existed that skeleton
+//! was transcribed at each call site, and the sites had to be kept in
+//! lockstep by hand.
+//!
+//! [`walk_levels_down`] is that skeleton, written once. The pipeline shape
+//! is fixed (descending level order, the top level is never stepped, exactly
+//! one step between adjacent levels) while everything site-specific is
+//! injected through three hooks:
+//!
+//! * **`enter`** runs first for every level, before any stepping. This is
+//!   where the live engine checks cancellation and emits `LevelStarted`. It
+//!   returns a guard value that stays alive for the remainder of the level,
+//!   which lets a site hold a tracing span across the step and emit phases.
+//!   Sites without per-level setup return `Ok(())`.
+//! * **`step`** is the tile operation: it consumes the raster of the level
+//!   above and produces this level's raster. It is *not* invoked for the
+//!   topmost level (that raster is the walk's input). A site wraps its
+//!   operation with whatever bookkeeping it needs (stage timing, memory
+//!   tracking); the plain form is `|_, prev| Ok(downscale_half(&prev)?)`.
+//!   This closure is the extension point the issue #138 roadmap calls the
+//!   tile op: a future rotate/sharpen/colour operation slots in here without
+//!   touching any walk site.
+//! * **`emit`** runs after the raster for the level is in hand: tile
+//!   extraction and sink writes for a live run, byte comparison for a
+//!   verify run.
+//!
+//! Callers today:
+//!
+//! * the monolithic engine's live run (`engine::run_pyramid`),
+//! * the monolithic verify walk (`engine::raster_verify`),
+//! * the strip-source verify walk (`stream_verify`), and
+//! * the streaming engines' monolithic flush
+//!   (`streaming::flush_monolithic_levels`, shared by the sequential and
+//!   MapReduce drivers).
+//!
+//! The strip-phase `downscale_half` applications (the per-strip halving in
+//! the streaming strip loops and in `streaming::propagate_down`) are strip
+//! transforms rather than full-level walks; they intentionally stay outside
+//! this helper.
+
+use crate::raster::Raster;
+
+/// Walk `levels_len` pyramid levels from the top (index `levels_len - 1`)
+/// down to level 0, carrying a raster that is transformed by `step` between
+/// adjacent levels.
+///
+/// For each level index `i`, in descending order:
+///
+/// 1. `enter(i)` runs; its return value is held until the level finishes.
+/// 2. If `i` is not the topmost index, `step(i, previous_raster)` produces
+///    this level's raster.
+/// 3. `emit(i, &raster)` runs.
+///
+/// Returns the final (level 0) raster so callers can release any external
+/// accounting tied to it. A `levels_len` of zero performs no visits and
+/// returns `top_raster` unchanged.
+pub(crate) fn walk_levels_down<E, G, Enter, Step, Emit>(
+    top_raster: Raster,
+    levels_len: usize,
+    mut enter: Enter,
+    mut step: Step,
+    mut emit: Emit,
+) -> Result<Raster, E>
+where
+    Enter: FnMut(usize) -> Result<G, E>,
+    Step: FnMut(usize, Raster) -> Result<Raster, E>,
+    Emit: FnMut(usize, &Raster) -> Result<(), E>,
+{
+    let mut current = top_raster;
+    if levels_len == 0 {
+        return Ok(current);
+    }
+    let top_idx = levels_len - 1;
+    for level_idx in (0..levels_len).rev() {
+        let _level_guard = enter(level_idx)?;
+        if level_idx < top_idx {
+            current = step(level_idx, current)?;
+        }
+        emit(level_idx, &current)?;
+    }
+    Ok(current)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pixel::PixelFormat;
+    use crate::raster::RasterError;
+    use crate::resize;
+
+    fn gradient_raster(w: u32, h: u32) -> Raster {
+        let bpp = PixelFormat::Rgb8.bytes_per_pixel();
+        let mut data = vec![0u8; w as usize * h as usize * bpp];
+        for y in 0..h {
+            for x in 0..w {
+                let off = (y as usize * w as usize + x as usize) * bpp;
+                data[off] = (x % 256) as u8;
+                data[off + 1] = (y % 256) as u8;
+                data[off + 2] = ((x + y) % 256) as u8;
+            }
+        }
+        Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    /// The shared walk must reproduce, byte for byte and level for level,
+    /// the inline loop every call site used before the extraction:
+    ///
+    /// ```text
+    /// for level_idx in (0..levels_len).rev() {
+    ///     if level_idx < top_level { current = downscale_half(&current)?; }
+    ///     visit(level_idx, &current);
+    /// }
+    /// ```
+    #[test]
+    fn walk_reproduces_prior_per_site_loop_byte_identically() {
+        // 317x201 is deliberately odd-sized so div_ceil rounding at every
+        // level exercises the same edge behaviour the engines see.
+        let levels_len = 6;
+        let src = gradient_raster(317, 201);
+
+        // Reference: the prior per-site inline loop, transcribed verbatim.
+        let mut reference: Vec<(usize, u32, u32, Vec<u8>)> = Vec::new();
+        {
+            let top_level = levels_len - 1;
+            let mut current = src.clone();
+            for level_idx in (0..levels_len).rev() {
+                if level_idx < top_level {
+                    current = resize::downscale_half(&current).unwrap();
+                }
+                reference.push((
+                    level_idx,
+                    current.width(),
+                    current.height(),
+                    current.data().to_vec(),
+                ));
+            }
+        }
+
+        // Shared walk with the same tile op.
+        let mut walked: Vec<(usize, u32, u32, Vec<u8>)> = Vec::new();
+        let final_raster = walk_levels_down::<RasterError, _, _, _, _>(
+            src,
+            levels_len,
+            |_| Ok(()),
+            |_, prev| resize::downscale_half(&prev),
+            |level_idx, raster| {
+                walked.push((
+                    level_idx,
+                    raster.width(),
+                    raster.height(),
+                    raster.data().to_vec(),
+                ));
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(reference, walked, "walk diverged from the inline loop");
+        // The returned raster is the last (level 0) one.
+        let last = reference.last().unwrap();
+        assert_eq!(last.0, 0);
+        assert_eq!(final_raster.data(), &last.3[..]);
+    }
+
+    /// Hook ordering is load-bearing for observer event streams: `enter`
+    /// must fire before the step (the live engine emits `LevelStarted` and
+    /// checks cancellation there), the step must not fire for the top
+    /// level, and levels must be visited strictly top-down.
+    #[test]
+    fn enter_step_emit_ordering_matches_engine_contract() {
+        let levels_len = 4;
+        let src = gradient_raster(64, 64);
+        let calls: std::cell::RefCell<Vec<String>> = std::cell::RefCell::new(Vec::new());
+
+        walk_levels_down::<RasterError, _, _, _, _>(
+            src,
+            levels_len,
+            |i| {
+                calls.borrow_mut().push(format!("enter{i}"));
+                Ok(())
+            },
+            |i, prev| {
+                calls.borrow_mut().push(format!("step{i}"));
+                resize::downscale_half(&prev)
+            },
+            |i, _| {
+                calls.borrow_mut().push(format!("emit{i}"));
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            calls.into_inner(),
+            vec![
+                "enter3", "emit3", // top level: no step
+                "enter2", "step2", "emit2", "enter1", "step1", "emit1", "enter0", "step0", "emit0",
+            ]
+        );
+    }
+
+    /// The guard returned by `enter` must stay alive across the step and
+    /// emit phases of its level (the live engine holds a tracing span in
+    /// it), and must be dropped before the next level's `enter`.
+    #[test]
+    fn enter_guard_spans_step_and_emit() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        struct Guard {
+            level: usize,
+            log: Rc<RefCell<Vec<String>>>,
+        }
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                self.log.borrow_mut().push(format!("drop{}", self.level));
+            }
+        }
+
+        let log: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let src = gradient_raster(16, 16);
+
+        walk_levels_down::<RasterError, _, _, _, _>(
+            src,
+            3,
+            |i| {
+                log.borrow_mut().push(format!("enter{i}"));
+                Ok(Guard {
+                    level: i,
+                    log: Rc::clone(&log),
+                })
+            },
+            |i, prev| {
+                log.borrow_mut().push(format!("step{i}"));
+                resize::downscale_half(&prev)
+            },
+            |i, _| {
+                log.borrow_mut().push(format!("emit{i}"));
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            log.borrow().as_slice(),
+            [
+                "enter2", "emit2", "drop2", "enter1", "step1", "emit1", "drop1", "enter0", "step0",
+                "emit0", "drop0",
+            ]
+        );
+    }
+
+    /// A failing enter/step/emit stops the walk immediately and propagates
+    /// the error, matching the `?` semantics of the prior inline loops.
+    #[test]
+    fn errors_short_circuit_like_the_inline_loops() {
+        let src = gradient_raster(32, 32);
+        let mut visited: Vec<usize> = Vec::new();
+        let err = walk_levels_down::<String, _, _, _, _>(
+            src,
+            5,
+            |_| Ok(()),
+            |i, prev| {
+                if i == 2 {
+                    Err(format!("step failed at level {i}"))
+                } else {
+                    resize::downscale_half(&prev).map_err(|e| e.to_string())
+                }
+            },
+            |i, _| {
+                visited.push(i);
+                Ok(())
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, "step failed at level 2");
+        // Levels 4 and 3 emitted; the failure at level 2's step stops the
+        // walk before level 2 emits.
+        assert_eq!(visited, vec![4, 3]);
+    }
+
+    /// Zero levels: no hooks fire and the input raster comes back unchanged.
+    #[test]
+    fn zero_levels_is_a_no_op() {
+        let src = gradient_raster(8, 8);
+        let bytes = src.data().to_vec();
+        let out = walk_levels_down::<RasterError, _, _, _, _>(
+            src,
+            0,
+            |_| -> Result<(), RasterError> { panic!("enter must not fire") },
+            |_, _| panic!("step must not fire"),
+            |_, _| panic!("emit must not fire"),
+        )
+        .unwrap();
+        assert_eq!(out.data(), &bytes[..]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod engine;
 pub mod engine_builder;
 pub mod extensions;
 pub mod geo;
+pub(crate) mod level_walk;
 #[cfg(loom)]
 mod loom_tests;
 pub mod manifest;

--- a/src/stream_verify.rs
+++ b/src/stream_verify.rs
@@ -342,7 +342,7 @@ pub fn verify_from_strip_source(
         y += sh;
     }
 
-    let mut current = canvas_raster;
+    let current = canvas_raster;
 
     // Sanity check: the assembled raster must match the top plan level's
     // recorded dimensions, otherwise the downstream downscale chain will
@@ -354,90 +354,98 @@ pub fn verify_from_strip_source(
     // ------------------------------------------------------------------
     // Phase 4: byte-exact verification, level-by-level, top to bottom.
     //
-    // This is a direct transcription of `run_verify`'s second loop. The
-    // downscale cadence, tile ordering, and event emission order are all
-    // preserved; only the top-level source changes (strip-assembled
-    // rather than `embed_in_canvas`-produced).
+    // The walk skeleton is the shared `level_walk::walk_levels_down` (the
+    // same one `raster_verify` and the live engines drive). The downscale
+    // cadence, tile ordering, and event emission order are all preserved;
+    // only the top-level source changes (strip-assembled rather than
+    // `embed_in_canvas`-produced).
     // ------------------------------------------------------------------
-    for level_idx in (0..plan.levels.len()).rev() {
-        let level = &plan.levels[level_idx];
-        if level_idx < top_level_idx {
-            current = resize::downscale_half(&current)?;
-        }
+    crate::level_walk::walk_levels_down::<EngineError, _, _, _, _>(
+        current,
+        plan.levels.len(),
+        |_| Ok(()),
+        // Step: the same tile op the live engines apply.
+        |_, prev| Ok(resize::downscale_half(&prev)?),
+        |level_idx, current| {
+            let level = &plan.levels[level_idx];
 
-        observer.on_event(EngineEvent::LevelStarted {
-            level: level.level,
-            width: level.width,
-            height: level.height,
-            tile_count: level.tile_count(),
-        });
+            observer.on_event(EngineEvent::LevelStarted {
+                level: level.level,
+                width: level.width,
+                height: level.height,
+                tile_count: level.tile_count(),
+            });
 
-        for row in 0..level.rows {
-            for col in 0..level.cols {
-                let coord = TileCoord::new(level_idx as u32, col, row);
-                observer.on_event(EngineEvent::TileCompleted { coord });
+            for row in 0..level.rows {
+                for col in 0..level.cols {
+                    let coord = TileCoord::new(level_idx as u32, col, row);
+                    observer.on_event(EngineEvent::TileCompleted { coord });
 
-                // `extract_tile_from_strip` with `strip_canvas_y = 0`
-                // applied to a full-level raster is byte-equivalent to the
-                // private `engine::extract_tile`: same rect projection,
-                // same edge padding, same Google vs. DeepZoom branching.
-                let expected =
-                    crate::streaming::extract_tile_from_strip(&current, plan, coord, 0, bg)?;
-                let expected_bytes = expected.data();
+                    // `extract_tile_from_strip` with `strip_canvas_y = 0`
+                    // applied to a full-level raster is byte-equivalent to the
+                    // private `engine::extract_tile`: same rect projection,
+                    // same edge padding, same Google vs. DeepZoom branching.
+                    let expected =
+                        crate::streaming::extract_tile_from_strip(current, plan, coord, 0, bg)?;
+                    let expected_bytes = expected.data();
 
-                let (abs, ext) = match find_tile_on_disk(root, plan, coord, &active_exts) {
-                    Some(found) => found,
-                    None => {
-                        return Err(EngineError::Sink(SinkError::Other(format!(
-                            "Verify: missing tile for coord {coord:?}"
-                        ))));
-                    }
-                };
+                    let (abs, ext) = match find_tile_on_disk(root, plan, coord, &active_exts) {
+                        Some(found) => found,
+                        None => {
+                            return Err(EngineError::Sink(SinkError::Other(format!(
+                                "Verify: missing tile for coord {coord:?}"
+                            ))));
+                        }
+                    };
 
-                let on_disk =
-                    std::fs::read(&abs).map_err(|e| EngineError::Sink(SinkError::Io(e)))?;
+                    let on_disk =
+                        std::fs::read(&abs).map_err(|e| EngineError::Sink(SinkError::Io(e)))?;
 
-                if ext == "raw" {
-                    if on_disk.len() == 1 && on_disk[0] == crate::sink::BLANK_TILE_MARKER {
-                        // A 1-byte placeholder: either a blank-tile marker
-                        // (`BlankTileStrategy::Placeholder*`) or a dedupe
-                        // reference whose payload lives in `_shared/`. Validate
-                        // the regenerated tile's blankness / manifest reference
-                        // instead of byte-comparing the marker (issue #94).
-                        let is_dedupe_ref = plan
-                            .tile_path(coord, ext)
-                            .is_some_and(|rel| blank_ref_paths.contains(&rel));
-                        if !is_dedupe_ref
-                            && !crate::engine::regenerated_tile_matches_marker(&expected, config)
-                        {
+                    if ext == "raw" {
+                        if on_disk.len() == 1 && on_disk[0] == crate::sink::BLANK_TILE_MARKER {
+                            // A 1-byte placeholder: either a blank-tile marker
+                            // (`BlankTileStrategy::Placeholder*`) or a dedupe
+                            // reference whose payload lives in `_shared/`. Validate
+                            // the regenerated tile's blankness / manifest reference
+                            // instead of byte-comparing the marker (issue #94).
+                            let is_dedupe_ref = plan
+                                .tile_path(coord, ext)
+                                .is_some_and(|rel| blank_ref_paths.contains(&rel));
+                            if !is_dedupe_ref
+                                && !crate::engine::regenerated_tile_matches_marker(
+                                    &expected, config,
+                                )
+                            {
+                                return Err(EngineError::ChecksumMismatch {
+                                    tile: coord,
+                                    expected: "blank tile (placeholder marker)".to_string(),
+                                    got: "regenerated tile is not blank".to_string(),
+                                });
+                            }
+                        } else if on_disk != expected_bytes {
                             return Err(EngineError::ChecksumMismatch {
                                 tile: coord,
-                                expected: "blank tile (placeholder marker)".to_string(),
-                                got: "regenerated tile is not blank".to_string(),
+                                expected: format!("{} bytes (raw)", expected_bytes.len()),
+                                got: format!(
+                                    "{} bytes on disk differ from regenerated tile",
+                                    on_disk.len()
+                                ),
                             });
                         }
-                    } else if on_disk != expected_bytes {
-                        return Err(EngineError::ChecksumMismatch {
-                            tile: coord,
-                            expected: format!("{} bytes (raw)", expected_bytes.len()),
-                            got: format!(
-                                "{} bytes on disk differ from regenerated tile",
-                                on_disk.len()
-                            ),
-                        });
                     }
+                    // Encoded formats (png/jpeg) fall through: existence
+                    // check already passed, and fresh re-encoding is not
+                    // byte-stable, so we don't compare pixel data here.
                 }
-                // Encoded formats (png/jpeg) fall through: existence
-                // check already passed, and fresh re-encoding is not
-                // byte-stable, so we don't compare pixel data here.
             }
-        }
 
-        observer.on_event(EngineEvent::LevelCompleted {
-            level: level.level,
-            tiles_produced: level.tile_count(),
-        });
-    }
+            observer.on_event(EngineEvent::LevelCompleted {
+                level: level.level,
+                tiles_produced: level.tile_count(),
+            });
+            Ok(())
+        },
+    )?;
 
     observer.on_event(EngineEvent::Finished {
         total_tiles: plan.total_tile_count(),

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1038,10 +1038,7 @@ pub(crate) fn generate_pyramid_streaming(
         // Step 3: Downscale the strip with the 2×2 box filter, producing
         // a half-strip at the next level. Free the original strip's memory
         // charge before accounting the new one.
-        let half = resize::downscale_half(&strip)?;
-        tracker.dealloc(strip_bytes);
-        let half_bytes = half.data().len() as u64;
-        tracker.alloc(half_bytes);
+        let half = downscale_strip_tracked(&strip, &tracker)?;
 
         // Step 4: Push the half-strip into the recursive propagation tree.
         // It will be paired with another half-strip at the next level, or
@@ -1076,150 +1073,33 @@ pub(crate) fn generate_pyramid_streaming(
     // ===================================================================
     // Phase 2: Flush unpaired strip accumulators
     // ===================================================================
-    //
-    // When the canvas height isn't evenly divisible by the strip height,
-    // the last half-strip at some levels arrives without a partner. These
-    // leftovers sit in `accumulators[level_idx]` and must be emitted and
-    // propagated before the monolithic flush.
-    //
-    // Process from highest to lowest so that propagation feeds data into
-    // levels below, which may themselves be monolithic.
-    for level_idx in (monolithic_threshold + 1..plan.levels.len()).rev() {
-        if let Some(leftover) = accumulators[level_idx].take() {
-            // The leftover was charged when it was stored as an unpaired first
-            // half; it is still charged now.
-            let leftover_bytes = leftover.data().len() as u64;
-            // The leftover covers the bottom slice of this level. Its Y
-            // position is the level height minus the strip's own height.
-            let (_, lh) = if plan.layout == Layout::Google {
-                plan.canvas_size_at_level(plan.levels[level_idx].level)
-            } else {
-                (plan.levels[level_idx].width, plan.levels[level_idx].height)
-            };
-            let leftover_y = lh.saturating_sub(leftover.height());
-
-            let (tp, ts_skip) = emit_strip_tiles(
-                &leftover,
-                plan,
-                level_idx as u32,
-                leftover_y,
-                sink,
-                &config.engine,
-                observer,
-            )?;
-            tiles_produced += tp;
-            tiles_skipped += ts_skip;
-
-            // Continue the downscale chain into lower levels
-            if level_idx > 0 {
-                let further_half = resize::downscale_half(&leftover)?;
-                let further_bytes = further_half.data().len() as u64;
-                // Charge the downscaled half before handing it down (the
-                // caller-charges-the-buffer contract of `propagate_down`).
-                // `leftover` is still live during the downscale, so the peak
-                // captures both.
-                tracker.alloc(further_bytes);
-                propagate_down(
-                    further_half,
-                    level_idx - 1,
-                    leftover_y / 2,
-                    &mut accumulators,
-                    &mut mono_accumulators,
-                    monolithic_threshold,
-                    plan,
-                    sink,
-                    &config.engine,
-                    observer,
-                    &tracker,
-                    &mut tiles_produced,
-                    &mut tiles_skipped,
-                )?;
-            }
-
-            // The leftover buffer is dropped at the end of this block; release
-            // its charge.
-            drop(leftover);
-            tracker.dealloc(leftover_bytes);
-        }
-    }
+    flush_unpaired_accumulators(
+        &mut accumulators,
+        &mut mono_accumulators,
+        monolithic_threshold,
+        plan,
+        sink,
+        &config.engine,
+        observer,
+        &tracker,
+        &mut tiles_produced,
+        &mut tiles_skipped,
+    )?;
 
     // ===================================================================
     // Phase 3: Monolithic flush — assemble and emit small levels
     // ===================================================================
-    //
-    // Only the topmost monolithic level has accumulated raw row data via
-    // propagate_down. All levels below it are empty — they are produced
-    // here by downscaling the level above, exactly as the monolithic
-    // engine does. This guarantees pixel-exact parity: each pixel goes
-    // through the same sequence of 2×2 box-filter averages regardless
-    // of whether the pyramid was built monolithically or via streaming.
-    {
-        let top_mono = monolithic_threshold.min(plan.levels.len() - 1);
-        let mut prev_raster: Option<Raster> = None;
-
-        // Walk from the largest monolithic level (top_mono) down to level 0
-        for level_idx in (0..=top_mono).rev() {
-            let level = &plan.levels[level_idx];
-            let (lw, lh) = if plan.layout == Layout::Google {
-                plan.canvas_size_at_level(level.level)
-            } else {
-                (level.width, level.height)
-            };
-            if lw == 0 || lh == 0 {
-                continue;
-            }
-
-            let raster = if let Some(prev) = prev_raster.take() {
-                // Produce this level by downscaling the level above,
-                // mirroring the monolithic engine's downscale chain
-                resize::downscale_half(&prev)?
-            } else {
-                // Topmost monolithic level — assemble from accumulated rows.
-                let mut acc_data = std::mem::take(&mut mono_accumulators[level_idx]);
-                if acc_data.is_empty() {
-                    continue;
-                }
-                let expected = lw as usize * lh as usize * bpp;
-
-                // The accumulated data may exceed the expected size when
-                // the source has odd dimensions and downscale_half produces
-                // div_ceil rows from each strip fragment. Truncate to the
-                // exact expected byte count.
-                if acc_data.len() > expected {
-                    acc_data.truncate(expected);
-                }
-                // Conversely, if the last strip was shorter than expected,
-                // pad remaining rows with the background colour.
-                if acc_data.len() < expected {
-                    let filled_rows = acc_data.len() / (lw as usize * bpp);
-                    acc_data.resize(expected, 0);
-                    fill_background_rows(
-                        &mut acc_data,
-                        filled_rows,
-                        lw,
-                        lh,
-                        bpp,
-                        config.engine.background_rgb,
-                    );
-                }
-                Raster::new(lw, lh, format, acc_data)?
-            };
-
-            let (tp, ts_skip) = emit_full_level_tiles(
-                &raster,
-                plan,
-                level_idx as u32,
-                sink,
-                &config.engine,
-                observer,
-            )?;
-            tiles_produced += tp;
-            tiles_skipped += ts_skip;
-
-            // Retain this raster so the next iteration can downscale it
-            prev_raster = Some(raster);
-        }
-    }
+    flush_monolithic_levels(
+        &mut mono_accumulators,
+        monolithic_threshold,
+        plan,
+        format,
+        sink,
+        &config.engine,
+        observer,
+        &mut tiles_produced,
+        &mut tiles_skipped,
+    )?;
 
     // Emit LevelCompleted for all levels
     for level in &plan.levels {
@@ -1291,6 +1171,211 @@ pub(crate) fn find_monolithic_threshold(
     }
     // Every level is larger than a strip — treat level 0 as monolithic anyway
     0
+}
+
+/// Full-level pixel dimensions for `level_idx`: the padded canvas size for
+/// Google layout, the recorded level size otherwise.
+fn level_dims(plan: &PyramidPlan, level_idx: usize) -> (u32, u32) {
+    if plan.layout == Layout::Google {
+        plan.canvas_size_at_level(plan.levels[level_idx].level)
+    } else {
+        (plan.levels[level_idx].width, plan.levels[level_idx].height)
+    }
+}
+
+/// Downscale a strip with the shared tile operation
+/// ([`resize::downscale_half`]) and transfer its memory-tracker charge to
+/// the resulting half-strip.
+///
+/// Shared by the sequential streaming strip loop and the MapReduce reduce
+/// loop; both charge the strip before calling and hand the returned half to
+/// [`propagate_down`] (whose caller-charges-the-buffer contract the `alloc`
+/// here satisfies).
+pub(crate) fn downscale_strip_tracked(
+    strip: &Raster,
+    tracker: &MemoryTracker,
+) -> Result<Raster, RasterError> {
+    let strip_bytes = strip.data().len() as u64;
+    let half = resize::downscale_half(strip)?;
+    tracker.dealloc(strip_bytes);
+    tracker.alloc(half.data().len() as u64);
+    Ok(half)
+}
+
+/// Phase 2 of the streaming engines: flush unpaired strip accumulators.
+///
+/// When the canvas height isn't evenly divisible by the strip height, the
+/// last half-strip at some levels arrives without a partner. These leftovers
+/// sit in `accumulators[level_idx]` and must be emitted and propagated
+/// before the monolithic flush.
+///
+/// Processes from highest to lowest so that propagation feeds data into
+/// levels below, which may themselves be monolithic. Shared verbatim by the
+/// sequential streaming engine and the MapReduce engine (issue #138).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn flush_unpaired_accumulators(
+    accumulators: &mut Vec<Option<Raster>>,
+    mono_accumulators: &mut Vec<Vec<u8>>,
+    monolithic_threshold: usize,
+    plan: &PyramidPlan,
+    sink: &dyn TileSink,
+    config: &EngineConfig,
+    observer: &dyn EngineObserver,
+    tracker: &MemoryTracker,
+    tiles_produced: &mut u64,
+    tiles_skipped: &mut u64,
+) -> Result<(), EngineError> {
+    for level_idx in (monolithic_threshold + 1..plan.levels.len()).rev() {
+        if let Some(leftover) = accumulators[level_idx].take() {
+            // The leftover was charged when it was stored as an unpaired first
+            // half; it is still charged now.
+            let leftover_bytes = leftover.data().len() as u64;
+            // The leftover covers the bottom slice of this level. Its Y
+            // position is the level height minus the strip's own height.
+            let (_, lh) = level_dims(plan, level_idx);
+            let leftover_y = lh.saturating_sub(leftover.height());
+
+            let (tp, ts_skip) = emit_strip_tiles(
+                &leftover,
+                plan,
+                level_idx as u32,
+                leftover_y,
+                sink,
+                config,
+                observer,
+            )?;
+            *tiles_produced += tp;
+            *tiles_skipped += ts_skip;
+
+            // Continue the downscale chain into lower levels
+            if level_idx > 0 {
+                let further_half = resize::downscale_half(&leftover)?;
+                let further_bytes = further_half.data().len() as u64;
+                // Charge the downscaled half before handing it down (the
+                // caller-charges-the-buffer contract of `propagate_down`,
+                // issue #109). `leftover` is still live during the downscale,
+                // so the peak captures both.
+                tracker.alloc(further_bytes);
+                propagate_down(
+                    further_half,
+                    level_idx - 1,
+                    leftover_y / 2,
+                    accumulators,
+                    mono_accumulators,
+                    monolithic_threshold,
+                    plan,
+                    sink,
+                    config,
+                    observer,
+                    tracker,
+                    tiles_produced,
+                    tiles_skipped,
+                )?;
+            }
+
+            // The leftover buffer is dropped at the end of this block; release
+            // its charge.
+            drop(leftover);
+            tracker.dealloc(leftover_bytes);
+        }
+    }
+    Ok(())
+}
+
+/// Phase 3 of the streaming engines: assemble and emit the monolithic
+/// (small) levels.
+///
+/// Only the topmost monolithic level has accumulated raw row data via
+/// [`propagate_down`]. All levels below it are produced here by downscaling
+/// the level above with the shared level walk
+/// ([`crate::level_walk::walk_levels_down`]), exactly as the monolithic
+/// engine does. This guarantees pixel-exact parity: each pixel goes through
+/// the same sequence of 2×2 box-filter averages regardless of whether the
+/// pyramid was built monolithically or via streaming. Shared verbatim by the
+/// sequential streaming engine and the MapReduce engine (issue #138).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn flush_monolithic_levels(
+    mono_accumulators: &mut [Vec<u8>],
+    monolithic_threshold: usize,
+    plan: &PyramidPlan,
+    format: PixelFormat,
+    sink: &dyn TileSink,
+    config: &EngineConfig,
+    observer: &dyn EngineObserver,
+    tiles_produced: &mut u64,
+    tiles_skipped: &mut u64,
+) -> Result<(), EngineError> {
+    let bpp = format.bytes_per_pixel();
+    let top_mono = monolithic_threshold.min(plan.levels.len() - 1);
+
+    // Locate the topmost monolithic level with accumulated data and
+    // assemble its full raster. Levels above it (empty accumulator, or the
+    // degenerate zero-dimension case) produce nothing, exactly as before
+    // the extraction: the pre-#138 loop `continue`d past them until the
+    // first level whose accumulator held rows.
+    let mut base: Option<(usize, Raster)> = None;
+    for level_idx in (0..=top_mono).rev() {
+        let (lw, lh) = level_dims(plan, level_idx);
+        if lw == 0 || lh == 0 {
+            continue;
+        }
+        let mut acc_data = std::mem::take(&mut mono_accumulators[level_idx]);
+        if acc_data.is_empty() {
+            continue;
+        }
+        let expected = lw as usize * lh as usize * bpp;
+
+        // The accumulated data may exceed the expected size when the source
+        // has odd dimensions and downscale_half produces div_ceil rows from
+        // each strip fragment. Truncate to the exact expected byte count.
+        if acc_data.len() > expected {
+            acc_data.truncate(expected);
+        }
+        // Conversely, if the last strip was shorter than expected, pad
+        // remaining rows with the background colour.
+        if acc_data.len() < expected {
+            let filled_rows = acc_data.len() / (lw as usize * bpp);
+            acc_data.resize(expected, 0);
+            fill_background_rows(
+                &mut acc_data,
+                filled_rows,
+                lw,
+                lh,
+                bpp,
+                config.background_rgb,
+            );
+        }
+        base = Some((level_idx, Raster::new(lw, lh, format, acc_data)?));
+        break;
+    }
+    let Some((base_idx, base_raster)) = base else {
+        return Ok(());
+    };
+
+    // Walk from the assembled base level down to level 0, producing each
+    // lower level by downscaling the level above (the shared tile op).
+    crate::level_walk::walk_levels_down::<EngineError, _, _, _, _>(
+        base_raster,
+        base_idx + 1,
+        |_| Ok(()),
+        |_, prev| Ok(resize::downscale_half(&prev)?),
+        |level_idx, raster| {
+            // Defensive guard carried over from the pre-#138 loop: a level
+            // with zero pixel dimensions emits nothing. Below a non-empty
+            // base this is unreachable (level sizes halve with div_ceil, so
+            // they never drop below 1×1).
+            let (lw, lh) = level_dims(plan, level_idx);
+            if lw == 0 || lh == 0 {
+                return Ok(());
+            }
+            let (tp, ts_skip) =
+                emit_full_level_tiles(raster, plan, level_idx as u32, sink, config, observer)?;
+            *tiles_produced += tp;
+            *tiles_skipped += ts_skip;
+            Ok(())
+        },
+    )?;
+    Ok(())
 }
 
 /// Obtain a horizontal strip in canvas coordinate space.

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -37,13 +37,13 @@ use crate::observe::{EngineEvent, EngineObserver, MemoryTracker};
 use crate::pixel::PixelFormat;
 use crate::planner::{Layout, PyramidPlan, TileCoord};
 use crate::raster::Raster;
-use crate::resize;
 use crate::sink::{Tile, TileSink};
 #[cfg(test)]
 use crate::streaming::RasterStripSource;
 use crate::streaming::{
-    StripSource, compute_strip_height, emit_full_level_tiles, emit_strip_tiles,
-    fill_background_rows, find_monolithic_threshold, obtain_canvas_strip, propagate_down,
+    StripSource, compute_strip_height, downscale_strip_tracked, emit_strip_tiles,
+    find_monolithic_threshold, flush_monolithic_levels, flush_unpaired_accumulators,
+    obtain_canvas_strip, propagate_down,
 };
 
 /// Configuration for the MapReduce streaming engine.
@@ -526,8 +526,6 @@ pub(crate) fn generate_pyramid_mapreduce(
                 total_strips,
             });
 
-            let strip_bytes = strip.data().len() as u64;
-
             // Emit tiles at the top level
             let (tp, ts_skip) = if config.tile_concurrency > 0 {
                 emit_strip_tiles_parallel(
@@ -554,11 +552,9 @@ pub(crate) fn generate_pyramid_mapreduce(
             tiles_skipped += ts_skip;
             batch_tiles += tp;
 
-            // Downscale for reduce propagation
-            let half = resize::downscale_half(&strip)?;
-            tracker.dealloc(strip_bytes);
-            let half_bytes = half.data().len() as u64;
-            tracker.alloc(half_bytes);
+            // Downscale for reduce propagation, transferring the strip's
+            // memory charge to the half-strip.
+            let half = downscale_strip_tracked(&strip, &tracker)?;
 
             // Propagate half-strip into lower levels.
             //
@@ -597,117 +593,33 @@ pub(crate) fn generate_pyramid_mapreduce(
     // ===================================================================
     // Phase 2: Flush unpaired strip accumulators
     // ===================================================================
-    for level_idx in (monolithic_threshold + 1..plan.levels.len()).rev() {
-        if let Some(leftover) = accumulators[level_idx].take() {
-            // The leftover was charged when stored as an unpaired first half.
-            let leftover_bytes = leftover.data().len() as u64;
-            let (_, lh) = if plan.layout == Layout::Google {
-                plan.canvas_size_at_level(plan.levels[level_idx].level)
-            } else {
-                (plan.levels[level_idx].width, plan.levels[level_idx].height)
-            };
-            let leftover_y = lh.saturating_sub(leftover.height());
-
-            let (tp, ts_skip) = emit_strip_tiles(
-                &leftover,
-                plan,
-                level_idx as u32,
-                leftover_y,
-                sink,
-                &engine_cfg,
-                observer,
-            )?;
-            tiles_produced += tp;
-            tiles_skipped += ts_skip;
-
-            if level_idx > 0 {
-                let further_half = resize::downscale_half(&leftover)?;
-                let further_bytes = further_half.data().len() as u64;
-                // Honour `propagate_down`'s caller-charges-the-buffer contract
-                // (issue #109): the callee releases this charge once consumed.
-                tracker.alloc(further_bytes);
-                propagate_down(
-                    further_half,
-                    level_idx - 1,
-                    leftover_y / 2,
-                    &mut accumulators,
-                    &mut mono_accumulators,
-                    monolithic_threshold,
-                    plan,
-                    sink,
-                    &engine_cfg,
-                    observer,
-                    &tracker,
-                    &mut tiles_produced,
-                    &mut tiles_skipped,
-                )?;
-            }
-
-            // The leftover buffer is dropped here; release its charge.
-            drop(leftover);
-            tracker.dealloc(leftover_bytes);
-        }
-    }
+    flush_unpaired_accumulators(
+        &mut accumulators,
+        &mut mono_accumulators,
+        monolithic_threshold,
+        plan,
+        sink,
+        &engine_cfg,
+        observer,
+        &tracker,
+        &mut tiles_produced,
+        &mut tiles_skipped,
+    )?;
 
     // ===================================================================
     // Phase 3: Monolithic flush — assemble and emit small levels
     // ===================================================================
-    {
-        let top_mono = monolithic_threshold.min(plan.levels.len() - 1);
-        let mut prev_raster: Option<Raster> = None;
-
-        for level_idx in (0..=top_mono).rev() {
-            let level = &plan.levels[level_idx];
-            let (lw, lh) = if plan.layout == Layout::Google {
-                plan.canvas_size_at_level(level.level)
-            } else {
-                (level.width, level.height)
-            };
-            if lw == 0 || lh == 0 {
-                continue;
-            }
-
-            let raster = if let Some(prev) = prev_raster.take() {
-                resize::downscale_half(&prev)?
-            } else {
-                let mut acc_data = std::mem::take(&mut mono_accumulators[level_idx]);
-                if acc_data.is_empty() {
-                    continue;
-                }
-                let expected = lw as usize * lh as usize * bpp;
-
-                if acc_data.len() > expected {
-                    acc_data.truncate(expected);
-                }
-                if acc_data.len() < expected {
-                    let filled_rows = acc_data.len() / (lw as usize * bpp);
-                    acc_data.resize(expected, 0);
-                    fill_background_rows(
-                        &mut acc_data,
-                        filled_rows,
-                        lw,
-                        lh,
-                        bpp,
-                        engine_cfg.background_rgb,
-                    );
-                }
-                Raster::new(lw, lh, format, acc_data)?
-            };
-
-            let (tp, ts_skip) = emit_full_level_tiles(
-                &raster,
-                plan,
-                level_idx as u32,
-                sink,
-                &engine_cfg,
-                observer,
-            )?;
-            tiles_produced += tp;
-            tiles_skipped += ts_skip;
-
-            prev_raster = Some(raster);
-        }
-    }
+    flush_monolithic_levels(
+        &mut mono_accumulators,
+        monolithic_threshold,
+        plan,
+        format,
+        sink,
+        &engine_cfg,
+        observer,
+        &mut tiles_produced,
+        &mut tiles_skipped,
+    )?;
 
     // Emit LevelCompleted for all levels
     for level in &plan.levels {


### PR DESCRIPTION
## What

I finish issue #138 by physically extracting the one shared level walk (the Extensions half landed in PR #218).

- **New `src/level_walk.rs`**: `walk_levels_down(top_raster, levels_len, enter, step, emit)`. The walk skeleton (descending level order, top level never stepped, exactly one tile-op step between adjacent levels) exists once; the `step` closure is the tile-operation parameter from the issue's roadmap, and `enter`/`emit` carry each site's cancellation checks, observer events, timing, and memory tracking in their original order. `enter` returns a guard held for the whole level, so the live engine's tracing span keeps its exact coverage.
- **engine.rs**: `run_pyramid` and `raster_verify` both delegate to the shared walk (previously two hand-rolled copies).
- **stream_verify.rs**: the strip-source verify walk delegates to the same helper.
- **streaming.rs / streaming_mapreduce.rs**: Phase 2 (unpaired-accumulator flush) and Phase 3 (monolithic flush) were near-verbatim duplicates across the two drivers. They now exist once in `streaming.rs` (`flush_unpaired_accumulators`, `flush_monolithic_levels`) and are called by both; Phase 3's cascade goes through `walk_levels_down`. The per-strip halving in both strip loops folds into `downscale_strip_tracked`; `propagate_down` was already shared.
- **engine_builder.rs docs**: the roadmap section now describes the landed shared walk and the remaining `TileOp` / `with_tile_op` step.

## Byte-identity evidence

- New unit tests in `level_walk.rs` pin the walk against a verbatim transcription of the prior per-site loop (level order plus per-level byte identity on an odd-sized raster), the enter/step/emit interleaving the engine event stream relies on, guard lifetime, error short-circuiting, and the zero-level edge.
- I also ran an out-of-tree differential: hashed every tile (sorted by coord) from the Monolithic, Streaming, and MapReduce engines over three plans (DeepZoom 517x333 t128, Google+centre 500x300 t256, DeepZoom 1024x777 t256, with small budgets forcing the strip/flush paths) on this branch and on origin/main. All nine digests are identical between the two trees, and identical across engines.
- The existing parity suites (`streaming_parity_deepzoom_small`, `mapreduce_basic_parity`, `mapreduce_order_independent_parity_at_concurrency`) and both verify suites pass unchanged.

## Gates

`make fmt`, `make clippy` (default and pdfium), `make test` (396 unit tests plus all integration suites), and `make doc` are green locally; clippy with `--features tracing` is also green. The `--all-features` clippy dead-code error in `pdf.rs` predates this change (it fails identically on origin/main).

Closes #138