### PR TITLE
feat(core)!: extensible raster drawing framework + worker attribution on tile events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-07-11
+
+### Breaking
+
+- Tile-lifecycle `EngineEvent` variants carry optional worker attribution
+  (issue #67). `TileCompleted`, `TileFailed`, `TileSkippedOnResume`, and
+  `RetryAttempted` each gain `worker_id: Option<WorkerId>` and
+  `timestamp: Option<SystemTime>`. The in-tree engines set `worker_id: None`
+  and stamp `timestamp: Some(_)` on the coordinating thread at emit time; an
+  out-of-tree executor layer fills `worker_id` to route events back to the
+  worker that produced them. Construction moves to the stamping helpers
+  `EngineEvent::tile_completed`, `::tile_failed`, `::tile_skipped_on_resume`,
+  and `::retry_attempted`. Code that pattern-matched these variants must add
+  `..` (e.g. `TileCompleted { coord, .. }`); code that constructed them by
+  struct literal must supply the new fields or use the helpers. `EngineEvent`
+  is `#[non_exhaustive]`, so `matches!(e, EngineEvent::TileCompleted { .. })`
+  filters are unaffected.
+
 ### Added
 
+- Extensible raster drawing framework in the new `draw` module (issue #55).
+  A `DrawOp` trait (`fn apply(&self, &mut Raster)`) is the seam: new shapes and
+  paint effects plug in as `impl DrawOp` without touching the core `Raster`.
+  Ships `Circle` and `Rectangle` ops (outline + filled), the inherent
+  convenience methods `Raster::draw`, `draw_circle`, `draw_circle_filled`,
+  `draw_rect`, `draw_rect_filled`, and `put_pixel` (clipping, format-agnostic
+  pixel write). All drawing clips to the raster bounds and is infallible.
+- Pixel utilities on `Raster` (issue #55): `getpoint(x, y) -> Vec<f64>` reads a
+  pixel as one `f64` per band (native byte order for 16-bit), and
+  `add(&other) -> Raster` combines two rasters pixel-by-pixel, promoting 8-bit
+  results to 16-bit so sums do not wrap (16-bit sums saturate at `65535`).
 - `WorkExecutor` trait, `StripWorkUnit`, `WorkContext`, and `LocalWorkExecutor`
   in `streaming_mapreduce` (re-exported at the crate root): a plug-in seam at
   the MapReduce MAP-phase strip dispatch, so an out-of-tree executor (process

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ zip = "7.2.0"
 
 [package]
 name = "libviprs"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 authors = ["Roman Goldmann <roman@devshell.org>"]
 rust-version = "1.85"

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,0 +1,486 @@
+//! Extensible in-place raster drawing.
+//!
+//! This module is the drawing seam for [`Raster`]. Every shape or paint
+//! operation is a value that implements the [`DrawOp`] trait, whose single
+//! [`apply`](DrawOp::apply) method mutates a `Raster` in place. New ops (line,
+//! polygon, ellipse, flood-fill, gradient, ...) plug in by adding one `impl
+//! DrawOp` and, optionally, one convenience method on `Raster`; the core
+//! [`Raster`] type and the existing ops never change. This keeps the drawing
+//! surface open for extension and closed for modification.
+//!
+//! # Why a trait, not four hard-coded methods
+//!
+//! A `DrawOp` is a first-class, inspectable value. Callers can build a
+//! `Vec<Box<dyn DrawOp>>` and replay it, wrap an op to log or clip it, or ship
+//! a custom op from a downstream crate without a libviprs release. The built-in
+//! shapes ([`Circle`], [`Rectangle`]) are ordinary implementors with no
+//! privileged access, so a third-party op is exactly as capable as a built-in
+//! one.
+//!
+//! This is deliberately *separate* from
+//! [`Extensions`](crate::extensions::Extensions), which carries opaque
+//! pipeline-level context (metrics recorders, tracing spans) into the pyramid
+//! engine. `DrawOp` is about mutating pixel buffers; `Extensions` is about
+//! threading shared context through a run. They solve different problems, so
+//! they stay distinct rather than one being forced through the other.
+//!
+//! # Coordinates and clipping
+//!
+//! Op coordinates are `i32` so shapes may be positioned partly off-canvas.
+//! Every op clips to the raster bounds: pixels outside `0..width` / `0..height`
+//! are silently skipped, matching the clip-don't-panic convention of classic
+//! raster libraries. Drawing is therefore always infallible.
+//!
+//! # Ink
+//!
+//! `ink` is the raw pixel value to paint, as bytes. It is written verbatim to
+//! each affected pixel, cycling if it is shorter than the pixel's byte width
+//! (so `&[100]` fills a `Gray8` pixel, and `&[r, g, b]` fills an `Rgb8` one).
+//! Ink longer than one pixel is truncated to the pixel width.
+//!
+//! # Example: a custom op
+//!
+//! ```
+//! use libviprs::{PixelFormat, Raster};
+//! use libviprs::draw::DrawOp;
+//!
+//! // A one-off op that paints a single horizontal scanline.
+//! struct HLine<'a> { ink: &'a [u8], y: i32, x0: i32, x1: i32 }
+//!
+//! impl DrawOp for HLine<'_> {
+//!     fn apply(&self, raster: &mut Raster) {
+//!         for x in self.x0..=self.x1 {
+//!             raster.put_pixel(x, self.y, self.ink);
+//!         }
+//!     }
+//! }
+//!
+//! let mut im = Raster::zeroed(8, 8, PixelFormat::Gray8).unwrap();
+//! im.draw(&HLine { ink: &[255], y: 3, x0: 0, x1: 7 });
+//! assert_eq!(im.getpoint(0, 3), vec![255.0]);
+//! ```
+
+use crate::raster::Raster;
+
+/// An in-place raster drawing operation.
+///
+/// Implement this for any new shape or paint effect. [`apply`](Self::apply)
+/// receives exclusive access to the target [`Raster`] and mutates it directly.
+/// Implementations must clip to the raster bounds and never panic on
+/// out-of-range coordinates; use [`Raster::put_pixel`], which clips for you.
+pub trait DrawOp {
+    /// Paint this op onto `raster`, mutating it in place.
+    fn apply(&self, raster: &mut Raster);
+}
+
+/// A circle, drawn as an outline or filled disc.
+///
+/// Built with [`Circle::outline`] / [`Circle::filled`], or applied through the
+/// [`Raster::draw_circle`] / [`Raster::draw_circle_filled`] convenience
+/// methods. The outline is a 1px midpoint circle; the fill is the solid disc of
+/// the same radius, so an outline and a fill of identical parameters share the
+/// same boundary pixels.
+#[derive(Debug, Clone)]
+pub struct Circle<'a> {
+    /// Pixel value to paint (see the [module docs](self#ink)).
+    pub ink: &'a [u8],
+    /// Centre x coordinate.
+    pub cx: i32,
+    /// Centre y coordinate.
+    pub cy: i32,
+    /// Radius in pixels. A radius `< 0` draws nothing.
+    pub radius: i32,
+    /// Whether to fill the disc (`true`) or draw only the outline (`false`).
+    pub fill: bool,
+}
+
+impl<'a> Circle<'a> {
+    /// A 1px-thick circle outline.
+    pub fn outline(ink: &'a [u8], cx: i32, cy: i32, radius: i32) -> Self {
+        Self {
+            ink,
+            cx,
+            cy,
+            radius,
+            fill: false,
+        }
+    }
+
+    /// A solid filled disc.
+    pub fn filled(ink: &'a [u8], cx: i32, cy: i32, radius: i32) -> Self {
+        Self {
+            ink,
+            cx,
+            cy,
+            radius,
+            fill: true,
+        }
+    }
+}
+
+impl DrawOp for Circle<'_> {
+    fn apply(&self, raster: &mut Raster) {
+        if self.radius < 0 {
+            return;
+        }
+        if self.fill {
+            fill_circle(raster, self.ink, self.cx, self.cy, self.radius);
+        } else {
+            outline_circle(raster, self.ink, self.cx, self.cy, self.radius);
+        }
+    }
+}
+
+/// A rectangle, drawn as an outline or filled.
+///
+/// Built with [`Rectangle::outline`] / [`Rectangle::filled`], or applied
+/// through [`Raster::draw_rect`] / [`Raster::draw_rect_filled`]. `left`/`top`
+/// are the top-left corner; `width`/`height` extend right/down. Non-positive
+/// `width` or `height` draws nothing.
+#[derive(Debug, Clone)]
+pub struct Rectangle<'a> {
+    /// Pixel value to paint (see the [module docs](self#ink)).
+    pub ink: &'a [u8],
+    /// Left edge x coordinate.
+    pub left: i32,
+    /// Top edge y coordinate.
+    pub top: i32,
+    /// Width in pixels.
+    pub width: i32,
+    /// Height in pixels.
+    pub height: i32,
+    /// Whether to fill the rectangle (`true`) or draw only the 1px border.
+    pub fill: bool,
+}
+
+impl<'a> Rectangle<'a> {
+    /// A 1px-thick rectangle border.
+    pub fn outline(ink: &'a [u8], left: i32, top: i32, width: i32, height: i32) -> Self {
+        Self {
+            ink,
+            left,
+            top,
+            width,
+            height,
+            fill: false,
+        }
+    }
+
+    /// A solid filled rectangle.
+    pub fn filled(ink: &'a [u8], left: i32, top: i32, width: i32, height: i32) -> Self {
+        Self {
+            ink,
+            left,
+            top,
+            width,
+            height,
+            fill: true,
+        }
+    }
+}
+
+impl DrawOp for Rectangle<'_> {
+    fn apply(&self, raster: &mut Raster) {
+        if self.width <= 0 || self.height <= 0 {
+            return;
+        }
+        // `right`/`bottom` are the inclusive far edges. Widen to i64 so a large
+        // `left + width` cannot overflow i32.
+        let right = (self.left as i64 + self.width as i64 - 1) as i32;
+        let bottom = (self.top as i64 + self.height as i64 - 1) as i32;
+        if self.fill {
+            for y in self.top..=bottom {
+                for x in self.left..=right {
+                    raster.put_pixel(x, y, self.ink);
+                }
+            }
+        } else {
+            for x in self.left..=right {
+                raster.put_pixel(x, self.top, self.ink);
+                raster.put_pixel(x, bottom, self.ink);
+            }
+            for y in self.top..=bottom {
+                raster.put_pixel(self.left, y, self.ink);
+                raster.put_pixel(right, y, self.ink);
+            }
+        }
+    }
+}
+
+/// Midpoint-circle outline: plot the eight symmetric octant points.
+fn outline_circle(raster: &mut Raster, ink: &[u8], cx: i32, cy: i32, radius: i32) {
+    if radius == 0 {
+        raster.put_pixel(cx, cy, ink);
+        return;
+    }
+    let mut x = radius;
+    let mut y = 0;
+    // Decision variable for the midpoint algorithm.
+    let mut err = 1 - radius;
+    while x >= y {
+        for (px, py) in [
+            (cx + x, cy + y),
+            (cx - x, cy + y),
+            (cx + x, cy - y),
+            (cx - x, cy - y),
+            (cx + y, cy + x),
+            (cx - y, cy + x),
+            (cx + y, cy - x),
+            (cx - y, cy - x),
+        ] {
+            raster.put_pixel(px, py, ink);
+        }
+        y += 1;
+        if err < 0 {
+            err += 2 * y + 1;
+        } else {
+            x -= 1;
+            err += 2 * (y - x) + 1;
+        }
+    }
+}
+
+/// Solid disc: paint the horizontal span for every scanline the circle covers.
+fn fill_circle(raster: &mut Raster, ink: &[u8], cx: i32, cy: i32, radius: i32) {
+    let r2 = radius as i64 * radius as i64;
+    for dy in -radius..=radius {
+        // Half-width of the span at this row: floor(sqrt(r^2 - dy^2)).
+        let rem = r2 - dy as i64 * dy as i64;
+        if rem < 0 {
+            continue;
+        }
+        let dx = isqrt_i64(rem) as i32;
+        let y = cy + dy;
+        for x in (cx - dx)..=(cx + dx) {
+            raster.put_pixel(x, y, ink);
+        }
+    }
+}
+
+/// Integer square root (floor) for non-negative `n`. Avoids float rounding at
+/// the disc boundary so `fill_circle` and `outline_circle` agree there.
+fn isqrt_i64(n: i64) -> i64 {
+    if n < 2 {
+        return n;
+    }
+    let mut x = (n as f64).sqrt() as i64;
+    // Correct any float rounding in either direction.
+    while x * x > n {
+        x -= 1;
+    }
+    while (x + 1) * (x + 1) <= n {
+        x += 1;
+    }
+    x
+}
+
+impl Raster {
+    /// Apply any [`DrawOp`] to this raster in place.
+    ///
+    /// This is the generic entry point; the `draw_*` methods below are thin
+    /// wrappers over it for the common shapes.
+    pub fn draw<O: DrawOp + ?Sized>(&mut self, op: &O) {
+        op.apply(self);
+    }
+
+    /// Write `ink` to the pixel at `(x, y)`, clipping if it lies off-canvas.
+    ///
+    /// `ink` is copied verbatim, cycling if shorter than the pixel's byte width
+    /// and truncating if longer. Out-of-bounds coordinates (including negative
+    /// ones) are a silent no-op, so drawing code never has to bounds-check.
+    pub fn put_pixel(&mut self, x: i32, y: i32, ink: &[u8]) {
+        if x < 0 || y < 0 || x >= self.width() as i32 || y >= self.height() as i32 {
+            return;
+        }
+        if ink.is_empty() {
+            return;
+        }
+        let bpp = self.format().bytes_per_pixel();
+        let stride = self.stride();
+        let start = y as usize * stride + x as usize * bpp;
+        let data = self.data_mut();
+        for (i, byte) in data[start..start + bpp].iter_mut().enumerate() {
+            *byte = ink[i % ink.len()];
+        }
+    }
+
+    /// Draw a circle outline (see [`Circle::outline`]).
+    pub fn draw_circle(&mut self, ink: &[u8], cx: i32, cy: i32, radius: i32) {
+        self.draw(&Circle::outline(ink, cx, cy, radius));
+    }
+
+    /// Draw a filled disc (see [`Circle::filled`]).
+    pub fn draw_circle_filled(&mut self, ink: &[u8], cx: i32, cy: i32, radius: i32) {
+        self.draw(&Circle::filled(ink, cx, cy, radius));
+    }
+
+    /// Draw a rectangle outline (see [`Rectangle::outline`]).
+    pub fn draw_rect(&mut self, ink: &[u8], left: i32, top: i32, width: i32, height: i32) {
+        self.draw(&Rectangle::outline(ink, left, top, width, height));
+    }
+
+    /// Draw a filled rectangle (see [`Rectangle::filled`]).
+    pub fn draw_rect_filled(&mut self, ink: &[u8], left: i32, top: i32, width: i32, height: i32) {
+        self.draw(&Rectangle::filled(ink, left, top, width, height));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pixel::PixelFormat;
+
+    fn black(w: u32, h: u32) -> Raster {
+        Raster::zeroed(w, h, PixelFormat::Gray8).unwrap()
+    }
+
+    fn at(im: &Raster, x: u32, y: u32) -> u8 {
+        im.region(x, y, 1, 1).unwrap().pixel(0, 0).unwrap()[0]
+    }
+
+    /// put_pixel writes ink and clips off-canvas coordinates without panicking.
+    #[test]
+    fn put_pixel_writes_and_clips() {
+        let mut im = black(4, 4);
+        im.put_pixel(1, 2, &[200]);
+        assert_eq!(at(&im, 1, 2), 200);
+        // Off-canvas (negative and past-edge) are silent no-ops.
+        im.put_pixel(-1, 0, &[9]);
+        im.put_pixel(0, -1, &[9]);
+        im.put_pixel(4, 0, &[9]);
+        im.put_pixel(0, 4, &[9]);
+        // Nothing else changed.
+        assert_eq!(im.data().iter().filter(|&&b| b != 0).count(), 1);
+    }
+
+    /// put_pixel fills every channel of a multi-band pixel from the ink slice.
+    #[test]
+    fn put_pixel_multiband() {
+        let mut im = Raster::zeroed(2, 1, PixelFormat::Rgb8).unwrap();
+        im.put_pixel(0, 0, &[10, 20, 30]);
+        assert_eq!(im.getpoint(0, 0), vec![10.0, 20.0, 30.0]);
+    }
+
+    /// Circle outline matches the libvips reference: the leftmost point is on
+    /// the circle (ink), the pixel just inside it is untouched (0).
+    #[test]
+    fn draw_circle_outline_reference() {
+        let mut im = black(100, 100);
+        im.draw_circle(&[100], 50, 50, 25);
+        assert_eq!(at(&im, 25, 50), 100, "pixel on circle");
+        assert_eq!(
+            at(&im, 26, 50),
+            0,
+            "pixel just inside outline is not filled"
+        );
+    }
+
+    /// Filled circle: boundary and interior are ink, just-outside is untouched.
+    #[test]
+    fn draw_circle_filled_reference() {
+        let mut im = black(100, 100);
+        im.draw_circle_filled(&[100], 50, 50, 25);
+        assert_eq!(at(&im, 25, 50), 100, "boundary");
+        assert_eq!(at(&im, 26, 50), 100, "interior");
+        assert_eq!(at(&im, 24, 50), 0, "just outside");
+    }
+
+    /// Filled coverage strictly exceeds outline coverage, and both agree on the
+    /// four cardinal extreme points of the circle.
+    #[test]
+    fn fill_covers_more_than_outline() {
+        let count = |im: &Raster| im.data().iter().filter(|&&b| b != 0).count();
+
+        let mut outline = black(64, 64);
+        outline.draw_circle(&[100], 32, 32, 20);
+        let mut filled = black(64, 64);
+        filled.draw_circle_filled(&[100], 32, 32, 20);
+
+        assert!(
+            count(&filled) > count(&outline),
+            "fill ({}) should cover more pixels than outline ({})",
+            count(&filled),
+            count(&outline)
+        );
+        // The cardinal boundary points sit on both the outline and the fill.
+        for (x, y) in [(12, 32), (52, 32), (32, 12), (32, 52)] {
+            assert_eq!(at(&outline, x, y), 100, "outline cardinal ({x},{y})");
+            assert_eq!(at(&filled, x, y), 100, "fill cardinal ({x},{y})");
+        }
+        // The centre is filled but not on the outline.
+        assert_eq!(at(&filled, 32, 32), 100);
+        assert_eq!(at(&outline, 32, 32), 0);
+    }
+
+    /// Rectangle outline paints only the border; the interior stays background.
+    #[test]
+    fn draw_rect_outline_border_only() {
+        let mut im = black(20, 20);
+        im.draw_rect(&[100], 5, 5, 10, 8);
+        // Corners and edges are ink.
+        assert_eq!(at(&im, 5, 5), 100);
+        assert_eq!(at(&im, 14, 5), 100); // left+width-1
+        assert_eq!(at(&im, 5, 12), 100); // top+height-1
+        assert_eq!(at(&im, 14, 12), 100);
+        // Interior is untouched.
+        assert_eq!(at(&im, 9, 8), 0);
+    }
+
+    /// Filled rectangle paints the whole interior span, and clips at the edge.
+    #[test]
+    fn draw_rect_filled_covers_interior_and_clips() {
+        let mut im = black(20, 20);
+        im.draw_rect_filled(&[77], 5, 5, 10, 8);
+        assert_eq!(at(&im, 5, 5), 77);
+        assert_eq!(at(&im, 14, 12), 77);
+        assert_eq!(at(&im, 9, 8), 77);
+        assert_eq!(at(&im, 4, 5), 0, "left of rect");
+        assert_eq!(at(&im, 15, 5), 0, "right of rect");
+
+        // A rectangle straddling the top-left corner clips without panic.
+        let mut im2 = black(10, 10);
+        im2.draw_rect_filled(&[5], -3, -3, 6, 6);
+        assert_eq!(at(&im2, 0, 0), 5);
+        assert_eq!(at(&im2, 2, 2), 5);
+        assert_eq!(at(&im2, 3, 3), 0);
+    }
+
+    /// Degenerate inputs are safe no-ops: negative radius, zero-size rect.
+    #[test]
+    fn degenerate_ops_are_noops() {
+        let mut im = black(8, 8);
+        im.draw_circle(&[1], 4, 4, -1);
+        im.draw_rect(&[1], 0, 0, 0, 5);
+        im.draw_rect_filled(&[1], 0, 0, 5, 0);
+        assert!(im.data().iter().all(|&b| b == 0));
+    }
+
+    /// The extensibility seam composes: a custom `DrawOp` from outside the
+    /// module drives the same `Raster::draw` entry point as the built-ins, and
+    /// a `&dyn DrawOp` erases the concrete type without changing behaviour.
+    #[test]
+    fn custom_draw_op_composes() {
+        struct Diagonal<'a> {
+            ink: &'a [u8],
+        }
+        impl DrawOp for Diagonal<'_> {
+            fn apply(&self, raster: &mut Raster) {
+                let n = raster.width().min(raster.height());
+                for i in 0..n as i32 {
+                    raster.put_pixel(i, i, self.ink);
+                }
+            }
+        }
+
+        let mut im = black(5, 5);
+        let op = Diagonal { ink: &[255] };
+        // Drive it both as a concrete op and behind a trait object.
+        im.draw(&op);
+        let dynamic: &dyn DrawOp = &op;
+        im.draw(dynamic);
+        for i in 0..5 {
+            assert_eq!(at(&im, i, i), 255);
+        }
+        assert_eq!(at(&im, 0, 4), 0);
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1244,7 +1244,7 @@ pub fn raster_verify(
             for row in 0..level.rows {
                 for col in 0..level.cols {
                     let coord = TileCoord::new(level_idx as u32, col, row);
-                    observer.on_event(EngineEvent::TileCompleted { coord });
+                    observer.on_event(EngineEvent::tile_completed(coord));
                     let expected = extract_tile(current, plan, coord, bg)?;
                     let expected_bytes = expected.data();
 
@@ -1536,10 +1536,7 @@ fn extract_and_emit_level(
                                 // no output; report it as TileFailed, never as
                                 // TileCompleted, so observers that pair
                                 // completions with sink writes stay consistent.
-                                observer.on_event(EngineEvent::TileFailed {
-                                    coord,
-                                    error: e.to_string(),
-                                });
+                                observer.on_event(EngineEvent::tile_failed(coord, e.to_string()));
                                 // Intentionally do NOT increment count here —
                                 // this tile did not produce output. But also
                                 // do not increment a skip counter tied to
@@ -1551,7 +1548,7 @@ fn extract_and_emit_level(
                         }
                     }
                 }
-                observer.on_event(EngineEvent::TileCompleted { coord });
+                observer.on_event(EngineEvent::tile_completed(coord));
                 #[cfg(feature = "tracing")]
                 if tracing::enabled!(target: "libviprs::tile", tracing::Level::TRACE) {
                     tracing::trace!(
@@ -1803,17 +1800,14 @@ fn extract_and_emit_parallel(
                             // output; report it as TileFailed, never as
                             // TileCompleted, so observers that pair completions
                             // with sink writes stay consistent.
-                            observer.on_event(EngineEvent::TileFailed {
-                                coord,
-                                error: e.to_string(),
-                            });
+                            observer.on_event(EngineEvent::tile_failed(coord, e.to_string()));
                             continue;
                         }
                         _ => return Err(promote_sink_error(e)),
                     }
                 }
             }
-            observer.on_event(EngineEvent::TileCompleted { coord });
+            observer.on_event(EngineEvent::tile_completed(coord));
             #[cfg(feature = "tracing")]
             if tracing::enabled!(target: "libviprs::tile", tracing::Level::TRACE) {
                 tracing::trace!(
@@ -2428,7 +2422,7 @@ mod tests {
             assert!(
                 !events.iter().any(|e| matches!(
                     e,
-                    EngineEvent::TileCompleted { coord } if *coord == target
+                    EngineEvent::TileCompleted { coord, .. } if *coord == target
                 )),
                 "concurrency={concurrency}: dropped tile {target:?} was emitted as \
                  TileCompleted — violates issue #128"
@@ -2438,7 +2432,7 @@ mod tests {
             let failed: Vec<String> = events
                 .iter()
                 .filter_map(|e| match e {
-                    EngineEvent::TileFailed { coord, error } if *coord == target => {
+                    EngineEvent::TileFailed { coord, error, .. } if *coord == target => {
                         Some(error.clone())
                     }
                     _ => None,
@@ -2459,7 +2453,7 @@ mod tests {
             assert!(
                 events.iter().any(|e| matches!(
                     e,
-                    EngineEvent::TileCompleted { coord }
+                    EngineEvent::TileCompleted { coord, .. }
                         if coord.level == top && *coord != target
                 )),
                 "concurrency={concurrency}: sibling tiles should still emit TileCompleted"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 pub mod cancel;
 pub mod checksum;
 pub mod dedupe;
+pub mod draw;
 pub mod engine;
 pub mod engine_builder;
 pub mod extensions;
@@ -66,6 +67,7 @@ pub mod pixel;
 pub mod planner;
 pub(crate) mod poison;
 pub mod raster;
+pub(crate) mod raster_ops;
 pub mod resize;
 pub mod resume;
 pub mod retry;
@@ -90,6 +92,7 @@ pub mod verify;
 pub use cancel::CancelToken;
 pub use checksum::{ChecksumMode, VerifyError, VerifyReport};
 pub use dedupe::{DedupeDecision, DedupeIndex, DedupeStrategy, LinkResult};
+pub use draw::{Circle, DrawOp, Rectangle};
 pub use engine::{
     BlankTileStrategy, EngineConfig, EngineError, EngineResult, StageDurations, is_blank_tile,
 };

--- a/src/observe.rs
+++ b/src/observe.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
 
 use crate::planner::TileCoord;
 
@@ -95,7 +96,21 @@ pub enum EngineEvent {
         tile_count: u64,
     },
     /// A tile was produced and sent to the sink.
-    TileCompleted { coord: TileCoord },
+    ///
+    /// `worker_id` attributes the tile to the [`WorkExecutor`](crate::WorkExecutor)
+    /// that produced it, and `timestamp` records when the coordinating thread
+    /// emitted the event (issue #67). Both are additive and optional: the
+    /// in-tree engines set `worker_id: None` (work is unattributed) and stamp
+    /// `timestamp: Some(_)` at emit time on the coordinating thread. An
+    /// out-of-tree executor layer fills `worker_id` to route the event back to
+    /// the worker that produced it. Construct with
+    /// [`EngineEvent::tile_completed`](Self::tile_completed) to stamp both the
+    /// default way.
+    TileCompleted {
+        coord: TileCoord,
+        worker_id: Option<WorkerId>,
+        timestamp: Option<SystemTime>,
+    },
     /// A tile failed terminally and was skipped under
     /// [`FailurePolicy::RetryThenSkip`](crate::retry::FailurePolicy::RetryThenSkip).
     ///
@@ -104,21 +119,40 @@ pub enum EngineEvent {
     /// completed would corrupt any observer that pairs completions with sink
     /// writes (progress bars, completion counters, per-tile audit logs). The
     /// `error` string carries a human-readable description of the terminal
-    /// failure.
-    TileFailed { coord: TileCoord, error: String },
+    /// failure. `worker_id` / `timestamp` carry the same optional attribution
+    /// as [`TileCompleted`](Self::TileCompleted) (issue #67).
+    TileFailed {
+        coord: TileCoord,
+        error: String,
+        worker_id: Option<WorkerId>,
+        timestamp: Option<SystemTime>,
+    },
     /// A tile was skipped on resume because a prior run already produced it.
     ///
     /// Emitted for tiles listed in an inbound resume checkpoint. Such tiles
     /// are never re-extracted or re-written this run, so they must not
     /// surface as [`TileCompleted`](Self::TileCompleted) — an observer would
     /// otherwise double-count them across the original and resumed runs.
-    TileSkippedOnResume { coord: TileCoord },
+    /// `worker_id` / `timestamp` carry the same optional attribution as
+    /// [`TileCompleted`](Self::TileCompleted) (issue #67).
+    TileSkippedOnResume {
+        coord: TileCoord,
+        worker_id: Option<WorkerId>,
+        timestamp: Option<SystemTime>,
+    },
     /// A tile write failed and a retry is about to be attempted.
     ///
     /// `attempt` is 1-based: the first retry after the initial failure is
     /// `attempt == 1`. Terminal failure (all retries exhausted) surfaces as
     /// [`TileFailed`](Self::TileFailed), never as `TileCompleted`.
-    RetryAttempted { coord: TileCoord, attempt: u32 },
+    /// `worker_id` / `timestamp` carry the same optional attribution as
+    /// [`TileCompleted`](Self::TileCompleted) (issue #67).
+    RetryAttempted {
+        coord: TileCoord,
+        attempt: u32,
+        worker_id: Option<WorkerId>,
+        timestamp: Option<SystemTime>,
+    },
     /// A level finished processing.
     LevelCompleted { level: u32, tiles_produced: u64 },
 
@@ -229,6 +263,55 @@ pub enum EngineEvent {
     /// (manifest writing, cleanup, etc.) is finished. The engine never
     /// emits this — it is purely a caller-side bookend to `SourceLoadStarted`.
     PipelineComplete,
+}
+
+impl EngineEvent {
+    /// Build a [`TileCompleted`](Self::TileCompleted) the in-tree way: no worker
+    /// attribution (`worker_id: None`) and a coordinating-thread timestamp
+    /// (`timestamp: Some(SystemTime::now())`).
+    ///
+    /// This is the constructor the built-in engines call, so every in-tree
+    /// tile-completion event is stamped identically. An out-of-tree executor
+    /// layer that needs `worker_id` builds the variant directly.
+    pub fn tile_completed(coord: TileCoord) -> Self {
+        Self::TileCompleted {
+            coord,
+            worker_id: None,
+            timestamp: Some(SystemTime::now()),
+        }
+    }
+
+    /// Build a [`TileFailed`](Self::TileFailed) with no worker attribution and a
+    /// coordinating-thread timestamp. See [`tile_completed`](Self::tile_completed).
+    pub fn tile_failed(coord: TileCoord, error: String) -> Self {
+        Self::TileFailed {
+            coord,
+            error,
+            worker_id: None,
+            timestamp: Some(SystemTime::now()),
+        }
+    }
+
+    /// Build a [`TileSkippedOnResume`](Self::TileSkippedOnResume) with no worker
+    /// attribution and a coordinating-thread timestamp.
+    pub fn tile_skipped_on_resume(coord: TileCoord) -> Self {
+        Self::TileSkippedOnResume {
+            coord,
+            worker_id: None,
+            timestamp: Some(SystemTime::now()),
+        }
+    }
+
+    /// Build a [`RetryAttempted`](Self::RetryAttempted) with no worker
+    /// attribution and a coordinating-thread timestamp.
+    pub fn retry_attempted(coord: TileCoord, attempt: u32) -> Self {
+        Self::RetryAttempted {
+            coord,
+            attempt,
+            worker_id: None,
+            timestamp: Some(SystemTime::now()),
+        }
+    }
 }
 
 /// Trait for receiving engine progress events.
@@ -512,9 +595,7 @@ mod tests {
             height: 1,
             tile_count: 1,
         });
-        obs.on_event(EngineEvent::TileCompleted {
-            coord: TileCoord::new(0, 0, 0),
-        });
+        obs.on_event(EngineEvent::tile_completed(TileCoord::new(0, 0, 0)));
         obs.on_event(EngineEvent::LevelCompleted {
             level: 0,
             tiles_produced: 1,
@@ -569,9 +650,7 @@ mod tests {
     #[test]
     fn poisoned_events_lock_recovers_without_cascade() {
         let obs = CollectingObserver::new();
-        obs.on_event(EngineEvent::TileCompleted {
-            coord: TileCoord::new(0, 0, 0),
-        });
+        obs.on_event(EngineEvent::tile_completed(TileCoord::new(0, 0, 0)));
 
         let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _guard = obs.events.lock().unwrap();
@@ -610,11 +689,11 @@ mod tests {
         let obs = CollectingObserver::new();
         let failed = TileCoord::new(2, 3, 4);
         let skipped = TileCoord::new(0, 1, 1);
-        obs.on_event(EngineEvent::TileFailed {
-            coord: failed,
-            error: "sink write failed after retries".to_string(),
-        });
-        obs.on_event(EngineEvent::TileSkippedOnResume { coord: skipped });
+        obs.on_event(EngineEvent::tile_failed(
+            failed,
+            "sink write failed after retries".to_string(),
+        ));
+        obs.on_event(EngineEvent::tile_skipped_on_resume(skipped));
 
         let events = obs.events();
         assert_eq!(events.len(), 2);
@@ -622,7 +701,7 @@ mod tests {
         // A failure is never observable as a completion.
         assert!(!matches!(events[0], EngineEvent::TileCompleted { .. }));
         match &events[0] {
-            EngineEvent::TileFailed { coord, error } => {
+            EngineEvent::TileFailed { coord, error, .. } => {
                 assert_eq!(*coord, failed);
                 assert_eq!(error, "sink write failed after retries");
             }
@@ -633,7 +712,7 @@ mod tests {
         assert!(!matches!(events[1], EngineEvent::TileCompleted { .. }));
         assert!(matches!(
             events[1],
-            EngineEvent::TileSkippedOnResume { coord } if coord == skipped
+            EngineEvent::TileSkippedOnResume { coord, .. } if coord == skipped
         ));
     }
 
@@ -647,7 +726,7 @@ mod tests {
     fn retry_and_checkpoint_events_round_trip() {
         let obs = CollectingObserver::new();
         let coord = TileCoord::new(1, 2, 3);
-        obs.on_event(EngineEvent::RetryAttempted { coord, attempt: 2 });
+        obs.on_event(EngineEvent::retry_attempted(coord, 2));
         obs.on_event(EngineEvent::CheckpointFlushed { tiles: 7 });
         let events = obs.events();
         assert!(matches!(

--- a/src/raster_ops.rs
+++ b/src/raster_ops.rs
@@ -1,0 +1,199 @@
+//! Pixel-access and combining utilities for [`Raster`].
+//!
+//! These are the small, format-aware helpers the arithmetic and creation ops
+//! build on: [`Raster::getpoint`] reads one pixel as per-band `f64` samples,
+//! and [`Raster::add`] combines two rasters pixel-by-pixel. They live beside
+//! the drawing framework (see [`crate::draw`]) as additive `impl Raster`
+//! blocks, so the core [`Raster`] type in [`crate::raster`] is untouched.
+//!
+//! 16-bit samples are read and written in native byte order, matching the
+//! convention the resize and decode paths already use.
+
+use crate::pixel::PixelFormat;
+use crate::raster::Raster;
+
+/// Read the `n`-th channel sample at byte offset `off` as `f64`, honouring the
+/// format's bit depth (native byte order for 16-bit).
+fn sample_f64(data: &[u8], off: usize, channel: usize, fmt: PixelFormat) -> f64 {
+    match fmt.bytes_per_channel() {
+        1 => data[off + channel] as f64,
+        _ => {
+            let b = off + channel * 2;
+            u16::from_ne_bytes([data[b], data[b + 1]]) as f64
+        }
+    }
+}
+
+impl Raster {
+    /// Read the pixel at `(x, y)` as one `f64` per channel.
+    ///
+    /// The returned vector has [`PixelFormat::channels`] entries: `[gray]` for
+    /// grayscale, `[r, g, b]` for RGB, `[r, g, b, a]` for RGBA. Samples are the
+    /// raw stored values (`0..=255` for 8-bit formats, `0..=65535` for 16-bit),
+    /// not normalised. This mirrors libvips `getpoint`, giving arithmetic and
+    /// LUT code a depth-independent view of a pixel.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `(x, y)` is outside the raster, matching the "known-good
+    /// index" contract of the ported callers; use [`Raster::region`] first when
+    /// the coordinate might be out of range.
+    pub fn getpoint(&self, x: u32, y: u32) -> Vec<f64> {
+        assert!(
+            x < self.width() && y < self.height(),
+            "getpoint({x},{y}) out of bounds for {}x{}",
+            self.width(),
+            self.height()
+        );
+        let fmt = self.format();
+        let channels = fmt.channels();
+        let bpp = fmt.bytes_per_pixel();
+        let off = y as usize * self.stride() + x as usize * bpp;
+        let data = self.data();
+        (0..channels)
+            .map(|c| sample_f64(data, off, c, fmt))
+            .collect()
+    }
+
+    /// Add two rasters pixel-by-pixel, returning a new raster.
+    ///
+    /// Both inputs must have identical dimensions and channel counts. To avoid
+    /// wrap-around, an 8-bit result is promoted to the matching 16-bit format
+    /// (`Gray8 -> Gray16`, `Rgb8 -> Rgb16`, `Rgba8 -> Rgba16`), so summing two
+    /// `Gray8` images whose values exceed 255 keeps the true sum. 16-bit inputs
+    /// have no wider format available, so their sums saturate at `65535`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the two rasters differ in width, height, or channel count. The
+    /// libvips-derived callers always add conformable images; the panic turns a
+    /// caller bug into an immediate, clear failure rather than silent garbage.
+    pub fn add(&self, other: &Raster) -> Raster {
+        assert_eq!(
+            (self.width(), self.height()),
+            (other.width(), other.height()),
+            "add: dimension mismatch"
+        );
+        assert_eq!(
+            self.format().channels(),
+            other.format().channels(),
+            "add: channel-count mismatch"
+        );
+
+        let width = self.width();
+        let height = self.height();
+        let channels = self.format().channels();
+        let out_fmt = widen(self.format());
+        let out_bpc = out_fmt.bytes_per_channel();
+        let count = width as usize * height as usize * channels;
+
+        let mut out = vec![0u8; count * out_bpc];
+        for i in 0..count {
+            let a = read_sample(self, i);
+            let b = read_sample(other, i);
+            let sum = a + b;
+            if out_bpc == 1 {
+                out[i] = sum.min(255) as u8;
+            } else {
+                let v = sum.min(u16::MAX as u32) as u16;
+                let bytes = v.to_ne_bytes();
+                out[i * 2] = bytes[0];
+                out[i * 2 + 1] = bytes[1];
+            }
+        }
+        // The output size is exactly `count * out_bpc`, computed from validated
+        // input dimensions, so construction cannot fail.
+        Raster::new(width, height, out_fmt, out).expect("add output is well-formed")
+    }
+}
+
+/// Read the `i`-th channel sample of `raster` (flat channel index) as `u32`.
+fn read_sample(raster: &Raster, i: usize) -> u32 {
+    let data = raster.data();
+    match raster.format().bytes_per_channel() {
+        1 => data[i] as u32,
+        _ => u16::from_ne_bytes([data[i * 2], data[i * 2 + 1]]) as u32,
+    }
+}
+
+/// The format one bit-depth wider, used so 8-bit sums do not wrap. 16-bit
+/// formats have no wider form here and are returned unchanged (sums saturate).
+fn widen(fmt: PixelFormat) -> PixelFormat {
+    match fmt {
+        PixelFormat::Gray8 => PixelFormat::Gray16,
+        PixelFormat::Rgb8 => PixelFormat::Rgb16,
+        PixelFormat::Rgba8 => PixelFormat::Rgba16,
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// getpoint returns one sample per band for 8-bit grayscale and RGB.
+    #[test]
+    fn getpoint_reads_bands_8bit() {
+        let im = Raster::new(2, 1, PixelFormat::Rgb8, vec![10, 20, 30, 40, 50, 60]).unwrap();
+        assert_eq!(im.getpoint(0, 0), vec![10.0, 20.0, 30.0]);
+        assert_eq!(im.getpoint(1, 0), vec![40.0, 50.0, 60.0]);
+
+        let g = Raster::new(1, 1, PixelFormat::Gray8, vec![7]).unwrap();
+        assert_eq!(g.getpoint(0, 0), vec![7.0]);
+    }
+
+    /// getpoint decodes 16-bit samples in native byte order.
+    #[test]
+    fn getpoint_reads_16bit() {
+        let v = 4096u16.to_ne_bytes();
+        let im = Raster::new(1, 1, PixelFormat::Gray16, vec![v[0], v[1]]).unwrap();
+        assert_eq!(im.getpoint(0, 0), vec![4096.0]);
+    }
+
+    /// getpoint round-trips a pixel written with put_pixel.
+    #[test]
+    fn getpoint_put_pixel_round_trip() {
+        let mut im = Raster::zeroed(4, 4, PixelFormat::Rgb8).unwrap();
+        im.put_pixel(2, 3, &[111, 122, 133]);
+        assert_eq!(im.getpoint(2, 3), vec![111.0, 122.0, 133.0]);
+    }
+
+    /// add combines two grayscale rasters and promotes 8-bit to 16-bit so the
+    /// sum does not wrap past 255.
+    #[test]
+    fn add_promotes_and_sums() {
+        let a = Raster::new(2, 1, PixelFormat::Gray8, vec![200, 10]).unwrap();
+        let sum = a.add(&a);
+        assert_eq!(sum.format(), PixelFormat::Gray16);
+        // 200 + 200 = 400 survives because the result is 16-bit.
+        assert_eq!(sum.getpoint(0, 0), vec![400.0]);
+        assert_eq!(sum.getpoint(1, 0), vec![20.0]);
+    }
+
+    /// add works per-band for colour images.
+    #[test]
+    fn add_colour_per_band() {
+        let a = Raster::new(1, 1, PixelFormat::Rgb8, vec![10, 20, 30]).unwrap();
+        let b = Raster::new(1, 1, PixelFormat::Rgb8, vec![1, 2, 3]).unwrap();
+        assert_eq!(a.add(&b).getpoint(0, 0), vec![11.0, 22.0, 33.0]);
+    }
+
+    /// 16-bit sums saturate at u16::MAX rather than wrapping.
+    #[test]
+    fn add_16bit_saturates() {
+        let hi = 60000u16.to_ne_bytes();
+        let a = Raster::new(1, 1, PixelFormat::Gray16, vec![hi[0], hi[1]]).unwrap();
+        let sum = a.add(&a);
+        assert_eq!(sum.format(), PixelFormat::Gray16);
+        assert_eq!(sum.getpoint(0, 0), vec![65535.0]);
+    }
+
+    /// add rejects mismatched dimensions.
+    #[test]
+    #[should_panic(expected = "dimension mismatch")]
+    fn add_dimension_mismatch_panics() {
+        let a = Raster::zeroed(2, 2, PixelFormat::Gray8).unwrap();
+        let b = Raster::zeroed(3, 2, PixelFormat::Gray8).unwrap();
+        let _ = a.add(&b);
+    }
+}

--- a/src/stream_verify.rs
+++ b/src/stream_verify.rs
@@ -379,7 +379,7 @@ pub fn verify_from_strip_source(
             for row in 0..level.rows {
                 for col in 0..level.cols {
                     let coord = TileCoord::new(level_idx as u32, col, row);
-                    observer.on_event(EngineEvent::TileCompleted { coord });
+                    observer.on_event(EngineEvent::tile_completed(coord));
 
                     // `extract_tile_from_strip` with `strip_canvas_y = 0`
                     // applied to a full-level raster is byte-equivalent to the

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1606,13 +1606,13 @@ pub(crate) fn emit_strip_tiles(
                 match &config.failure_policy {
                     crate::retry::FailurePolicy::RetryThenSkip(_) => {
                         sink.note_sink_skipped();
-                        observer.on_event(EngineEvent::TileCompleted { coord });
+                        observer.on_event(EngineEvent::tile_completed(coord));
                         continue;
                     }
                     _ => return Err(promote_sink_error(e)),
                 }
             }
-            observer.on_event(EngineEvent::TileCompleted { coord });
+            observer.on_event(EngineEvent::tile_completed(coord));
             count += 1;
         }
     }

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -447,13 +447,13 @@ fn emit_strip_tiles_parallel(
                 match &config.failure_policy {
                     crate::retry::FailurePolicy::RetryThenSkip(_) => {
                         sink.note_sink_skipped();
-                        observer.on_event(EngineEvent::TileCompleted { coord });
+                        observer.on_event(EngineEvent::tile_completed(coord));
                         continue;
                     }
                     _ => return Err(crate::engine::promote_sink_error(e)),
                 }
             }
-            observer.on_event(EngineEvent::TileCompleted { coord });
+            observer.on_event(EngineEvent::tile_completed(coord));
             count += 1;
         }
         Ok((count, skipped))


### PR DESCRIPTION
Lands two approved items in libviprs core.

## Item A — extensible raster drawing framework (Refs #55)

New `draw` module built around a `DrawOp` trait (`fn apply(&self, &mut Raster)`)
so new shapes/paint effects plug in as `impl DrawOp` without editing core
`Raster`. Adding a future op (line, polygon, ellipse, flood-fill) is a new impl,
not a core change (open for extension, closed for modification). Kept distinct
from the `Extensions` typemap on purpose: `Extensions` threads opaque pipeline
context into the engine, `DrawOp` mutates pixel buffers.

- Ops: `Circle` and `Rectangle`, each outline + filled.
- Inherent methods: `Raster::draw` (generic entry point), `draw_circle`,
  `draw_circle_filled`, `draw_rect`, `draw_rect_filled`, `put_pixel`.
- Pixel utilities: `getpoint(x, y) -> Vec<f64>` (per-band `f64`, native
  byte order for 16-bit) and `add(&other) -> Raster` (pixel-by-pixel, promotes
  8-bit to 16-bit so sums do not wrap; 16-bit saturates).
- All drawing clips to bounds and is infallible; `i32` coordinates allow
  partly-off-canvas shapes.
- Public surface matches the libviprs-tests `ported_*` call sites
  (`draw_circle`, `draw_circle_filled`, `getpoint`, `add`); un-ignoring those
  gated tests is a separate enablement round, so this closes nothing on #55.
- Unit tests: getpoint round-trip, add promotion + saturation, circle/rect
  outline-vs-filled coverage, degenerate no-ops, and a custom out-of-module
  `DrawOp` composing through `Raster::draw` (extensibility seam).

## Item B — worker attribution on tile events, 0.4.0 break (Closes #67)

Adds optional `worker_id: Option<WorkerId>` and `timestamp: Option<SystemTime>`
to the tile-lifecycle `EngineEvent` variants (`TileCompleted`, `TileFailed`,
`TileSkippedOnResume`, `RetryAttempted`), stamped on the coordinating thread via
new `EngineEvent::tile_completed` / `tile_failed` / `tile_skipped_on_resume` /
`retry_attempted` constructors (`worker_id: None`, `timestamp: Some(now)` for the
in-tree engines; an out-of-tree executor layer fills `worker_id`). Version bumped
`0.3.1 -> 0.4.0`. All in-repo consumers (engine, streaming, streaming_mapreduce,
stream_verify, observe tests) updated.

This is the last remaining piece of #67; the `WorkExecutor` seam,
`MapReduceHotCache`, `with_observers`, and the worker-attribution event
vocabulary already landed.

### Sibling blast radius (out of scope here, follow-on)

Repos that pattern-match/construct these `EngineEvent` variants and will need a
`{ coord, .. }` / constructor fixup:
- **libviprs-tests** — at least `tests/observability.rs` (exact `{ coord }`
  destructure), plus `streaming_engine.rs`, `builder_stream_verify.rs`,
  `builder_mapreduce_verify.rs`, `builder_resume_observer_parity.rs`.
- **libviprs-cli** — its `EngineObserver` matches tile events for progress.
- **libviprs-bench** — same event-matching pattern.

## Mirror (local, green)

`make fmt`, `make clippy` (default + pdfium), `make test` (418 lib + all
integration green), `cargo test --features serde`, and the doc intra-doc-link
check all pass.
