### PR TITLE
Add worker attribution events and multi-observer fan-out (#67) [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a single `finish()` (issue #67). Byte-identical output to the streaming and
   MapReduce engines; explicit opt-in only, never selected by
   `EngineKind::Auto`.
+- Worker attribution on `EngineEvent` (issue #67): new `WorkerId` newtype and
+  new event variants `StripDispatched`, `StripExecutorDone` (emitted by the
+  MapReduce engines on the coordinating thread, in canonical dispatch order,
+  stamped with the installed executor's self-reported
+  `WorkExecutor::worker_id`, `None` for `LocalWorkExecutor`), plus
+  `WorkerJoined`, `WorkerLeft`, and `MemorySnapshot` as vocabulary for
+  out-of-tree executor layers (never emitted by the in-tree engines).
+  `WorkExecutor::worker_id` has a `None` default, so existing executor
+  implementations are unaffected.
+- `EngineBuilder::with_observers(Vec<Arc<dyn EngineObserver>>)` and the
+  `FanOutObserver` composition behind it (issue #67): every event (and the
+  `on_extensions` hatch) fans out to each registered observer in order.
+  `with_observer` stays as the single-observer shorthand.
 
 ## [0.3.1] — 2026-04-25
 

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -289,6 +289,26 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
         self
     }
 
+    /// Attach several observers at once; every [`EngineEvent`](crate::EngineEvent)
+    /// fans out to each of them, in the order they appear in the vector
+    /// (issue #67).
+    ///
+    /// Composes the observers through a [`FanOutObserver`](crate::FanOutObserver),
+    /// so delivery is synchronous, on the thread that produced the event,
+    /// exactly as with a single observer; the extension hatch
+    /// ([`EngineObserver::on_extensions`](crate::EngineObserver::on_extensions))
+    /// is forwarded to each of them too. Like every observer setter, this
+    /// fills the builder's one observer slot: it replaces anything a prior
+    /// [`with_observer`](Self::with_observer) /
+    /// [`with_observer_arc`](Self::with_observer_arc) / `with_observers`
+    /// call attached, and a later call replaces it in turn.
+    /// [`with_observer`](Self::with_observer) remains the single-observer
+    /// shorthand.
+    pub fn with_observers(mut self, observers: Vec<Arc<dyn EngineObserver>>) -> Self {
+        self.observer = Some(Arc::new(crate::observe::FanOutObserver::new(observers)));
+        self
+    }
+
     /// Select which engine implementation [`EngineBuilder::run`] will
     /// dispatch to. Defaults to [`EngineKind::Auto`].
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,9 @@ pub use manifest::{
     ChecksumAlgo, Checksums, GenerationSettings, LevelMetadata, Manifest, ManifestBuilder,
     ManifestError, ManifestV1, SourceMetadata, SparsePolicy,
 };
-pub use observe::{CollectingObserver, EngineEvent, EngineObserver, MemoryTracker};
+pub use observe::{
+    CollectingObserver, EngineEvent, EngineObserver, FanOutObserver, MemoryTracker, WorkerId,
+};
 #[cfg(feature = "pdfium")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pdfium")))]
 pub use pdf::{BudgetRenderResult, render_page_pdfium, render_page_pdfium_budgeted};

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -3,6 +3,36 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::planner::TileCoord;
 
+/// Opaque identity of the executor (or external worker) that produced an
+/// event (issue #67).
+///
+/// The engine treats the string as opaque: it is never parsed, only carried
+/// on [`EngineEvent`] variants so an observer can attribute work back to the
+/// executor that performed it. An out-of-tree distribution layer picks its
+/// own naming scheme (hostnames, pool slots, UUIDs). The built-in
+/// [`LocalWorkExecutor`](crate::LocalWorkExecutor) reports no identity, so
+/// locally-executed work stays unattributed (`None`) exactly as before.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct WorkerId(pub String);
+
+impl WorkerId {
+    /// Create a `WorkerId` from anything string-shaped.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// The identity as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for WorkerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Events emitted during pyramid generation.
 ///
 /// Each variant represents a distinct lifecycle moment in the tile-pyramid
@@ -115,6 +145,66 @@ pub enum EngineEvent {
     BatchCompleted {
         batch_index: u32,
         tiles_produced: u64,
+    },
+
+    // -- Worker attribution events (issue #67) --
+    /// A MAP-phase strip work unit was handed to the installed
+    /// [`WorkExecutor`](crate::WorkExecutor).
+    ///
+    /// Emitted by the MapReduce engines (including
+    /// [`EngineKind::MapReduceHotCache`](crate::EngineKind::MapReduceHotCache))
+    /// on the coordinating thread, in canonical dispatch order (strictly
+    /// increasing `spec.canvas_y`). `worker_id` is the executor's
+    /// self-reported identity from
+    /// [`WorkExecutor::worker_id`](crate::WorkExecutor::worker_id); the
+    /// built-in [`LocalWorkExecutor`](crate::LocalWorkExecutor) reports
+    /// `None`, preserving the unattributed default.
+    StripDispatched {
+        worker_id: Option<WorkerId>,
+        spec: crate::streaming_mapreduce::StripWorkUnit,
+    },
+
+    /// A MAP-phase strip work unit finished executing.
+    ///
+    /// Emitted by the MapReduce engines on the coordinating thread after the
+    /// batch's results are reassembled, in the same canonical order as
+    /// [`StripDispatched`](Self::StripDispatched), so the event stream stays
+    /// deterministic even when strips render concurrently. `duration` is the
+    /// wall-clock time [`WorkExecutor::execute`](crate::WorkExecutor::execute)
+    /// took for this unit.
+    StripExecutorDone {
+        worker_id: Option<WorkerId>,
+        spec: crate::streaming_mapreduce::StripWorkUnit,
+        duration: std::time::Duration,
+    },
+
+    /// An external worker became available to an out-of-tree executor layer.
+    ///
+    /// The in-tree engines never emit this: it is vocabulary for a
+    /// distribution layer built on the [`WorkExecutor`](crate::WorkExecutor)
+    /// seam, so its observers can share one event stream (and one
+    /// [`EngineObserver`] implementation) with the engine's own events.
+    WorkerJoined { worker_id: WorkerId },
+
+    /// An external worker left an out-of-tree executor layer.
+    ///
+    /// Like [`WorkerJoined`](Self::WorkerJoined), this is emitted only by
+    /// out-of-tree distribution layers, never by the in-tree engines.
+    /// `reason` is a free-form, human-readable explanation (for example
+    /// "drained" or "heartbeat timeout").
+    WorkerLeft { worker_id: WorkerId, reason: String },
+
+    /// A point-in-time memory reading attributed to a worker.
+    ///
+    /// Emitted only by out-of-tree executor layers that want to surface
+    /// per-worker memory pressure through the shared event stream;
+    /// `worker_id` is `None` when the reading describes the process as a
+    /// whole. The in-tree engines report memory through
+    /// [`EngineResult`](crate::EngineResult) instead and never emit this.
+    MemorySnapshot {
+        worker_id: Option<WorkerId>,
+        current_bytes: u64,
+        peak_bytes: u64,
     },
 
     // -- Durability events --
@@ -248,6 +338,73 @@ impl Default for CollectingObserver {
 impl EngineObserver for CollectingObserver {
     fn on_event(&self, event: EngineEvent) {
         crate::poison::recover(&self.events).push(event);
+    }
+}
+
+/// An observer that fans every event out to a list of observers, in order.
+///
+/// This is the multi-observer composition behind
+/// [`EngineBuilder::with_observers`](crate::EngineBuilder::with_observers)
+/// (issue #67): each [`EngineEvent`] is delivered to every registered
+/// observer in registration order, synchronously, on the thread that
+/// produced the event. [`on_extensions`](EngineObserver::on_extensions) is
+/// forwarded the same way, so every registered observer can read the
+/// extension hatch.
+///
+/// The type is public so callers composing observers by hand (outside the
+/// builder) can reuse it instead of writing their own fan-out.
+pub struct FanOutObserver {
+    observers: Vec<Arc<dyn EngineObserver>>,
+}
+
+impl FanOutObserver {
+    /// Create a fan-out over the given observers. Events are delivered in
+    /// the order the observers appear in the vector.
+    pub fn new(observers: Vec<Arc<dyn EngineObserver>>) -> Self {
+        Self { observers }
+    }
+
+    /// Append another observer; it receives events after all previously
+    /// registered ones.
+    pub fn push(&mut self, observer: Arc<dyn EngineObserver>) {
+        self.observers.push(observer);
+    }
+
+    /// Number of registered observers.
+    pub fn len(&self) -> usize {
+        self.observers.len()
+    }
+
+    /// Whether no observers are registered (events are then discarded).
+    pub fn is_empty(&self) -> bool {
+        self.observers.is_empty()
+    }
+}
+
+impl std::fmt::Debug for FanOutObserver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FanOutObserver")
+            .field("observers", &self.observers.len())
+            .finish()
+    }
+}
+
+impl EngineObserver for FanOutObserver {
+    fn on_event(&self, event: EngineEvent) {
+        // Clone for all but the last delivery; the final observer takes the
+        // original by value.
+        if let Some((last, rest)) = self.observers.split_last() {
+            for obs in rest {
+                obs.on_event(event.clone());
+            }
+            last.on_event(event);
+        }
+    }
+
+    fn on_extensions(&self, extensions: &crate::extensions::Extensions) {
+        for obs in &self.observers {
+            obs.on_extensions(extensions);
+        }
     }
 }
 

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -186,6 +186,19 @@ impl std::fmt::Debug for WorkContext<'_> {
 pub trait WorkExecutor: Send + Sync {
     /// Render one canvas-space strip.
     fn execute(&self, spec: StripWorkUnit, ctx: WorkContext<'_>) -> Result<Raster, EngineError>;
+
+    /// Self-reported identity carried on the attribution events the engine
+    /// emits for this executor's work (issue #67).
+    ///
+    /// The engine stamps this value onto [`EngineEvent::StripDispatched`]
+    /// and [`EngineEvent::StripExecutorDone`]
+    /// so an observer can attribute strip work back to the executor that
+    /// performed it. The default is `None` (unattributed), which is what
+    /// [`LocalWorkExecutor`] reports; an out-of-tree distribution layer
+    /// overrides this with its own identity scheme.
+    fn worker_id(&self) -> Option<crate::observe::WorkerId> {
+        None
+    }
 }
 
 /// Default [`WorkExecutor`]: renders the strip in-process.
@@ -582,24 +595,49 @@ pub(crate) fn generate_pyramid_mapreduce(
             plan,
             config: &engine_cfg,
         };
-        let rendered_strips = if config.tile_concurrency > 0
+
+        // Attribution (issue #67): announce every work unit on the
+        // coordinating thread, in canonical dispatch order, before any of the
+        // batch executes. The matching `StripExecutorDone` events are emitted
+        // below, also on the coordinating thread and also in canonical order
+        // (results are reassembled positionally first), so the event stream
+        // is deterministic regardless of executor concurrency; only the
+        // measured `duration` values vary run to run.
+        let exec_worker_id = executor.worker_id();
+        for &(y, sh) in batch_specs {
+            observer.on_event(EngineEvent::StripDispatched {
+                worker_id: exec_worker_id.clone(),
+                spec: StripWorkUnit {
+                    canvas_y: y,
+                    height: sh,
+                    level: top_level as u32,
+                },
+            });
+        }
+
+        let timed_strips: Vec<(Raster, std::time::Duration)> = if config.tile_concurrency > 0
             && batch_specs.len() > 1
             && source.permits_concurrent_strips()
         {
-            let mut strips: Vec<Option<Raster>> = vec![None; batch_specs.len()];
+            let mut strips: Vec<Option<(Raster, std::time::Duration)>> =
+                vec![None; batch_specs.len()];
             std::thread::scope(|s| -> Result<(), EngineError> {
                 let mut handles = Vec::with_capacity(batch_specs.len());
                 for &(y, sh) in batch_specs {
-                    handles.push(s.spawn(move || -> Result<Raster, EngineError> {
-                        executor.execute(
-                            StripWorkUnit {
-                                canvas_y: y,
-                                height: sh,
-                                level: top_level as u32,
-                            },
-                            work_context,
-                        )
-                    }));
+                    handles.push(s.spawn(
+                        move || -> Result<(Raster, std::time::Duration), EngineError> {
+                            let started = std::time::Instant::now();
+                            let strip = executor.execute(
+                                StripWorkUnit {
+                                    canvas_y: y,
+                                    height: sh,
+                                    level: top_level as u32,
+                                },
+                                work_context,
+                            )?;
+                            Ok((strip, started.elapsed()))
+                        },
+                    ));
                 }
                 for (i, handle) in handles.into_iter().enumerate() {
                     let strip = handle.join().map_err(|_| EngineError::WorkerPanic)??;
@@ -612,17 +650,39 @@ pub(crate) fn generate_pyramid_mapreduce(
             batch_specs
                 .iter()
                 .map(|&(y, sh)| {
-                    executor.execute(
+                    let started = std::time::Instant::now();
+                    let strip = executor.execute(
                         StripWorkUnit {
                             canvas_y: y,
                             height: sh,
                             level: top_level as u32,
                         },
                         work_context,
-                    )
+                    )?;
+                    Ok((strip, started.elapsed()))
                 })
-                .collect::<Result<Vec<_>, _>>()?
+                .collect::<Result<Vec<_>, EngineError>>()?
         };
+
+        // Emit completion attribution in canonical order, then strip the
+        // timing wrapper so the REDUCE phase below is unchanged.
+        let rendered_strips: Vec<Raster> = timed_strips
+            .into_iter()
+            .enumerate()
+            .map(|(i, (strip, duration))| {
+                let (y, sh) = batch_specs[i];
+                observer.on_event(EngineEvent::StripExecutorDone {
+                    worker_id: exec_worker_id.clone(),
+                    spec: StripWorkUnit {
+                        canvas_y: y,
+                        height: sh,
+                        level: top_level as u32,
+                    },
+                    duration,
+                });
+                strip
+            })
+            .collect();
 
         // All strips in this batch are now materialised simultaneously (the
         // Map phase renders them concurrently, or sequentially into one Vec).

--- a/tests/worker_executor_hot_cache.rs
+++ b/tests/worker_executor_hot_cache.rs
@@ -20,14 +20,24 @@
 //!   write), and stays deterministic across tile-concurrency settings.
 //! * `MapReduceHotCache` keeps MapReduce's pre-flight `BudgetExceeded`
 //!   rejection.
+//! * (Part 2) The MapReduce engines emit `StripDispatched` /
+//!   `StripExecutorDone` attribution events in canonical order,
+//!   unattributed for the local executor and stamped with
+//!   `WorkExecutor::worker_id` for a custom one, deterministically across
+//!   tile-concurrency settings.
+//! * (Part 2) `EngineBuilder::with_observers` / `FanOutObserver` deliver the
+//!   identical event stream to every registered observer, and the worker
+//!   lifecycle vocabulary (`WorkerJoined` / `WorkerLeft` / `MemorySnapshot`)
+//!   flows through it while the in-tree engines never emit it themselves.
 
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use libviprs::streaming_mapreduce::{LocalWorkExecutor, StripWorkUnit, WorkContext, WorkExecutor};
 use libviprs::{
-    EngineBuilder, EngineError, EngineKind, Layout, MemorySink, PixelFormat, PyramidPlanner,
-    Raster, SinkError, Tile, TileCoord, TileSink,
+    CollectingObserver, EngineBuilder, EngineError, EngineEvent, EngineKind, EngineObserver,
+    FanOutObserver, Layout, MemorySink, PixelFormat, PyramidPlanner, Raster, SinkError, Tile,
+    TileCoord, TileSink, WorkerId,
 };
 
 // ---------------------------------------------------------------------------
@@ -399,5 +409,300 @@ fn hot_cache_uses_executor_seam() {
     for ((rc, rd), (hc, hd)) in reference.iter().zip(hot.iter()) {
         assert_eq!(rc, hc);
         assert_eq!(rd, hd, "tile bytes diverged at {hc:?}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worker attribution events + multi-observer fan-out (issue #67, part 2)
+// ---------------------------------------------------------------------------
+
+/// Pull the `StripDispatched` / `StripExecutorDone` specs out of an event
+/// stream, preserving emission order.
+fn attribution_specs(events: &[EngineEvent]) -> (Vec<StripWorkUnit>, Vec<StripWorkUnit>) {
+    let mut dispatched = Vec::new();
+    let mut done = Vec::new();
+    for e in events {
+        match e {
+            EngineEvent::StripDispatched { spec, .. } => dispatched.push(*spec),
+            EngineEvent::StripExecutorDone { spec, .. } => done.push(*spec),
+            _ => {}
+        }
+    }
+    (dispatched, done)
+}
+
+/// Both MapReduce engines emit `StripDispatched` / `StripExecutorDone` in
+/// canonical, gap-free order covering the whole canvas; the built-in local
+/// executor leaves them unattributed (`worker_id == None`); every dispatch
+/// precedes its matching completion; and all of it precedes `Finished`.
+#[test]
+fn strip_attribution_events_are_canonical_and_unattributed_by_default() {
+    let src = gradient_raster(1024, 1024);
+    let plan = PyramidPlanner::new(1024, 1024, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    let budget = 6_000_000u64;
+    let top_level = (plan.levels.len() - 1) as u32;
+
+    for kind in [EngineKind::MapReduce, EngineKind::MapReduceHotCache] {
+        let observer = Arc::new(CollectingObserver::new());
+        EngineBuilder::new(&src, plan.clone(), MemorySink::new())
+            .with_engine(kind)
+            .with_memory_budget(budget)
+            .with_observer_arc(observer.clone())
+            .run_collect()
+            .expect("run should succeed");
+        let events = observer.events();
+
+        // The local executor reports no identity, so attribution stays None.
+        for e in &events {
+            match e {
+                EngineEvent::StripDispatched { worker_id, .. }
+                | EngineEvent::StripExecutorDone { worker_id, .. } => {
+                    assert!(
+                        worker_id.is_none(),
+                        "local executor work must stay unattributed ({kind:?})"
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        let (dispatched, done) = attribution_specs(&events);
+        assert!(
+            dispatched.len() >= 2,
+            "test needs multiple strips, got {} ({kind:?})",
+            dispatched.len()
+        );
+        assert_eq!(
+            dispatched, done,
+            "every dispatched unit completes, in the same canonical order ({kind:?})"
+        );
+
+        // Canonical, gap-free coverage of the canvas at the top level.
+        let mut expected_y = 0u32;
+        for spec in &dispatched {
+            assert_eq!(spec.canvas_y, expected_y, "canonical dispatch ({kind:?})");
+            assert_eq!(spec.level, top_level);
+            assert!(spec.height > 0);
+            expected_y += spec.height;
+        }
+        assert_eq!(expected_y, plan.canvas_height);
+
+        // Ordering: dispatch precedes completion for each unit, and Finished
+        // comes after all attribution events.
+        for spec in &dispatched {
+            let d_idx = events
+                .iter()
+                .position(
+                    |e| matches!(e, EngineEvent::StripDispatched { spec: s, .. } if s == spec),
+                )
+                .unwrap();
+            let f_idx = events
+                .iter()
+                .position(
+                    |e| matches!(e, EngineEvent::StripExecutorDone { spec: s, .. } if s == spec),
+                )
+                .unwrap();
+            assert!(d_idx < f_idx, "dispatch must precede completion ({kind:?})");
+        }
+        let finished_idx = events
+            .iter()
+            .position(|e| matches!(e, EngineEvent::Finished { .. }))
+            .expect("Finished must be emitted");
+        for (i, e) in events.iter().enumerate() {
+            if matches!(
+                e,
+                EngineEvent::StripDispatched { .. } | EngineEvent::StripExecutorDone { .. }
+            ) {
+                assert!(i < finished_idx, "attribution precedes Finished ({kind:?})");
+            }
+        }
+    }
+}
+
+/// An executor that reports an identity; work delegates to the local renderer.
+struct IdentifiedExecutor;
+
+impl WorkExecutor for IdentifiedExecutor {
+    fn execute(&self, spec: StripWorkUnit, ctx: WorkContext<'_>) -> Result<Raster, EngineError> {
+        LocalWorkExecutor.execute(spec, ctx)
+    }
+    fn worker_id(&self) -> Option<WorkerId> {
+        Some(WorkerId::new("pool-slot-7"))
+    }
+}
+
+/// The engine stamps the executor's self-reported `WorkerId` onto every
+/// attribution event.
+#[test]
+fn custom_executor_identity_stamps_attribution_events() {
+    let src = gradient_raster(1024, 1024);
+    let plan = PyramidPlanner::new(1024, 1024, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+
+    let observer = Arc::new(CollectingObserver::new());
+    EngineBuilder::new(&src, plan, MemorySink::new())
+        .with_engine(EngineKind::MapReduce)
+        .with_memory_budget(6_000_000)
+        .with_executor(Arc::new(IdentifiedExecutor))
+        .with_observer_arc(observer.clone())
+        .run_collect()
+        .expect("run should succeed");
+
+    let mut attributed = 0usize;
+    for e in observer.events() {
+        match e {
+            EngineEvent::StripDispatched { worker_id, .. }
+            | EngineEvent::StripExecutorDone { worker_id, .. } => {
+                assert_eq!(
+                    worker_id.as_ref().map(WorkerId::as_str),
+                    Some("pool-slot-7"),
+                    "attribution events must carry the executor's identity"
+                );
+                attributed += 1;
+            }
+            _ => {}
+        }
+    }
+    assert!(
+        attributed >= 4,
+        "expected attributed dispatch + done events"
+    );
+}
+
+/// The attribution event stream (which units, in which order) is identical
+/// across tile-concurrency settings; only measured durations may differ.
+#[test]
+fn attribution_specs_identical_across_tile_concurrency() {
+    let src = gradient_raster(1024, 1024);
+    let plan = PyramidPlanner::new(1024, 1024, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+
+    let run = |tile_concurrency: usize| {
+        let observer = Arc::new(CollectingObserver::new());
+        EngineBuilder::new(&src, plan.clone(), MemorySink::new())
+            .with_engine(EngineKind::MapReduce)
+            .with_memory_budget(6_000_000)
+            .with_concurrency(tile_concurrency)
+            .with_observer_arc(observer.clone())
+            .run_collect()
+            .expect("run should succeed");
+        attribution_specs(&observer.events())
+    };
+
+    let (d0, f0) = run(0);
+    let (d4, f4) = run(4);
+    assert!(!d0.is_empty());
+    assert_eq!(d0, f0);
+    assert_eq!(d0, d4, "dispatch order must not depend on concurrency");
+    assert_eq!(f0, f4, "completion order must not depend on concurrency");
+}
+
+/// `with_observers` fans every event out to each observer, identically and
+/// in order.
+#[test]
+fn with_observers_fans_out_identical_event_streams() {
+    let src = gradient_raster(1024, 1024);
+    let plan = PyramidPlanner::new(1024, 1024, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+
+    let a = Arc::new(CollectingObserver::new());
+    let b = Arc::new(CollectingObserver::new());
+    EngineBuilder::new(&src, plan, MemorySink::new())
+        .with_engine(EngineKind::MapReduce)
+        .with_memory_budget(6_000_000)
+        .with_observers(vec![
+            a.clone() as Arc<dyn EngineObserver>,
+            b.clone() as Arc<dyn EngineObserver>,
+        ])
+        .run_collect()
+        .expect("run should succeed");
+
+    let ea = a.events();
+    let eb = b.events();
+    assert!(!ea.is_empty(), "fan-out observers must receive events");
+    assert_eq!(ea, eb, "every observer sees the identical stream");
+    assert!(
+        ea.iter()
+            .any(|e| matches!(e, EngineEvent::StripDispatched { .. })),
+        "engine events flow through the fan-out"
+    );
+    assert!(matches!(ea.last(), Some(EngineEvent::Finished { .. })));
+}
+
+/// The worker lifecycle vocabulary (`WorkerJoined` / `WorkerLeft` /
+/// `MemorySnapshot`) is emitted by out-of-tree layers, not the engines: it
+/// must flow through `FanOutObserver` so a distribution layer can share one
+/// event stream with the engine's own events. The in-tree engines must not
+/// emit it.
+#[test]
+fn worker_lifecycle_vocabulary_flows_through_fan_out_and_engines_stay_silent() {
+    // External emission through the fan-out.
+    let a = Arc::new(CollectingObserver::new());
+    let b = Arc::new(CollectingObserver::new());
+    let fan = FanOutObserver::new(vec![
+        a.clone() as Arc<dyn EngineObserver>,
+        b.clone() as Arc<dyn EngineObserver>,
+    ]);
+    assert_eq!(fan.len(), 2);
+    assert!(!fan.is_empty());
+
+    let id = WorkerId::new("agent-1");
+    assert_eq!(id.to_string(), "agent-1");
+    fan.on_event(EngineEvent::WorkerJoined {
+        worker_id: id.clone(),
+    });
+    fan.on_event(EngineEvent::MemorySnapshot {
+        worker_id: Some(id.clone()),
+        current_bytes: 10,
+        peak_bytes: 20,
+    });
+    fan.on_event(EngineEvent::WorkerLeft {
+        worker_id: id.clone(),
+        reason: "drained".to_string(),
+    });
+
+    let ea = a.events();
+    assert_eq!(ea, b.events());
+    assert_eq!(ea.len(), 3);
+    assert!(matches!(&ea[0], EngineEvent::WorkerJoined { worker_id } if worker_id == &id));
+    assert!(matches!(
+        &ea[1],
+        EngineEvent::MemorySnapshot {
+            worker_id: Some(w),
+            current_bytes: 10,
+            peak_bytes: 20,
+        } if w == &id
+    ));
+    assert!(
+        matches!(&ea[2], EngineEvent::WorkerLeft { worker_id, reason } if worker_id == &id && reason == "drained")
+    );
+
+    // The in-tree engines never emit the lifecycle vocabulary.
+    let src = gradient_raster(512, 512);
+    let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan();
+    for kind in [EngineKind::MapReduce, EngineKind::MapReduceHotCache] {
+        let observer = Arc::new(CollectingObserver::new());
+        EngineBuilder::new(&src, plan.clone(), MemorySink::new())
+            .with_engine(kind)
+            .with_memory_budget(4_000_000)
+            .with_observer_arc(observer.clone())
+            .run_collect()
+            .expect("run should succeed");
+        assert!(
+            !observer.events().iter().any(|e| matches!(
+                e,
+                EngineEvent::WorkerJoined { .. }
+                    | EngineEvent::WorkerLeft { .. }
+                    | EngineEvent::MemorySnapshot { .. }
+            )),
+            "in-tree engines must not emit worker lifecycle events ({kind:?})"
+        );
     }
 }


### PR DESCRIPTION
## What

Second increment of #67, on top of the `WorkExecutor` seam and `EngineKind::MapReduceHotCache` that landed in #245. All src-only and additive:

- `WorkerId` newtype (opaque executor identity), re-exported at the crate root.
- `WorkExecutor::worker_id()` with a `None` default, so every existing executor implementation compiles and behaves exactly as before.
- New `EngineEvent` variants (the enum is `non_exhaustive`, so these are additive): `StripDispatched`, `StripExecutorDone`, `WorkerJoined`, `WorkerLeft`, `MemorySnapshot`.
- The MapReduce engines (including `MapReduceHotCache`) emit `StripDispatched` / `StripExecutorDone` on the coordinating thread, in canonical dispatch order on both the sequential and the parallel MAP path, stamped with the executor's identity (`None` for `LocalWorkExecutor`). The event stream is therefore deterministic across tile-concurrency settings; only measured durations vary. `WorkerJoined` / `WorkerLeft` / `MemorySnapshot` are vocabulary for out-of-tree executor layers; the in-tree engines never emit them (pinned in tests).
- `EngineBuilder::with_observers(Vec<Arc<dyn EngineObserver>>)` plus a public `FanOutObserver` that forwards every event (and `on_extensions`) to each registered observer in order. `with_observer` stays as the single-observer shorthand.

## Determinism and back-compat

- Rendering is untouched; the MAP path only gained a timing wrapper that is stripped before REDUCE. Byte-identity with Streaming / MapReduce is still pinned by the existing parity tests.
- No field moves on any existing `EngineEvent` variant, so downstream pattern matches keep compiling.
- No engine default changes; `Auto` still never selects `MapReduceHotCache`.

## Tests

New pins in `tests/worker_executor_hot_cache.rs`: canonical, unattributed attribution for both MapReduce kinds; identity stamping from a custom executor; cross-concurrency dispatch and completion determinism; identical fan-out streams to every observer; lifecycle vocabulary pass-through via `FanOutObserver`; and engine silence on the lifecycle variants.

Local mirror green: `make fmt`, `make clippy` (with and without pdfium), `make test` (12/12 targets), `make doc`.

## Remaining scope on #67 (stays open)

- `serde` cargo feature (`cfg_attr` derives + `src/wire.rs` with `JobDescriptor` / `TileBatch`): needs `Cargo.toml` changes (feature + optional dependency), which are owned separately right now.
- Optional `worker_id` / `timestamp` fields on the pre-existing engine-emitted variants: adding fields to existing variants breaks downstream field patterns on an API that just shipped, so it needs a deliberate breaking-change window rather than this additive PR.

Refs #67