### PR TITLE
feat(core): WorkExecutor plug-in seam + MapReduceHotCache engine (#67, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to libviprs are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `WorkExecutor` trait, `StripWorkUnit`, `WorkContext`, and `LocalWorkExecutor`
+  in `streaming_mapreduce` (re-exported at the crate root): a plug-in seam at
+  the MapReduce MAP-phase strip dispatch, so an out-of-tree executor (process
+  pool, distributed worker layer) can substitute for the built-in in-process
+  rendering (issue #67). Installed via `EngineBuilder::with_executor(...)`;
+  the default `LocalWorkExecutor` is byte-identical to the previous engine.
+- `EngineKind::MapReduceHotCache`: a local-only MapReduce variant that holds
+  every produced tile in RAM and drains the caller's sink in one batched pass
+  at the end of the run, in canonical `(level, row, col)` order, followed by
+  a single `finish()` (issue #67). Byte-identical output to the streaming and
+  MapReduce engines; explicit opt-in only, never selected by
+  `EngineKind::Auto`.
+
 ## [0.3.1] — 2026-04-25
 
 Documentation-only patch: the README and crate-root rustdoc shipped on

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -52,6 +52,7 @@ use crate::engine::{
     BlankTileStrategy, EngineConfig, EngineError, EngineResult, generate_pyramid_observed,
 };
 use crate::extensions::Extensions;
+use crate::mapreduce_hot_cache::generate_pyramid_mapreduce_hot_cache;
 use crate::observe::{EngineObserver, NoopObserver};
 use crate::planner::PyramidPlan;
 use crate::raster::Raster;
@@ -61,7 +62,9 @@ use crate::sink::TileSink;
 use crate::streaming::{
     BudgetPolicy, RasterStripSource, StreamingConfig, StripSource, generate_pyramid_streaming,
 };
-use crate::streaming_mapreduce::{MapReduceConfig, generate_pyramid_mapreduce};
+use crate::streaming_mapreduce::{
+    LocalWorkExecutor, MapReduceConfig, WorkExecutor, generate_pyramid_mapreduce,
+};
 
 /// Checks that a [`PyramidPlan`] is internally well-formed and describes the
 /// source it is about to be run against.
@@ -120,6 +123,20 @@ pub enum EngineKind {
     Streaming,
     /// Parallel map-reduce streaming engine. Accepts either source kind.
     MapReduce,
+    /// MapReduce engine with an in-memory hot cache: rendering is identical
+    /// to [`MapReduce`](Self::MapReduce), but every produced tile is retained
+    /// in RAM and the caller's sink receives the whole pyramid as one batched
+    /// flush at the end of the run, in canonical `(level, row, col)` order,
+    /// followed by a single `finish()`.
+    ///
+    /// A local-only memory-vs-throughput tradeoff (issue #67): the memory
+    /// budget still bounds the MAP/REDUCE working set (including the
+    /// pre-flight [`EngineError::BudgetExceeded`] rejection), while the cache
+    /// itself holds the full pyramid's raster bytes until the flush. Because
+    /// of that deliberate residency, [`Auto`](Self::Auto) never selects this
+    /// engine; it is explicit opt-in only. Accepts either source kind.
+    /// Byte-identical output to the streaming and MapReduce engines.
+    MapReduceHotCache,
 }
 
 // ---------------------------------------------------------------------------
@@ -188,6 +205,7 @@ pub struct EngineBuilder<'a, S: TileSink> {
 
     engine_kind: EngineKind,
     observer: Option<Arc<dyn EngineObserver>>,
+    executor: Option<Arc<dyn WorkExecutor>>,
 
     // EngineConfig knobs
     concurrency: Option<usize>,
@@ -216,6 +234,7 @@ impl<'a, S: TileSink> std::fmt::Debug for EngineBuilder<'a, S> {
         f.debug_struct("EngineBuilder")
             .field("source", &self.source)
             .field("engine_kind", &self.engine_kind)
+            .field("has_executor", &self.executor.is_some())
             .field("concurrency", &self.concurrency)
             .field("buffer_size", &self.buffer_size)
             .field("background_rgb", &self.background_rgb)
@@ -239,6 +258,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             sink,
             engine_kind: EngineKind::Auto,
             observer: None,
+            executor: None,
             concurrency: None,
             buffer_size: None,
             background_rgb: None,
@@ -275,6 +295,22 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
     /// **See also:** [interactive example](https://libviprs.org/cli/#flag-parallel).
     pub fn with_engine(mut self, kind: EngineKind) -> Self {
         self.engine_kind = kind;
+        self
+    }
+
+    /// Install a [`WorkExecutor`] at the MapReduce MAP-phase strip-dispatch
+    /// seam (issue #67), substituting for the built-in in-process rendering.
+    ///
+    /// Consulted by [`EngineKind::MapReduce`] and
+    /// [`EngineKind::MapReduceHotCache`] (the engines with a MAP phase);
+    /// the monolithic and sequential streaming engines have no strip-dispatch
+    /// seam and ignore it. Defaults to
+    /// [`LocalWorkExecutor`](crate::streaming_mapreduce::LocalWorkExecutor),
+    /// which preserves the engine's historical behaviour exactly. See
+    /// [`WorkExecutor`] for the dispatch-order and byte-parity contract a
+    /// custom executor must uphold.
+    pub fn with_executor(mut self, executor: Arc<dyn WorkExecutor>) -> Self {
+        self.executor = Some(executor);
         self
     }
 
@@ -494,6 +530,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             sink,
             engine_kind,
             observer,
+            executor,
             concurrency,
             buffer_size,
             background_rgb,
@@ -524,6 +561,14 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
         let observer_ref: &dyn EngineObserver = match &observer {
             Some(arc) => arc.as_ref(),
             None => &NoopObserver,
+        };
+
+        // The MAP-phase strip-dispatch seam (issue #67). Absent an installed
+        // executor, the local in-process renderer preserves the engines'
+        // historical behaviour exactly.
+        let executor_ref: &dyn WorkExecutor = match &executor {
+            Some(arc) => arc.as_ref(),
+            None => &LocalWorkExecutor,
         };
 
         // Deliver the extension hatch to its one reader. The map used to be
@@ -625,7 +670,8 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                         )?
                     }
                     (EngineKind::Streaming, EngineSource::Raster(raster))
-                    | (EngineKind::MapReduce, EngineSource::Raster(raster)) => {
+                    | (EngineKind::MapReduce, EngineSource::Raster(raster))
+                    | (EngineKind::MapReduceHotCache, EngineSource::Raster(raster)) => {
                         let strip = RasterStripSource::new(raster);
                         crate::verify::verify_from_strip_source(
                             &strip,
@@ -636,7 +682,8 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                         )?
                     }
                     (EngineKind::Streaming, EngineSource::Strip(strip))
-                    | (EngineKind::MapReduce, EngineSource::Strip(strip)) => {
+                    | (EngineKind::MapReduce, EngineSource::Strip(strip))
+                    | (EngineKind::MapReduceHotCache, EngineSource::Strip(strip)) => {
                         crate::verify::verify_from_strip_source(
                             strip.as_ref(),
                             &plan,
@@ -720,7 +767,14 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                         &engine_cfg.failure_policy,
                         cancel.clone(),
                     );
-                    generate_pyramid_mapreduce(&strip, &plan, &wrapped, &cfg, observer_ref)
+                    generate_pyramid_mapreduce(
+                        &strip,
+                        &plan,
+                        &wrapped,
+                        &cfg,
+                        observer_ref,
+                        executor_ref,
+                    )
                 }
                 (EngineKind::MapReduce, EngineSource::Strip(strip)) => {
                     let cfg = build_mapreduce_config(
@@ -732,7 +786,53 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                         &engine_cfg.failure_policy,
                         cancel.clone(),
                     );
-                    generate_pyramid_mapreduce(strip.as_ref(), &plan, &wrapped, &cfg, observer_ref)
+                    generate_pyramid_mapreduce(
+                        strip.as_ref(),
+                        &plan,
+                        &wrapped,
+                        &cfg,
+                        observer_ref,
+                        executor_ref,
+                    )
+                }
+                (EngineKind::MapReduceHotCache, EngineSource::Raster(raster)) => {
+                    let strip = RasterStripSource::new(raster);
+                    let cfg = build_mapreduce_config(
+                        memory_budget_bytes,
+                        concurrency,
+                        buffer_size,
+                        background_rgb,
+                        blank_strategy,
+                        &engine_cfg.failure_policy,
+                        cancel.clone(),
+                    );
+                    generate_pyramid_mapreduce_hot_cache(
+                        &strip,
+                        &plan,
+                        &wrapped,
+                        &cfg,
+                        observer_ref,
+                        executor_ref,
+                    )
+                }
+                (EngineKind::MapReduceHotCache, EngineSource::Strip(strip)) => {
+                    let cfg = build_mapreduce_config(
+                        memory_budget_bytes,
+                        concurrency,
+                        buffer_size,
+                        background_rgb,
+                        blank_strategy,
+                        &engine_cfg.failure_policy,
+                        cancel.clone(),
+                    );
+                    generate_pyramid_mapreduce_hot_cache(
+                        strip.as_ref(),
+                        &plan,
+                        &wrapped,
+                        &cfg,
+                        observer_ref,
+                        executor_ref,
+                    )
                 }
                 (EngineKind::Monolithic, EngineSource::Strip(_)) => {
                     unreachable!("Monolithic + Strip rejected above")
@@ -829,7 +929,14 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                     &engine_cfg.failure_policy,
                     cancel.clone(),
                 );
-                generate_pyramid_mapreduce(&source, &plan, engine_sink, &cfg, observer_ref)?
+                generate_pyramid_mapreduce(
+                    &source,
+                    &plan,
+                    engine_sink,
+                    &cfg,
+                    observer_ref,
+                    executor_ref,
+                )?
             }
             (EngineKind::MapReduce, EngineSource::Strip(source)) => {
                 let cfg = build_mapreduce_config(
@@ -841,7 +948,53 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                     &engine_cfg.failure_policy,
                     cancel.clone(),
                 );
-                generate_pyramid_mapreduce(source.as_ref(), &plan, engine_sink, &cfg, observer_ref)?
+                generate_pyramid_mapreduce(
+                    source.as_ref(),
+                    &plan,
+                    engine_sink,
+                    &cfg,
+                    observer_ref,
+                    executor_ref,
+                )?
+            }
+            (EngineKind::MapReduceHotCache, EngineSource::Raster(raster)) => {
+                let source = RasterStripSource::new(raster);
+                let cfg = build_mapreduce_config(
+                    memory_budget_bytes,
+                    concurrency,
+                    buffer_size,
+                    background_rgb,
+                    blank_strategy,
+                    &engine_cfg.failure_policy,
+                    cancel.clone(),
+                );
+                generate_pyramid_mapreduce_hot_cache(
+                    &source,
+                    &plan,
+                    engine_sink,
+                    &cfg,
+                    observer_ref,
+                    executor_ref,
+                )?
+            }
+            (EngineKind::MapReduceHotCache, EngineSource::Strip(source)) => {
+                let cfg = build_mapreduce_config(
+                    memory_budget_bytes,
+                    concurrency,
+                    buffer_size,
+                    background_rgb,
+                    blank_strategy,
+                    &engine_cfg.failure_policy,
+                    cancel.clone(),
+                );
+                generate_pyramid_mapreduce_hot_cache(
+                    source.as_ref(),
+                    &plan,
+                    engine_sink,
+                    &cfg,
+                    observer_ref,
+                    executor_ref,
+                )?
             }
             (EngineKind::Auto, _) => {
                 // `resolve_engine_kind` already flattened Auto to a concrete
@@ -1397,6 +1550,7 @@ mod extension_wiring_tests {
             EngineKind::Monolithic,
             EngineKind::Streaming,
             EngineKind::MapReduce,
+            EngineKind::MapReduceHotCache,
         ] {
             let seen_value = Arc::new(AtomicU64::new(0));
             let fired = Arc::new(AtomicU64::new(0));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,9 @@
 //!    [`MemorySink`] (in-memory).
 //! 4. **Select an engine** with [`EngineKind`]: `Auto` (default; picks based on
 //!    source kind and memory budget), `Monolithic` (in-memory),
-//!    `Streaming` (sequential strip), or `MapReduce` (parallel strip).
+//!    `Streaming` (sequential strip), `MapReduce` (parallel strip), or
+//!    `MapReduceHotCache` (parallel strip, tiles cached in RAM and flushed to
+//!    the sink in one canonical-order batch at the end).
 //! 5. **Observe progress** by passing an [`EngineObserver`] to
 //!    `.with_observer(...)`; lifecycle, level, tile, and batch updates arrive as
 //!    [`EngineEvent`] variants (see the [`observe`] module).
@@ -57,6 +59,7 @@ pub(crate) mod level_walk;
 #[cfg(loom)]
 mod loom_tests;
 pub mod manifest;
+pub(crate) mod mapreduce_hot_cache;
 pub mod observe;
 pub mod pdf;
 pub mod pixel;
@@ -127,4 +130,6 @@ pub use streaming::{
 #[cfg(feature = "pdfium")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pdfium")))]
 pub use streaming::{PdfiumRenderMode, PdfiumStripSource};
-pub use streaming_mapreduce::MapReduceConfig;
+pub use streaming_mapreduce::{
+    LocalWorkExecutor, MapReduceConfig, StripWorkUnit, WorkContext, WorkExecutor,
+};

--- a/src/mapreduce_hot_cache.rs
+++ b/src/mapreduce_hot_cache.rs
@@ -1,0 +1,344 @@
+//! MapReduce hot-cache pyramid engine (issue #67).
+//!
+//! A local-only variant of the MapReduce engine that trades memory for
+//! throughput: the MAP/REDUCE phases run unchanged, but every produced tile
+//! is retained in an in-memory hot cache instead of being written to the
+//! caller's sink as it arrives. When the whole pyramid has been rendered, the
+//! cache is drained to the user sink in one batched pass, in canonical
+//! `(level, row, col)` order, followed by a single `finish()`.
+//!
+//! ## Why
+//!
+//! Sinks whose per-write cost dominates (network stores, archive writers,
+//! sinks holding coarse locks) benefit from receiving the whole pyramid as
+//! one ordered burst at the end of the run instead of interleaved with
+//! rendering. The canonical flush order also makes the *write order* to the
+//! sink deterministic even at `tile_concurrency > 0`, which the plain
+//! MapReduce engine deliberately does not promise (it writes in
+//! channel-arrival order).
+//!
+//! ## Determinism
+//!
+//! Byte-identical to the streaming and MapReduce engines for the same inputs:
+//! the tile bytes are produced by the exact same MAP/REDUCE code (this module
+//! reuses [`generate_pyramid_mapreduce`] wholesale against the cache), and the
+//! flush replays them without transformation.
+//!
+//! ## Memory
+//!
+//! The configured memory budget bounds the MAP/REDUCE working set exactly as
+//! it does for [`EngineKind::MapReduce`](crate::EngineKind::MapReduce),
+//! including the pre-flight [`EngineError::BudgetExceeded`] rejection. The
+//! hot cache itself is *additional*, deliberately unbounded residency (the
+//! whole pyramid's raster bytes stay in RAM until the flush): that is the
+//! opt-in tradeoff this engine exists for, and it is why
+//! [`EngineKind::Auto`](crate::EngineKind::Auto) never selects it. The cached
+//! bytes are charged into [`EngineResult::peak_memory_bytes`] so the reported
+//! peak reflects the real residency.
+//!
+//! ## Observer semantics
+//!
+//! `TileCompleted` fires when a tile is *produced* (lands in the hot cache),
+//! not when it reaches the caller's sink; the sink receives everything during
+//! the final flush. `Finished` keeps its "comes last" contract: the inner
+//! run's `Finished` is withheld and re-emitted only after the flush and the
+//! user sink's `finish()` have completed.
+//!
+//! ## Entry point
+//!
+//! Reached through the fluent [`EngineBuilder`](crate::EngineBuilder) via
+//! [`EngineKind::MapReduceHotCache`](crate::EngineKind::MapReduceHotCache).
+//! Explicit opt-in only.
+
+use std::sync::Mutex;
+
+use crate::engine::{EngineError, EngineResult, promote_sink_error};
+use crate::observe::{EngineEvent, EngineObserver};
+use crate::planner::PyramidPlan;
+use crate::sink::{SinkError, Tile, TileSink};
+use crate::streaming::StripSource;
+use crate::streaming_mapreduce::{MapReduceConfig, WorkExecutor, generate_pyramid_mapreduce};
+
+/// Terminal in-memory sink holding every produced tile until the final flush.
+///
+/// Unlike [`MemorySink`](crate::sink::MemorySink) it preserves the full
+/// [`Tile`] (including the `blank` flag), so the flush replays exactly what
+/// the engine produced and placeholder-writing sinks behave identically to a
+/// direct run.
+#[derive(Debug, Default)]
+struct HotCacheSink {
+    tiles: Mutex<Vec<Tile>>,
+}
+
+impl HotCacheSink {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn into_tiles(self) -> Vec<Tile> {
+        self.tiles
+            .into_inner()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl TileSink for HotCacheSink {
+    fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+        crate::poison::recover(&self.tiles).push(Tile {
+            coord: tile.coord,
+            raster: tile.raster.clone(),
+            blank: tile.blank,
+        });
+        Ok(())
+    }
+}
+
+/// Observer adapter that withholds the inner run's `Finished` event.
+///
+/// The hot-cache driver runs the MapReduce engine to completion against the
+/// cache and only then flushes the user sink, so the `Finished` event the
+/// inner run emits would reach observers *before* any tile lands in the real
+/// sink. The driver suppresses it here and re-emits `Finished` itself once
+/// the flush (and the user sink's `finish()`) has completed, preserving the
+/// documented "Finished comes last" ordering. Every other event forwards
+/// unchanged.
+struct DeferFinished<'a> {
+    inner: &'a dyn EngineObserver,
+}
+
+impl EngineObserver for DeferFinished<'_> {
+    fn on_event(&self, event: EngineEvent) {
+        if matches!(event, EngineEvent::Finished { .. }) {
+            return;
+        }
+        self.inner.on_event(event);
+    }
+
+    fn on_extensions(&self, extensions: &crate::extensions::Extensions) {
+        self.inner.on_extensions(extensions);
+    }
+}
+
+/// Generate a tile pyramid with the MapReduce hot-cache engine.
+///
+/// Runs [`generate_pyramid_mapreduce`] unchanged against an in-memory cache,
+/// then drains the cache to `sink` in canonical `(level, row, col)` order and
+/// calls `sink.finish()` once. See the [module docs](self) for the contract.
+///
+/// # Pixel parity
+///
+/// Byte-identical to the streaming and MapReduce engines: the tiles are
+/// produced by the same code and replayed verbatim.
+pub(crate) fn generate_pyramid_mapreduce_hot_cache(
+    source: &dyn StripSource,
+    plan: &PyramidPlan,
+    sink: &dyn TileSink,
+    config: &MapReduceConfig,
+    observer: &dyn EngineObserver,
+    executor: &dyn WorkExecutor,
+) -> Result<EngineResult, EngineError> {
+    // Phase 1: render the whole pyramid into the hot cache. The inner run's
+    // `Finished` is withheld; it is re-emitted after the flush below.
+    let cache = HotCacheSink::new();
+    let defer = DeferFinished { inner: observer };
+    let mut result = generate_pyramid_mapreduce(source, plan, &cache, config, &defer, executor)?;
+
+    // Phase 2: single-pass batched flush, canonical order. Sorting here is
+    // what makes the user-visible *write order* deterministic even when the
+    // cache was filled in channel-arrival order at `tile_concurrency > 0`.
+    let mut tiles = cache.into_tiles();
+    tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
+    let cached_bytes: u64 = tiles.iter().map(|t| t.raster.data().len() as u64).sum();
+
+    let mut flush_skipped = 0u64;
+    for tile in &tiles {
+        // Cooperative cancellation between writes, matching the polling
+        // cadence of the other engines' write loops.
+        if let Some(token) = &config.cancel {
+            if token.is_cancelled() {
+                return Err(EngineError::Cancelled);
+            }
+        }
+        if let Err(e) = sink.write_tile(tile) {
+            // Same terminal-failure handling as the MapReduce emit paths: a
+            // write whose retry backoff was interrupted by cancellation
+            // surfaces as Cancelled, RetryThenSkip skips and accounts, and
+            // every other policy aborts the run.
+            if let Some(token) = &config.cancel {
+                if token.is_cancelled() {
+                    return Err(EngineError::Cancelled);
+                }
+            }
+            match &config.failure_policy {
+                crate::retry::FailurePolicy::RetryThenSkip(_) => {
+                    sink.note_sink_skipped();
+                    flush_skipped += 1;
+                    continue;
+                }
+                _ => return Err(promote_sink_error(e)),
+            }
+        }
+    }
+
+    sink.finish()?;
+
+    // A tile dropped at flush time produced no output, so it must not be
+    // counted as produced (parity with the direct engines, where a skipped
+    // write never increments the produced count).
+    result.tiles_produced = result.tiles_produced.saturating_sub(flush_skipped);
+    result.skipped_due_to_failure = sink.sink_skipped_due_to_failure();
+    // Charge the cache residency into the reported peak: the cached pyramid
+    // is held alongside the MAP/REDUCE working set, so the sum is a
+    // conservative upper bound on the run's real raster residency.
+    result.peak_memory_bytes = result.peak_memory_bytes.saturating_add(cached_bytes);
+
+    observer.on_event(EngineEvent::Finished {
+        total_tiles: result.tiles_produced,
+        levels: plan.levels.len() as u32,
+    });
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::EngineConfig;
+    use crate::observe::{CollectingObserver, NoopObserver};
+    use crate::pixel::PixelFormat;
+    use crate::planner::{Layout, PyramidPlanner};
+    use crate::raster::Raster;
+    use crate::sink::MemorySink;
+    use crate::streaming::RasterStripSource;
+    use crate::streaming_mapreduce::LocalWorkExecutor;
+
+    fn gradient_raster(w: u32, h: u32) -> Raster {
+        let bpp = PixelFormat::Rgb8.bytes_per_pixel();
+        let mut data = vec![0u8; w as usize * h as usize * bpp];
+        for y in 0..h {
+            for x in 0..w {
+                let off = (y as usize * w as usize + x as usize) * bpp;
+                data[off] = (x % 256) as u8;
+                data[off + 1] = (y % 256) as u8;
+                data[off + 2] = ((x + y) % 256) as u8;
+            }
+        }
+        Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    #[test]
+    fn hot_cache_parity_with_monolithic_reference() {
+        let src = gradient_raster(256, 256);
+        let plan = PyramidPlanner::new(256, 256, 128, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+
+        let ref_sink = MemorySink::new();
+        crate::engine::generate_pyramid_observed(
+            &src,
+            &plan,
+            &ref_sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .unwrap();
+        let mut ref_tiles = ref_sink.tiles();
+        ref_tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
+
+        let hot_sink = MemorySink::new();
+        let config = MapReduceConfig {
+            memory_budget_bytes: 1_000_000,
+            ..MapReduceConfig::default()
+        };
+        let strip_src = RasterStripSource::new(&src);
+        generate_pyramid_mapreduce_hot_cache(
+            &strip_src,
+            &plan,
+            &hot_sink,
+            &config,
+            &NoopObserver,
+            &LocalWorkExecutor,
+        )
+        .unwrap();
+        let mut hot_tiles = hot_sink.tiles();
+        hot_tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
+
+        assert_eq!(ref_tiles.len(), hot_tiles.len());
+        for (r, h) in ref_tiles.iter().zip(hot_tiles.iter()) {
+            assert_eq!(r.coord, h.coord);
+            assert_eq!(r.data, h.data, "tile data diverged at {:?}", h.coord);
+        }
+    }
+
+    #[test]
+    fn hot_cache_emits_finished_exactly_once_and_last() {
+        let src = gradient_raster(256, 256);
+        let plan = PyramidPlanner::new(256, 256, 128, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+        let observer = CollectingObserver::new();
+        let sink = MemorySink::new();
+        let config = MapReduceConfig {
+            memory_budget_bytes: 1_000_000,
+            ..MapReduceConfig::default()
+        };
+        let result = generate_pyramid_mapreduce_hot_cache(
+            &RasterStripSource::new(&src),
+            &plan,
+            &sink,
+            &config,
+            &observer,
+            &LocalWorkExecutor,
+        )
+        .unwrap();
+
+        let events = observer.events();
+        let finished: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, EngineEvent::Finished { .. }))
+            .collect();
+        assert_eq!(
+            finished.len(),
+            1,
+            "the withheld inner Finished must not leak alongside the re-emitted one"
+        );
+        assert!(
+            matches!(events.last(), Some(EngineEvent::Finished { .. })),
+            "Finished must be the final event"
+        );
+        assert!(
+            matches!(
+                events.last(),
+                Some(EngineEvent::Finished { total_tiles, .. }) if *total_tiles == result.tiles_produced
+            ),
+            "Finished must carry the post-flush produced count"
+        );
+    }
+
+    #[test]
+    fn hot_cache_rejects_budget_too_small_for_strip() {
+        // Parity with the MapReduce pre-flight: a budget below the minimum
+        // aligned strip is rejected up front, before anything is cached.
+        let src = gradient_raster(512, 512);
+        let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+        let config = MapReduceConfig {
+            memory_budget_bytes: 100_000,
+            ..MapReduceConfig::default()
+        };
+        let err = generate_pyramid_mapreduce_hot_cache(
+            &RasterStripSource::new(&src),
+            &plan,
+            &MemorySink::new(),
+            &config,
+            &NoopObserver,
+            &LocalWorkExecutor,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, EngineError::BudgetExceeded { .. }),
+            "expected BudgetExceeded, got {err:?}"
+        );
+    }
+}

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -111,6 +111,97 @@ impl MapReduceConfig {
 }
 
 // ---------------------------------------------------------------------------
+// WorkExecutor seam (issue #67)
+// ---------------------------------------------------------------------------
+
+/// One unit of MAP-phase strip work, as dispatched by the MapReduce engine.
+///
+/// Identifies the horizontal band of the top-level canvas a
+/// [`WorkExecutor`] must render: `canvas_y` is the band's starting row in
+/// canvas coordinates, `height` its row count, and `level` the pyramid level
+/// the band belongs to (always the top level today; carried explicitly so an
+/// out-of-process executor can reconstruct the request without the plan).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StripWorkUnit {
+    /// Starting row of the strip, in canvas coordinates.
+    pub canvas_y: u32,
+    /// Number of rows in the strip.
+    pub height: u32,
+    /// Pyramid level the strip is rendered at (the plan's top level).
+    pub level: u32,
+}
+
+/// Borrowed context handed to a [`WorkExecutor`] alongside each
+/// [`StripWorkUnit`].
+///
+/// Everything a local executor needs to render the strip in-process. An
+/// out-of-tree distribution layer is free to ignore these borrows and
+/// reconstruct equivalent state on the far side of its transport.
+#[derive(Clone, Copy)]
+pub struct WorkContext<'a> {
+    /// The strip source the engine was launched with.
+    pub source: &'a dyn StripSource,
+    /// The pyramid plan for this run.
+    pub plan: &'a PyramidPlan,
+    /// The engine configuration derived from the run's [`MapReduceConfig`].
+    pub config: &'a EngineConfig,
+}
+
+impl std::fmt::Debug for WorkContext<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkContext")
+            .field("plan", &self.plan)
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Plug-in seam for MAP-phase strip dispatch (issue #67).
+///
+/// The MapReduce engine routes every strip render through this trait, so an
+/// alternative executor (a process pool, an out-of-tree distributed worker
+/// layer) can substitute for the built-in in-process rendering. Install one
+/// via [`EngineBuilder::with_executor`](crate::EngineBuilder::with_executor);
+/// the default is [`LocalWorkExecutor`], which preserves the engine's
+/// historical behaviour exactly.
+///
+/// # Contract
+///
+/// * **Dispatch order** — the engine dispatches work units in canonical
+///   order: strictly increasing `canvas_y`, gap-free over the canvas. On the
+///   parallel MAP path (a source that opts in via
+///   [`StripSource::permits_concurrent_strips`] plus `tile_concurrency > 0`)
+///   several `execute` calls may be in flight at once, so *completion* order
+///   is unspecified; the engine reassembles results positionally, and the
+///   REDUCE phase always consumes strips in canonical order regardless of the
+///   executor.
+/// * **Output** — the returned [`Raster`] must be the canvas-space strip for
+///   the request: `plan.canvas_width` wide, exactly `spec.height` rows, in
+///   `ctx.source.format()`. Byte-identical output to [`LocalWorkExecutor`] is
+///   required for the engine's byte-identical-pyramid guarantee to hold.
+/// * **Errors** — returning `Err` aborts the run with that error. A panic
+///   inside `execute` on the parallel path surfaces as
+///   [`EngineError::WorkerPanic`]; on the sequential path it unwinds, exactly
+///   as the built-in renderer always has.
+pub trait WorkExecutor: Send + Sync {
+    /// Render one canvas-space strip.
+    fn execute(&self, spec: StripWorkUnit, ctx: WorkContext<'_>) -> Result<Raster, EngineError>;
+}
+
+/// Default [`WorkExecutor`]: renders the strip in-process.
+///
+/// Wraps the engine's built-in canvas-strip renderer, so installing it
+/// explicitly is byte-identical to not installing an executor at all.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LocalWorkExecutor;
+
+impl WorkExecutor for LocalWorkExecutor {
+    fn execute(&self, spec: StripWorkUnit, ctx: WorkContext<'_>) -> Result<Raster, EngineError> {
+        obtain_canvas_strip(ctx.source, ctx.plan, spec.canvas_y, spec.height, ctx.config)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Memory estimation
 // ---------------------------------------------------------------------------
 
@@ -381,6 +472,7 @@ pub(crate) fn generate_pyramid_mapreduce(
     sink: &dyn TileSink,
     config: &MapReduceConfig,
     observer: &dyn EngineObserver,
+    executor: &dyn WorkExecutor,
 ) -> Result<EngineResult, EngineError> {
     let format = source.format();
     let bpp = format.bytes_per_pixel();
@@ -473,12 +565,23 @@ pub(crate) fn generate_pyramid_mapreduce(
 
         // MAP: render all strips in this batch (parallel when beneficial).
         //
+        // Every strip render goes through the `WorkExecutor` seam (issue #67);
+        // the default `LocalWorkExecutor` reproduces the historical in-process
+        // rendering exactly. Work units are dispatched in canonical order and
+        // results are reassembled positionally, so the REDUCE phase below sees
+        // strips in canonical order regardless of the executor.
+        //
         // Concurrent rendering issues `render_strip` from several threads at
         // once and therefore out of `y` order. That only honours the
         // `StripSource` contract for sources that opt in via
         // `permits_concurrent_strips`; a default (cursor-based) source is
         // promised sequential, strictly-increasing-`y` access, so it must take
         // the sequential branch even when concurrency is enabled (issue #105).
+        let work_context = WorkContext {
+            source,
+            plan,
+            config: &engine_cfg,
+        };
         let rendered_strips = if config.tile_concurrency > 0
             && batch_specs.len() > 1
             && source.permits_concurrent_strips()
@@ -487,9 +590,15 @@ pub(crate) fn generate_pyramid_mapreduce(
             std::thread::scope(|s| -> Result<(), EngineError> {
                 let mut handles = Vec::with_capacity(batch_specs.len());
                 for &(y, sh) in batch_specs {
-                    let engine_cfg = &engine_cfg;
                     handles.push(s.spawn(move || -> Result<Raster, EngineError> {
-                        obtain_canvas_strip(source, plan, y, sh, engine_cfg)
+                        executor.execute(
+                            StripWorkUnit {
+                                canvas_y: y,
+                                height: sh,
+                                level: top_level as u32,
+                            },
+                            work_context,
+                        )
                     }));
                 }
                 for (i, handle) in handles.into_iter().enumerate() {
@@ -502,7 +611,16 @@ pub(crate) fn generate_pyramid_mapreduce(
         } else {
             batch_specs
                 .iter()
-                .map(|&(y, sh)| obtain_canvas_strip(source, plan, y, sh, &engine_cfg))
+                .map(|&(y, sh)| {
+                    executor.execute(
+                        StripWorkUnit {
+                            canvas_y: y,
+                            height: sh,
+                            level: top_level as u32,
+                        },
+                        work_context,
+                    )
+                })
                 .collect::<Result<Vec<_>, _>>()?
         };
 
@@ -764,7 +882,15 @@ mod tests {
             ..MapReduceConfig::default()
         };
         let strip_src = RasterStripSource::new(&src);
-        generate_pyramid_mapreduce(&strip_src, &plan, &mr_sink, &config, &NoopObserver).unwrap();
+        generate_pyramid_mapreduce(
+            &strip_src,
+            &plan,
+            &mr_sink,
+            &config,
+            &NoopObserver,
+            &LocalWorkExecutor,
+        )
+        .unwrap();
         let mut mr_tiles = mr_sink.tiles();
         mr_tiles.sort_by_key(|t| (t.coord.level, t.coord.row, t.coord.col));
 
@@ -798,6 +924,7 @@ mod tests {
             &sink,
             &config,
             &NoopObserver,
+            &LocalWorkExecutor,
         )
         .unwrap_err();
         assert!(
@@ -862,6 +989,7 @@ mod tests {
             &sink,
             &config,
             &NoopObserver,
+            &LocalWorkExecutor,
         )
         .unwrap();
         assert!(
@@ -926,6 +1054,7 @@ mod tests {
                 &sink,
                 &config,
                 &NoopObserver,
+                &LocalWorkExecutor,
             )
             .unwrap();
             let mut tiles = sink.tiles();
@@ -1034,6 +1163,7 @@ mod tests {
                 &sink,
                 &config,
                 &NoopObserver,
+                &LocalWorkExecutor,
             )
             .unwrap();
             // `tiles()` preserves write (arrival) order — capture it before
@@ -1108,6 +1238,7 @@ mod tests {
             &sink,
             &config,
             &NoopObserver,
+            &LocalWorkExecutor,
         )
         .unwrap();
         assert_eq!(result.tiles_produced, plan.total_tile_count());
@@ -1156,6 +1287,7 @@ mod single_level_tests {
             &sink,
             &config,
             &NoopObserver,
+            &LocalWorkExecutor,
         )
         .expect("single-level plan must run to completion without underflow panic");
         sink

--- a/tests/worker_executor_hot_cache.rs
+++ b/tests/worker_executor_hot_cache.rs
@@ -1,0 +1,403 @@
+//! Feature tests for issue #67: the `WorkExecutor` plug-in seam and the
+//! `EngineKind::MapReduceHotCache` engine.
+//!
+//! Written test-first: these tests compile against the intended public
+//! surface (`WorkExecutor`, `StripWorkUnit`, `WorkContext`,
+//! `LocalWorkExecutor`, `EngineBuilder::with_executor`,
+//! `EngineKind::MapReduceHotCache`) and fail until that surface lands.
+//!
+//! Contracts pinned here:
+//!
+//! * `LocalWorkExecutor` (and the implicit default) is byte-identical to the
+//!   pre-seam MapReduce engine.
+//! * A custom executor receives strip work units in canonical order (strictly
+//!   increasing `canvas_y`, covering the whole canvas, all at the top level)
+//!   and its output feeds the unchanged REDUCE phase byte-identically.
+//! * An executor failure propagates as the `EngineError` it returned.
+//! * `MapReduceHotCache` is byte-identical to the Streaming and MapReduce
+//!   engines, flushes the user sink in a single pass at the end (canonical
+//!   `(level, row, col)` write order, `finish` exactly once, after every
+//!   write), and stays deterministic across tile-concurrency settings.
+//! * `MapReduceHotCache` keeps MapReduce's pre-flight `BudgetExceeded`
+//!   rejection.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use libviprs::streaming_mapreduce::{LocalWorkExecutor, StripWorkUnit, WorkContext, WorkExecutor};
+use libviprs::{
+    EngineBuilder, EngineError, EngineKind, Layout, MemorySink, PixelFormat, PyramidPlanner,
+    Raster, SinkError, Tile, TileCoord, TileSink,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Deterministic non-uniform raster (same pattern as the in-crate parity
+/// tests) so byte-level comparisons are meaningful.
+fn gradient_raster(w: u32, h: u32) -> Raster {
+    let bpp = PixelFormat::Rgb8.bytes_per_pixel();
+    let mut data = vec![0u8; w as usize * h as usize * bpp];
+    for y in 0..h {
+        for x in 0..w {
+            let off = (y as usize * w as usize + x as usize) * bpp;
+            data[off] = (x % 256) as u8;
+            data[off + 1] = (y % 256) as u8;
+            data[off + 2] = ((x + y) % 256) as u8;
+        }
+    }
+    Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+}
+
+/// Collect a run's tiles sorted by canonical coordinate for byte comparison.
+fn sorted_tiles(sink: &MemorySink) -> Vec<(TileCoord, Vec<u8>)> {
+    let mut tiles: Vec<(TileCoord, Vec<u8>)> = sink
+        .tiles()
+        .into_iter()
+        .map(|t| (t.coord, t.data))
+        .collect();
+    tiles.sort_by_key(|(c, _)| (c.level, c.row, c.col));
+    tiles
+}
+
+fn run_engine(
+    src: &Raster,
+    plan: &libviprs::PyramidPlan,
+    kind: EngineKind,
+    budget: u64,
+) -> Vec<(TileCoord, Vec<u8>)> {
+    let sink = MemorySink::new();
+    let (_result, sink) = EngineBuilder::new(src, plan.clone(), sink)
+        .with_engine(kind)
+        .with_memory_budget(budget)
+        .run_collect()
+        .expect("engine run should succeed");
+    sorted_tiles(&sink)
+}
+
+// ---------------------------------------------------------------------------
+// WorkExecutor seam
+// ---------------------------------------------------------------------------
+
+/// Explicitly installing `LocalWorkExecutor` must be byte-identical to the
+/// default MapReduce run (no executor installed).
+#[test]
+fn local_executor_byte_identical_to_default_mapreduce() {
+    let src = gradient_raster(1024, 1024);
+    let plan = PyramidPlanner::new(1024, 1024, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    let budget = 6_000_000u64;
+
+    let reference = run_engine(&src, &plan, EngineKind::MapReduce, budget);
+
+    let sink = MemorySink::new();
+    let (_result, sink) = EngineBuilder::new(&src, plan.clone(), sink)
+        .with_engine(EngineKind::MapReduce)
+        .with_memory_budget(budget)
+        .with_executor(Arc::new(LocalWorkExecutor))
+        .run_collect()
+        .expect("run with explicit LocalWorkExecutor should succeed");
+    let via_seam = sorted_tiles(&sink);
+
+    assert_eq!(reference.len(), via_seam.len());
+    for ((rc, rd), (sc, sd)) in reference.iter().zip(via_seam.iter()) {
+        assert_eq!(rc, sc);
+        assert_eq!(rd, sd, "tile bytes diverged at {sc:?}");
+    }
+}
+
+/// A recording executor that delegates to the local implementation.
+struct RecordingExecutor {
+    seen: Mutex<Vec<StripWorkUnit>>,
+}
+
+impl WorkExecutor for RecordingExecutor {
+    fn execute(&self, spec: StripWorkUnit, ctx: WorkContext<'_>) -> Result<Raster, EngineError> {
+        self.seen.lock().unwrap().push(spec);
+        LocalWorkExecutor.execute(spec, ctx)
+    }
+}
+
+/// A custom executor sees every strip work unit, in canonical dispatch order
+/// (sequential MAP path), covering the whole canvas at the top level, and the
+/// pyramid it feeds into REDUCE is byte-identical to the built-in path.
+#[test]
+fn custom_executor_receives_canonical_specs_and_preserves_output() {
+    let src = gradient_raster(1024, 1024);
+    let plan = PyramidPlanner::new(1024, 1024, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    // Budget sized so the canvas spans several strips (same choice as the
+    // in-crate parity test), so the executor is dispatched more than once.
+    let budget = 6_000_000u64;
+    let top_level = (plan.levels.len() - 1) as u32;
+
+    let reference = run_engine(&src, &plan, EngineKind::MapReduce, budget);
+
+    let executor = Arc::new(RecordingExecutor {
+        seen: Mutex::new(Vec::new()),
+    });
+    let sink = MemorySink::new();
+    let (_result, sink) = EngineBuilder::new(&src, plan.clone(), sink)
+        .with_engine(EngineKind::MapReduce)
+        .with_memory_budget(budget)
+        .with_executor(executor.clone())
+        .run_collect()
+        .expect("run with recording executor should succeed");
+
+    let seen = executor.seen.lock().unwrap().clone();
+    assert!(
+        seen.len() >= 2,
+        "test needs multiple strips to exercise dispatch ordering, got {}",
+        seen.len()
+    );
+
+    // Canonical order: strictly increasing canvas_y, top level, gap-free
+    // coverage of the full canvas height.
+    let mut expected_y = 0u32;
+    for spec in &seen {
+        assert_eq!(
+            spec.canvas_y, expected_y,
+            "strip dispatch must be canonical and gap-free"
+        );
+        assert_eq!(
+            spec.level, top_level,
+            "MAP work is dispatched at the top level"
+        );
+        assert!(spec.height > 0);
+        expected_y += spec.height;
+    }
+    assert_eq!(
+        expected_y, plan.canvas_height,
+        "dispatched strips must cover the whole canvas"
+    );
+
+    // And the output is unchanged.
+    let via_seam = sorted_tiles(&sink);
+    assert_eq!(reference.len(), via_seam.len());
+    for ((rc, rd), (sc, sd)) in reference.iter().zip(via_seam.iter()) {
+        assert_eq!(rc, sc);
+        assert_eq!(rd, sd, "tile bytes diverged at {sc:?}");
+    }
+}
+
+/// An executor that always fails.
+struct FailingExecutor;
+
+impl WorkExecutor for FailingExecutor {
+    fn execute(&self, _spec: StripWorkUnit, _ctx: WorkContext<'_>) -> Result<Raster, EngineError> {
+        Err(EngineError::WorkerPanic)
+    }
+}
+
+/// An executor failure must abort the run with the error it returned.
+#[test]
+fn failing_executor_error_propagates() {
+    let src = gradient_raster(512, 512);
+    let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    let err = EngineBuilder::new(&src, plan, MemorySink::new())
+        .with_engine(EngineKind::MapReduce)
+        .with_memory_budget(4_000_000)
+        .with_executor(Arc::new(FailingExecutor))
+        .run()
+        .unwrap_err();
+    assert!(
+        matches!(err, EngineError::WorkerPanic),
+        "expected the executor's WorkerPanic to propagate, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// MapReduceHotCache engine
+// ---------------------------------------------------------------------------
+
+/// The hot-cache engine is byte-identical to Streaming and MapReduce for the
+/// same inputs, and its reported peak accounts for the cached tiles.
+#[test]
+fn hot_cache_byte_parity_with_streaming_and_mapreduce() {
+    let src = gradient_raster(1024, 1024);
+    let plan = PyramidPlanner::new(1024, 1024, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    let budget = 6_000_000u64;
+
+    let streaming = run_engine(&src, &plan, EngineKind::Streaming, budget);
+    let mapreduce = run_engine(&src, &plan, EngineKind::MapReduce, budget);
+
+    let sink = MemorySink::new();
+    let (result, sink) = EngineBuilder::new(&src, plan.clone(), sink)
+        .with_engine(EngineKind::MapReduceHotCache)
+        .with_memory_budget(budget)
+        .run_collect()
+        .expect("hot-cache run should succeed");
+    let hot = sorted_tiles(&sink);
+
+    assert_eq!(result.tiles_produced, plan.total_tile_count());
+    assert_eq!(streaming.len(), hot.len());
+    assert_eq!(mapreduce.len(), hot.len());
+    for (((sc, sd), (mc, md)), (hc, hd)) in streaming.iter().zip(mapreduce.iter()).zip(hot.iter()) {
+        assert_eq!(sc, hc);
+        assert_eq!(mc, hc);
+        assert_eq!(sd, hd, "hot-cache bytes diverged from streaming at {hc:?}");
+        assert_eq!(md, hd, "hot-cache bytes diverged from mapreduce at {hc:?}");
+    }
+
+    // The cached pyramid is held in RAM until the flush; the reported peak
+    // must account for (at least) those tile bytes.
+    let cached_bytes: u64 = hot.iter().map(|(_, d)| d.len() as u64).sum();
+    assert!(
+        result.peak_memory_bytes >= cached_bytes,
+        "peak {} must charge the {} bytes held by the hot cache",
+        result.peak_memory_bytes,
+        cached_bytes
+    );
+}
+
+/// Sink that records the order of every `write_tile` / `finish` call.
+#[derive(Debug, Default)]
+struct CallOrderSink {
+    calls: Mutex<Vec<CallRecord>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CallRecord {
+    Write(TileCoord),
+    Finish,
+}
+
+impl TileSink for CallOrderSink {
+    fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(CallRecord::Write(tile.coord));
+        Ok(())
+    }
+    fn finish(&self) -> Result<(), SinkError> {
+        self.calls.lock().unwrap().push(CallRecord::Finish);
+        Ok(())
+    }
+}
+
+/// The hot-cache engine drains the user sink in one pass at the end: every
+/// write arrives in canonical `(level, row, col)` order, `finish` is called
+/// exactly once and only after the last write, and the write order is
+/// identical across tile-concurrency settings (the determinism plain
+/// MapReduce cannot promise at `tile_concurrency > 0`).
+#[test]
+fn hot_cache_single_pass_canonical_flush_and_cross_concurrency_determinism() {
+    let src = gradient_raster(1024, 1024);
+    let plan = PyramidPlanner::new(1024, 1024, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    let budget = 6_000_000u64;
+
+    let run = |tile_concurrency: usize| {
+        let sink = CallOrderSink::default();
+        let (_result, sink) = EngineBuilder::new(&src, plan.clone(), sink)
+            .with_engine(EngineKind::MapReduceHotCache)
+            .with_memory_budget(budget)
+            .with_concurrency(tile_concurrency)
+            .run_collect()
+            .expect("hot-cache run should succeed");
+        sink.calls.lock().unwrap().clone()
+    };
+
+    let sequential = run(0);
+    let parallel = run(4);
+
+    for calls in [&sequential, &parallel] {
+        // finish exactly once, as the final call.
+        let finishes = calls
+            .iter()
+            .filter(|c| matches!(c, CallRecord::Finish))
+            .count();
+        assert_eq!(finishes, 1, "finish must be called exactly once");
+        assert_eq!(
+            calls.last(),
+            Some(&CallRecord::Finish),
+            "finish must come after every write"
+        );
+
+        // Writes arrive in canonical order.
+        let coords: Vec<TileCoord> = calls
+            .iter()
+            .filter_map(|c| match c {
+                CallRecord::Write(coord) => Some(*coord),
+                CallRecord::Finish => None,
+            })
+            .collect();
+        assert_eq!(coords.len() as u64, plan.total_tile_count());
+        let mut expected = coords.clone();
+        expected.sort_by_key(|c| (c.level, c.row, c.col));
+        assert_eq!(
+            coords, expected,
+            "hot-cache flush must write in canonical (level, row, col) order"
+        );
+    }
+
+    assert_eq!(
+        sequential, parallel,
+        "hot-cache write order must be identical across tile-concurrency settings"
+    );
+}
+
+/// The hot-cache engine keeps MapReduce's pre-flight budget rejection: a
+/// budget below the minimum aligned strip fails up front with
+/// `BudgetExceeded` instead of silently over-committing.
+#[test]
+fn hot_cache_rejects_budget_below_minimum_strip() {
+    let src = gradient_raster(512, 512);
+    let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    let err = EngineBuilder::new(&src, plan, MemorySink::new())
+        .with_engine(EngineKind::MapReduceHotCache)
+        .with_memory_budget(100_000)
+        .run()
+        .unwrap_err();
+    assert!(
+        matches!(err, EngineError::BudgetExceeded { .. }),
+        "expected BudgetExceeded, got {err:?}"
+    );
+}
+
+/// The hot-cache engine honours the executor seam too: the same recording
+/// executor sees the canonical dispatch and output parity holds.
+#[test]
+fn hot_cache_uses_executor_seam() {
+    let src = gradient_raster(1024, 1024);
+    let plan = PyramidPlanner::new(1024, 1024, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    let budget = 6_000_000u64;
+
+    let reference = run_engine(&src, &plan, EngineKind::MapReduce, budget);
+
+    let executor = Arc::new(RecordingExecutor {
+        seen: Mutex::new(Vec::new()),
+    });
+    let sink = MemorySink::new();
+    let (_result, sink) = EngineBuilder::new(&src, plan.clone(), sink)
+        .with_engine(EngineKind::MapReduceHotCache)
+        .with_memory_budget(budget)
+        .with_executor(executor.clone())
+        .run_collect()
+        .expect("hot-cache run with executor should succeed");
+
+    assert!(
+        !executor.seen.lock().unwrap().is_empty(),
+        "hot-cache MAP phase must dispatch through the installed executor"
+    );
+
+    let hot = sorted_tiles(&sink);
+    assert_eq!(reference.len(), hot.len());
+    for ((rc, rd), (hc, hd)) in reference.iter().zip(hot.iter()) {
+        assert_eq!(rc, hc);
+        assert_eq!(rd, hd, "tile bytes diverged at {hc:?}");
+    }
+}


### PR DESCRIPTION
## What

First increment of #67: the library-side worker plug-in seam and the local-only hot-cache engine.

### `WorkExecutor` seam (MAP-phase strip dispatch)

- New in `streaming_mapreduce` (re-exported at the crate root): `WorkExecutor` trait, `StripWorkUnit`, `WorkContext`, and `LocalWorkExecutor`.
- `EngineBuilder::with_executor(Arc<dyn WorkExecutor>)` installs an alternative executor; the default `LocalWorkExecutor` wraps `obtain_canvas_strip()` and is byte-identical to the previous engine.
- The engine dispatches work units in canonical order (strictly increasing `canvas_y`, gap-free, top level) and reassembles results positionally, so the REDUCE phase stays sequential and byte-identity is preserved regardless of the executor. The trait docs spell out the dispatch-order, output-shape, and error contracts.

### `EngineKind::MapReduceHotCache`

- New module `src/mapreduce_hot_cache.rs`. Rendering reuses `generate_pyramid_mapreduce` wholesale against an internal cache that preserves the full `Tile` (including the `blank` flag), so placeholder-writing sinks behave identically to a direct run.
- The caller's sink receives the whole pyramid as one batched flush at the end, in canonical `(level, row, col)` order, followed by a single `finish()`. That makes the write order deterministic even at `tile_concurrency > 0`, which plain MapReduce deliberately does not promise.
- `with_memory_budget` bounds the MAP/REDUCE working set exactly as for MapReduce, including the pre-flight `BudgetExceeded` rejection; the cache residency is charged into `peak_memory_bytes`. `Auto` never selects it: explicit opt-in only.
- Flush-time failures honor the configured `FailurePolicy` and the cancel token, and route through the builder's `RetryingSink` wrapper. `Finished` keeps its comes-last contract: the inner run's event is withheld and re-emitted after the flush.
- Resume/Overwrite and Verify route exactly like MapReduce (Verify uses the shared read-only `verify_from_strip_source` walk). The issue text says Verify is "rejected, matching MapReduce's existing constraint"; MapReduce as shipped supports Verify through the shared helper, so matching it means supporting it, and HotCache does.

## Additivity

No existing engine behavior or default moves: `generate_pyramid_mapreduce` is `pub(crate)` so its new executor parameter is invisible externally, `EngineKind` is `#[non_exhaustive]`, and every new builder knob defaults to the previous behavior. No exported symbol is removed or renamed.

## Tests (RED then GREEN)

`tests/worker_executor_hot_cache.rs` was written first against the intended surface and failed to resolve any of the new symbols; it passes after the change:

- `LocalWorkExecutor` byte-parity with the default MapReduce run.
- Custom executor receives canonical, gap-free, top-level specs and preserves output byte-identically (also under HotCache).
- Executor failure propagates as the `EngineError` it returned.
- HotCache byte-parity with Streaming and MapReduce; `peak_memory_bytes` charges the cached bytes.
- Single-pass canonical flush: `finish` exactly once, after every write; write order identical across `tile_concurrency` 0 and 4.
- `BudgetExceeded` pre-flight parity.

In-crate unit tests additionally pin monolithic-reference parity, Finished-once-and-last observer ordering, and the budget rejection; the builder's `extensions_delivered_across_engine_kinds` test now covers the new kind.

Local mirror green: `make fmt`, `make clippy` (default + pdfium), `make test` (402 lib + all integration suites), `make doc` (deny broken intra-doc links), `make loom`.

## Remaining scope of #67 (deliberately split out)

- Worker attribution + lifecycle on `EngineEvent`: `WorkerId`, `StripDispatched` / `StripExecutorDone` / `MemorySnapshot` / `WorkerJoined` / `WorkerLeft`, and `EngineBuilder::with_observers` multi-observer fan-out.
- `serde` cargo feature: `cfg_attr` derives on the wire-format types plus `src/wire.rs` (`JobDescriptor`, `TileBatch`).

Refs #67
