### PR TITLE
feat(serde): add serde cargo feature gating wire-type derives (#67) [skip ci]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,15 @@ pdfium-static = ["pdfium", "pdfium-render/static"]
 s3 = []
 tracing = ["dep:tracing"]
 packfile = ["dep:tar", "dep:zip"]
+# Gates public `Serialize` / `Deserialize` derives on the wire/config types
+# (`PyramidPlan`, `LevelPlan`, `TileCoord`, `TileRect`, `Layout`,
+# `EngineConfig`, `BlankTileStrategy`, `FailurePolicy`, `RetryPolicy`,
+# `DedupeStrategy`, `WorkerId`) so out-of-process callers can reconstruct a
+# job from a JSON envelope (issue #67). The serde crate itself is already a
+# required dependency (resume checkpoints and packfile manifests use it
+# internally), so this feature adds no dependencies; it only widens the
+# public API surface, keeping the default build's API unchanged.
+serde = []
 
 [dependencies]
 blake3 = { workspace = true }

--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -57,6 +57,7 @@ use crate::manifest::ChecksumAlgo;
 ///
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-dedupe-blanks)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum DedupeStrategy {
     /// No deduplication — every tile is written to its own file. Default.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -123,6 +123,7 @@ pub enum EngineError {
 /// for integration-level examples. In the CLI, the `--skip-blank` flag selects
 /// [`BlankTileStrategy::Placeholder`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum BlankTileStrategy {
     /// Emit blank tiles as full raster data (default). Every tile coordinate
@@ -158,7 +159,13 @@ pub enum BlankTileStrategy {
 ///
 /// **See also:** the [interactive CLI generator](https://libviprs.org/cli/#cli-generator)
 /// composes a runnable program from these same knobs.
+/// With the `serde` feature enabled the config derives `Serialize` /
+/// `Deserialize` so an out-of-process caller can reconstruct it from a JSON
+/// envelope (issue #67). The [`cancel`](Self::cancel) token is a
+/// process-local runtime handle, not wire state, so it is `#[serde(skip)]`:
+/// it serializes as absent and always deserializes to `None`.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub struct EngineConfig {
     /// Number of worker threads for tile extraction. 0 = single-threaded (current thread).
@@ -205,6 +212,11 @@ pub struct EngineConfig {
     /// short slices so it can be interrupted) and stops with
     /// [`EngineError::Cancelled`] once the token is cancelled. `None` (the
     /// default) is a run that cannot be cancelled.
+    ///
+    /// Skipped by the `serde` derives: a cancellation flag is shared process
+    /// memory (an `Arc<AtomicBool>`), so there is nothing meaningful to put
+    /// on the wire. Deserialized configs always start with `None`.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub cancel: Option<crate::cancel::CancelToken>,
 }
 

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -13,6 +13,7 @@ use crate::planner::TileCoord;
 /// [`LocalWorkExecutor`](crate::LocalWorkExecutor) reports no identity, so
 /// locally-executed work stays unattributed (`None`) exactly as before.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WorkerId(pub String);
 
 impl WorkerId {

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -42,6 +42,7 @@ pub enum PlannerError {
 ///
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-layout)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Layout {
     /// Deep Zoom Image -- `{level}/{col}_{row}.{ext}`, plus `.dzi` manifest.
@@ -101,7 +102,15 @@ pub struct PyramidPlanner {
 /// fabricate a plan with invariant-violating fields (for example an empty
 /// `levels` list or dimensions that do not describe any real source). Read
 /// access to the fields is unaffected. See issue #132.
+///
+/// With the `serde` feature enabled the plan also derives `Serialize` /
+/// `Deserialize`, so an out-of-process caller can reconstruct the exact plan
+/// from a JSON envelope (issue #67). Deserialization is the one sanctioned
+/// path around the `#[non_exhaustive]` construction fence: it exists
+/// precisely so a wire envelope can carry a plan produced by
+/// [`PyramidPlanner::plan`] on the other side of the boundary.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub struct PyramidPlan {
     pub image_width: u32,
@@ -134,6 +143,7 @@ pub struct PyramidPlan {
 ///
 /// * [pdf_to_pyramid tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pdf_to_pyramid.rs)
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LevelPlan {
     /// Level index (0 = smallest / most zoomed out).
     pub level: u32,
@@ -158,6 +168,7 @@ pub struct LevelPlan {
 ///
 /// * [pyramid_fs_sink tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pyramid_fs_sink.rs)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TileCoord {
     pub level: u32,
     pub col: u32,
@@ -176,6 +187,7 @@ pub struct TileCoord {
 ///
 /// * [pyramid_fs_sink tests](https://github.com/libviprs/libviprs-tests/blob/main/tests/pyramid_fs_sink.rs)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TileRect {
     pub x: u32,
     pub y: u32,

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -109,6 +109,7 @@ fn sample_jitter(max_nanos: u64, jitter_tick: &AtomicU64, sink_nonce: u64) -> u6
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-retry-max)
 /// (and [`--retry-backoff`](https://libviprs.org/cli/#flag-retry-backoff) for the backoff arg)
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub struct RetryPolicy {
     pub max_retries: u32,
@@ -200,6 +201,7 @@ impl RetryPolicy {
 ///
 /// **See also:** [interactive example](https://libviprs.org/cli/#flag-failure-policy)
 #[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum FailurePolicy {
     /// Propagate the first error; no retries.

--- a/tests/serde_wire.rs
+++ b/tests/serde_wire.rs
@@ -1,0 +1,152 @@
+//! Round-trip tests for the `serde` cargo feature (issue #67).
+//!
+//! The feature gates `Serialize` / `Deserialize` derives on the wire/config
+//! types so an out-of-process caller (an external worker layer plugged in via
+//! `WorkExecutor`) can reconstruct a `PyramidPlan` / `EngineConfig` from a
+//! JSON envelope. These tests pin two properties:
+//!
+//! * value round-trip: serialize → deserialize reproduces the original value
+//!   for every gated type, including a real multi-level plan produced by
+//!   `PyramidPlanner::plan` (not a hand-built toy);
+//! * runtime-handle hygiene: `EngineConfig::cancel` is process-local state
+//!   and must be skipped, never serialized, and always `None` after
+//!   deserialization.
+
+#![cfg(feature = "serde")]
+
+use libviprs::{
+    BlankTileStrategy, CancelToken, DedupeStrategy, EngineConfig, FailurePolicy, Layout,
+    PyramidPlan, PyramidPlanner, RetryPolicy, TileCoord, TileRect, WorkerId,
+};
+use std::time::Duration;
+
+/// A realistic plan: non-square image, overlap, centring, multiple levels.
+fn sample_plan() -> PyramidPlan {
+    PyramidPlanner::new(4097, 2731, 254, 1, Layout::DeepZoom)
+        .expect("valid planner parameters")
+        .with_centre(true)
+        .plan()
+}
+
+#[test]
+fn pyramid_plan_round_trips_through_json() {
+    let plan = sample_plan();
+    assert!(plan.levels.len() > 1, "sample plan should be multi-level");
+
+    let json = serde_json::to_string(&plan).expect("serialize PyramidPlan");
+    let back: PyramidPlan = serde_json::from_str(&json).expect("deserialize PyramidPlan");
+
+    assert_eq!(back, plan);
+}
+
+#[test]
+fn plan_leaf_types_round_trip_through_json() {
+    let coord = TileCoord {
+        level: 7,
+        col: 3,
+        row: 11,
+    };
+    let json = serde_json::to_string(&coord).expect("serialize TileCoord");
+    let back: TileCoord = serde_json::from_str(&json).expect("deserialize TileCoord");
+    assert_eq!(back, coord);
+
+    let rect = TileRect {
+        x: 253,
+        y: 507,
+        width: 256,
+        height: 129,
+    };
+    let json = serde_json::to_string(&rect).expect("serialize TileRect");
+    let back: TileRect = serde_json::from_str(&json).expect("deserialize TileRect");
+    assert_eq!(back, rect);
+
+    for layout in [Layout::DeepZoom, Layout::Xyz, Layout::Google] {
+        let json = serde_json::to_string(&layout).expect("serialize Layout");
+        let back: Layout = serde_json::from_str(&json).expect("deserialize Layout");
+        assert_eq!(back, layout);
+    }
+}
+
+#[test]
+fn engine_config_round_trips_through_json() {
+    let mut config = EngineConfig::default()
+        .with_concurrency(4)
+        .with_buffer_size(128)
+        .with_blank_tile_strategy(BlankTileStrategy::PlaceholderWithTolerance {
+            max_channel_delta: 3,
+        })
+        .with_checkpoint_every(50)
+        .with_dedupe_strategy(DedupeStrategy::Blanks)
+        .with_source_content_hash("blake3:00ff");
+    config.background_rgb = [0, 128, 255];
+
+    let json = serde_json::to_string(&config).expect("serialize EngineConfig");
+    let back: EngineConfig = serde_json::from_str(&json).expect("deserialize EngineConfig");
+
+    assert_eq!(back.concurrency, config.concurrency);
+    assert_eq!(back.buffer_size, config.buffer_size);
+    assert_eq!(back.background_rgb, config.background_rgb);
+    assert_eq!(back.blank_tile_strategy, config.blank_tile_strategy);
+    assert_eq!(back.failure_policy, config.failure_policy);
+    assert_eq!(back.checkpoint_every, config.checkpoint_every);
+    assert_eq!(back.dedupe_strategy, config.dedupe_strategy);
+    assert_eq!(back.checkpoint_root, config.checkpoint_root);
+    assert_eq!(back.source_content_hash, config.source_content_hash);
+    assert!(back.cancel.is_none());
+}
+
+#[test]
+fn engine_config_cancel_token_is_never_serialized() {
+    let mut config = EngineConfig::default();
+    config.cancel = Some(CancelToken::new());
+
+    let json = serde_json::to_string(&config).expect("serialize EngineConfig");
+    assert!(
+        !json.contains("cancel"),
+        "cancel token is a process-local handle and must stay off the wire: {json}"
+    );
+
+    let back: EngineConfig = serde_json::from_str(&json).expect("deserialize EngineConfig");
+    assert!(back.cancel.is_none(), "deserialized cancel must be None");
+}
+
+#[test]
+fn failure_and_retry_policies_round_trip_through_json() {
+    let retry = RetryPolicy::new(5, Duration::from_millis(75))
+        .with_multiplier(1.5)
+        .with_max_backoff(Duration::from_secs(2))
+        .with_jitter(false);
+    let json = serde_json::to_string(&retry).expect("serialize RetryPolicy");
+    let back: RetryPolicy = serde_json::from_str(&json).expect("deserialize RetryPolicy");
+    assert_eq!(back, retry);
+
+    for policy in [
+        FailurePolicy::FailFast,
+        FailurePolicy::RetryThenFail(retry.clone()),
+        FailurePolicy::RetryThenSkip(retry),
+    ] {
+        let json = serde_json::to_string(&policy).expect("serialize FailurePolicy");
+        let back: FailurePolicy = serde_json::from_str(&json).expect("deserialize FailurePolicy");
+        assert_eq!(back, policy);
+    }
+}
+
+#[test]
+fn dedupe_strategy_and_worker_id_round_trip_through_json() {
+    for strategy in [
+        DedupeStrategy::None,
+        DedupeStrategy::Blanks,
+        DedupeStrategy::All {
+            algo: libviprs::ChecksumAlgo::Sha256,
+        },
+    ] {
+        let json = serde_json::to_string(&strategy).expect("serialize DedupeStrategy");
+        let back: DedupeStrategy = serde_json::from_str(&json).expect("deserialize DedupeStrategy");
+        assert_eq!(back, strategy);
+    }
+
+    let worker = WorkerId::new("pool-3/agent-11");
+    let json = serde_json::to_string(&worker).expect("serialize WorkerId");
+    let back: WorkerId = serde_json::from_str(&json).expect("deserialize WorkerId");
+    assert_eq!(back, worker);
+}


### PR DESCRIPTION
Lands the additive serde slice of the #67 remainder.

## What

- New `serde` cargo feature (off by default). It gates `Serialize` / `Deserialize` derives via `cfg_attr` on the wire/config types the issue names: `PyramidPlan`, `LevelPlan`, `TileCoord`, `TileRect`, `Layout`, `EngineConfig`, `BlankTileStrategy`, `FailurePolicy`, `RetryPolicy`, `DedupeStrategy`, `WorkerId`. `TileFormat` and `ChecksumAlgo` already derived serde unconditionally and are untouched.
- The serde crate is already a required dependency (resume checkpoints, packfile manifests), so the feature is `serde = []`: it pulls in no new dependencies and only widens the public derive surface. The default build's API is unchanged.
- `EngineConfig::cancel` is a process-local `Arc<AtomicBool>` handle, not wire state: it is `serde(skip)`, never serialized, always `None` after deserialization.
- Feature-gated round-trip tests in `tests/serde_wire.rs`: a real multi-level centred plan from `PyramidPlanner::plan`, every leaf type, and a pin that the cancel token stays off the wire.

## What this deliberately does NOT do

- No `src/wire.rs` (`JobDescriptor` / `TileBatch`): stays in the #67 remainder.
- No serde on `EngineEvent`: it is entangled with the deferred optional `worker_id` / `timestamp` fields on existing variants, which are a breaking change to the shipped 0.3.x surface and need their own window.
- No change to the pdfium-render pin.

## Verification (local CI mirror)

- `make fmt`, `make clippy` (default + pdfium), `make test`: green.
- `cargo clippy --all-targets --features serde -- -D warnings`: green.
- `cargo test --features serde`: green (all suites plus the 6 new round-trip tests).
- `make doc` (all-features, deny broken intra-doc links): passes; remaining warnings are pre-existing private-item links.

Part of #67 (issue stays open for the remainder listed above).