### PR TITLE
fix(core): resume leaves no lock file behind; plan-hash gate precedes the run lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A `Resume` refused on a plan-hash mismatch now returns
+  `EngineError::PlanHashMismatch` before anything touches the output
+  directory: the plan-hash gate runs ahead of the advisory run-lock
+  acquisition, so a refused resume no longer materialises
+  `.libviprs-job.lock` (or any other file) as a side effect.
+- `RunLock` removes its `.libviprs-job.lock` file when the guard drops, so a
+  finished run leaves no bookkeeping behind in the output tree and a
+  crash+resume run now produces a pyramid byte-identical to a clean single
+  run. The unlink happens while the exclusive lock is still held, and
+  `RunLock::acquire` revalidates after locking that the path still names the
+  inode it locked (retrying against the fresh file otherwise), which keeps
+  the removal safe against concurrent acquirers.
+
 ## [0.4.0] — 2026-07-11
 
 ### Breaking

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -722,6 +722,35 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
                 return Ok((result, sink));
             }
 
+            // Refuse a mismatched Resume BEFORE anything touches the output
+            // directory. `prepare_resume_state` re-checks the checkpoint under
+            // the run lock (that check stays authoritative for the race where
+            // another job swaps the checkpoint in between), but by that point
+            // `RunLock::acquire` has already created its lock file inside the
+            // directory. A refused resume must leave the directory exactly as
+            // it found it: no tile output, and no bookkeeping either. This
+            // preflight reads the same atomically-renamed checkpoint file the
+            // locked check reads, so it never sees a torn header.
+            if matches!(policy.mode(), ResumeMode::Resume) {
+                if let Some(root) = crate::engine::resolve_checkpoint_root(&engine_cfg, &sink) {
+                    if let Some(meta) = crate::resume::JobCheckpoint::load(&root)
+                        .map_err(EngineError::ResumeFailed)?
+                    {
+                        if let Err(current) = crate::resume::verify_checkpoint_contract(
+                            &meta,
+                            &plan,
+                            &engine_cfg,
+                            &sink,
+                        ) {
+                            return Err(EngineError::PlanHashMismatch {
+                                expected: current,
+                                actual: meta.plan_hash,
+                            });
+                        }
+                    }
+                }
+            }
+
             // Overwrite / Resume: take the advisory run lock on the checkpoint
             // root BEFORE any work touches the directory, and hold it for the
             // whole run. This is the engine-side half of issue #126: unique
@@ -2484,6 +2513,234 @@ mod run_lock_wiring_tests {
         let reacquired = RunLock::acquire(out.path())
             .expect("the run must release its lock so a later job can acquire it");
         drop(reacquired);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resume on-disk side-effect tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod resume_side_effect_tests {
+    use super::*;
+    use crate::pixel::PixelFormat;
+    use crate::planner::{Layout, PyramidPlanner};
+    use crate::raster::Raster;
+    use crate::resume::{JobCheckpoint, JobMetadata, ResumePolicy};
+    use crate::sink::{FsSink, SinkError, Tile, TileFormat, TileSink};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Recursively list every regular file under `root`, relative to `root`,
+    /// sorted. Used to assert a refused run has zero on-disk side effects and
+    /// to byte-compare a resumed pyramid against a clean one.
+    fn list_files(root: &Path) -> Vec<PathBuf> {
+        fn walk(root: &Path, cur: &Path, out: &mut Vec<PathBuf>) {
+            let Ok(entries) = std::fs::read_dir(cur) else {
+                return;
+            };
+            for entry in entries.filter_map(Result::ok) {
+                let p = entry.path();
+                if p.is_dir() {
+                    walk(root, &p, out);
+                } else {
+                    out.push(p.strip_prefix(root).unwrap().to_path_buf());
+                }
+            }
+        }
+        let mut out = Vec::new();
+        walk(root, root, &mut out);
+        out.sort();
+        out
+    }
+
+    /// A raster with gradient content so every tile is non-blank and distinct.
+    fn gradient_source(w: u32, h: u32) -> Raster {
+        let bpp = PixelFormat::Rgb8.bytes_per_pixel();
+        let mut data = vec![0u8; w as usize * h as usize * bpp];
+        for y in 0..h as usize {
+            for x in 0..w as usize {
+                let off = (y * w as usize + x) * bpp;
+                data[off] = (x % 251) as u8;
+                data[off + 1] = (y % 241) as u8;
+                data[off + 2] = ((x ^ y) % 239) as u8;
+            }
+        }
+        Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    // A Resume refused on a plan-hash mismatch must leave the output
+    // directory EXACTLY as it found it: no tiles, no lock file, no segment
+    // log. The plan-hash gate therefore runs before the run lock (whose
+    // acquisition creates `.libviprs-job.lock`) and before any engine work.
+    #[test]
+    fn refused_plan_hash_mismatch_leaves_the_directory_untouched() {
+        let out = tempfile::tempdir().unwrap();
+        let source = gradient_source(64, 64);
+        let plan = PyramidPlanner::new(64, 64, 32, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+
+        // A pre-existing checkpoint whose hash cannot match the current plan.
+        let stale = JobMetadata::new("f".repeat(64), "1970-01-01T00:00:00Z".into());
+        JobCheckpoint::save(out.path(), &stale).unwrap();
+        let before = list_files(out.path());
+
+        let sink = FsSink::new(out.path().to_path_buf(), plan.clone()).with_format(TileFormat::Png);
+        let err = EngineBuilder::new(&source, plan.clone(), sink)
+            .with_engine(EngineKind::Monolithic)
+            .with_resume(ResumePolicy::resume())
+            .run()
+            .expect_err("a stale plan hash must refuse to resume");
+        assert!(
+            matches!(err, EngineError::PlanHashMismatch { .. }),
+            "expected PlanHashMismatch, got {err:?}"
+        );
+
+        let after = list_files(out.path());
+        assert_eq!(
+            before, after,
+            "a refused Resume must not write tiles, a lock file, or any other file"
+        );
+    }
+
+    // The plan-hash gate runs BEFORE the run lock is acquired: with a live
+    // holder on the directory AND a stale checkpoint, the mismatch refusal
+    // must win. Pre-fix the lock was taken first, so this returned
+    // ResumeFailed(Locked) and, when the directory was free, materialised
+    // `.libviprs-job.lock` before refusing.
+    #[test]
+    #[cfg_attr(miri, ignore)] // file locking unsupported under Miri isolation
+    fn plan_hash_gate_refuses_before_the_run_lock_is_taken() {
+        let out = tempfile::tempdir().unwrap();
+        let source = gradient_source(64, 64);
+        let plan = PyramidPlanner::new(64, 64, 32, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+
+        let stale = JobMetadata::new("f".repeat(64), "1970-01-01T00:00:00Z".into());
+        JobCheckpoint::save(out.path(), &stale).unwrap();
+
+        // Another live job owns the directory for the whole attempt.
+        let held = crate::resume::RunLock::acquire(out.path()).expect("test holder acquires");
+
+        let sink = FsSink::new(out.path().to_path_buf(), plan.clone()).with_format(TileFormat::Png);
+        let err = EngineBuilder::new(&source, plan.clone(), sink)
+            .with_engine(EngineKind::Monolithic)
+            .with_resume(ResumePolicy::resume())
+            .run()
+            .expect_err("stale plan hash must refuse to resume");
+        assert!(
+            matches!(err, EngineError::PlanHashMismatch { .. }),
+            "the plan-hash gate must fire before lock acquisition, got {err:?}"
+        );
+
+        drop(held);
+    }
+
+    /// Sink wrapper that panics on the Nth `write_tile`, simulating a mid-run
+    /// crash. Bookkeeping (checkpoint root, content format, ...) forwards to
+    /// the wrapped sink through `inner_sink`.
+    struct PanickingSink<S: TileSink> {
+        inner: S,
+        panic_at: usize,
+        writes: AtomicUsize,
+    }
+
+    impl<S: TileSink> TileSink for PanickingSink<S> {
+        fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+            let n = self.writes.fetch_add(1, Ordering::SeqCst) + 1;
+            if n == self.panic_at {
+                panic!("PanickingSink: deliberate crash at write #{n}");
+            }
+            self.inner.write_tile(tile)
+        }
+        fn finish(&self) -> Result<(), SinkError> {
+            self.inner.finish()
+        }
+        fn inner_sink(&self) -> Option<&dyn TileSink> {
+            Some(&self.inner)
+        }
+    }
+
+    // Resume determinism under concurrency: a run that crashes partway and is
+    // then resumed at tile_concurrency 4 must land a pyramid byte-identical
+    // to a single clean run. Only the checkpoint header and segment log (pure
+    // resume bookkeeping) may differ; everything else, including the absence
+    // of stray lock or temp files, is compared byte for byte.
+    #[test]
+    fn crash_and_resume_at_concurrency_four_matches_a_clean_run_byte_for_byte() {
+        let source = gradient_source(96, 64);
+        let plan = PyramidPlanner::new(96, 64, 32, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+        let config = EngineConfig::default().with_concurrency(4);
+
+        // Clean single-run reference.
+        let ref_dir = tempfile::tempdir().unwrap();
+        let ref_base = ref_dir.path().join("pyramid");
+        let ref_sink = FsSink::new(ref_base.clone(), plan.clone()).with_format(TileFormat::Png);
+        EngineBuilder::new(&source, plan.clone(), ref_sink)
+            .with_engine(EngineKind::Monolithic)
+            .with_config(config.clone())
+            .run()
+            .expect("clean reference run succeeds");
+
+        // Crashing first run: panic partway through, with per-tile checkpoint
+        // flushes so the resume genuinely skips prior work instead of
+        // re-rendering everything.
+        let crash_dir = tempfile::tempdir().unwrap();
+        let crash_base = crash_dir.path().join("pyramid");
+        let panic_at = (plan.total_tile_count() as usize / 3).max(2);
+        let panicking = PanickingSink {
+            inner: FsSink::new(crash_base.clone(), plan.clone()).with_format(TileFormat::Png),
+            panic_at,
+            writes: AtomicUsize::new(0),
+        };
+        let first_run = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            EngineBuilder::new(&source, plan.clone(), &panicking)
+                .with_engine(EngineKind::Monolithic)
+                .with_config(config.clone())
+                .with_resume(ResumePolicy::resume().with_checkpoint_every(1))
+                .run()
+        }));
+        assert!(first_run.is_err(), "the first run must crash mid-pyramid");
+
+        // Resume into the same directory.
+        let resume_sink =
+            FsSink::new(crash_base.clone(), plan.clone()).with_format(TileFormat::Png);
+        EngineBuilder::new(&source, plan.clone(), resume_sink)
+            .with_engine(EngineKind::Monolithic)
+            .with_config(config.clone())
+            .with_resume(ResumePolicy::resume().with_checkpoint_every(1))
+            .run()
+            .expect("the resume run completes the pyramid");
+
+        // Byte-compare the two trees, ignoring only the resume bookkeeping
+        // files. A leftover `.libviprs-job.lock` (or a stray temp file) shows
+        // up as a set mismatch and fails the assertion.
+        let bookkeeping = [
+            std::ffi::OsStr::new(crate::resume::CHECKPOINT_FILENAME),
+            std::ffi::OsStr::new(crate::resume::SEGMENTS_FILENAME),
+        ];
+        let keep =
+            |p: &PathBuf| -> bool { !bookkeeping.contains(&p.file_name().unwrap_or_default()) };
+        let ref_files: Vec<PathBuf> = list_files(&ref_base).into_iter().filter(keep).collect();
+        let crash_files: Vec<PathBuf> = list_files(&crash_base).into_iter().filter(keep).collect();
+        assert_eq!(
+            ref_files, crash_files,
+            "crash+resume must produce exactly the clean run's file set"
+        );
+        for rel in &ref_files {
+            let a = std::fs::read(ref_base.join(rel)).unwrap();
+            let b = std::fs::read(crash_base.join(rel)).unwrap();
+            assert_eq!(
+                a,
+                b,
+                "crash+resume diverges from the clean run at {}",
+                rel.display()
+            );
+        }
     }
 }
 

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -861,6 +861,13 @@ pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
 /// [`std::fs::File::try_lock`]) tied to the open file handle, so the kernel
 /// releases it automatically if the process dies without dropping the guard —
 /// a crashed job never strands a stale lock that would wedge every later run.
+///
+/// Releasing the guard also removes the lock file itself, so a finished (or
+/// refused) run leaves no bookkeeping behind in the output directory: a clean
+/// run and a crash+resume run produce byte-identical trees. The unlink happens
+/// while the exclusive lock is still held, and [`RunLock::acquire`]
+/// revalidates after locking that the path still names the inode it locked,
+/// so the removal cannot let two jobs hold "the" lock at once (see `Drop`).
 #[derive(Debug)]
 #[must_use = "the run lock is released as soon as the guard is dropped"]
 pub struct RunLock {
@@ -891,32 +898,53 @@ impl RunLock {
     /// fail fast telling the user another run owns the directory than silently
     /// queue behind it for an unbounded time.
     ///
-    /// The lock file is opened (creating it if absent) but never truncated, and
-    /// is intentionally left on disk when the guard drops — unlinking it would
-    /// race a concurrent acquirer that has already opened the same path,
-    /// reintroducing the interleaving this lock exists to prevent.
+    /// The lock file is opened (creating it if absent) but never truncated. A
+    /// releasing holder unlinks the file while its lock is still held (see
+    /// `Drop`), so an acquirer may open a doomed inode just before that unlink
+    /// and lock it just after the release. A lock on an orphaned inode
+    /// excludes nobody: after every successful `try_lock` the path is
+    /// therefore revalidated against the locked handle, and on a mismatch the
+    /// stale lock is dropped and the acquisition retried against the fresh
+    /// file.
     pub fn acquire(dir: &Path) -> Result<RunLock, ResumeError> {
         // Ensure the directory exists so a first-ever run can place its lock
         // before the sink has materialised any output.
         std::fs::create_dir_all(dir)?;
         let path = Self::lock_path(dir);
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&path)?;
-        // `File::try_lock` is stable since Rust 1.89; the crate's declared MSRV
-        // is older, so silence the incompatible-MSRV lint at this single call
-        // rather than pulling in a third-party file-locking crate for the same
-        // primitive. Promoting the whole crate to 1.89 is left to the maintainer.
-        #[allow(clippy::incompatible_msrv)]
-        let outcome = file.try_lock();
-        match outcome {
-            Ok(()) => Ok(RunLock { file, path }),
-            Err(std::fs::TryLockError::WouldBlock) => Err(ResumeError::Locked { path }),
-            Err(std::fs::TryLockError::Error(e)) => Err(ResumeError::Io(e)),
+        // Every retry requires another job to have completed a full
+        // acquire-release cycle inside the microsecond window between our
+        // `open` and our `try_lock`, so a handful of attempts is ample. The
+        // bound turns pathological churn into a clean refusal, not a livelock.
+        const MAX_ACQUIRE_ATTEMPTS: usize = 16;
+        for _ in 0..MAX_ACQUIRE_ATTEMPTS {
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&path)?;
+            // `File::try_lock` is stable since Rust 1.89; the crate's declared MSRV
+            // is older, so silence the incompatible-MSRV lint at this single call
+            // rather than pulling in a third-party file-locking crate for the same
+            // primitive. Promoting the whole crate to 1.89 is left to the maintainer.
+            #[allow(clippy::incompatible_msrv)]
+            let outcome = file.try_lock();
+            match outcome {
+                Ok(()) => {
+                    if lock_path_names_handle(&file, &path)? {
+                        return Ok(RunLock { file, path });
+                    }
+                    // The file we locked was unlinked by a releasing holder:
+                    // drop the stale lock (closing `file`) and race for the
+                    // fresh file now at `path`.
+                }
+                Err(std::fs::TryLockError::WouldBlock) => {
+                    return Err(ResumeError::Locked { path });
+                }
+                Err(std::fs::TryLockError::Error(e)) => return Err(ResumeError::Io(e)),
+            }
         }
+        Err(ResumeError::Locked { path })
     }
 
     /// Path of the lock file this guard currently holds.
@@ -925,10 +953,49 @@ impl RunLock {
     }
 }
 
+/// True when `path` still names the same file `locked` has open (same device
+/// and inode). [`RunLock::acquire`] calls this after a successful `try_lock`
+/// to detect that a releasing holder unlinked the lock file between the
+/// acquirer's `open` and its lock.
+#[cfg(unix)]
+fn lock_path_names_handle(locked: &std::fs::File, path: &Path) -> io::Result<bool> {
+    use std::os::unix::fs::MetadataExt;
+    let held = locked.metadata()?;
+    match std::fs::metadata(path) {
+        Ok(on_disk) => Ok(on_disk.dev() == held.dev() && on_disk.ino() == held.ino()),
+        // The path is gone entirely: the locked inode is orphaned.
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+/// Non-Unix fallback: report the handle as current. On these platforms the
+/// release path cannot unlink an open, locked file in the first place (the
+/// `remove_file` in [`RunLock`]'s `Drop` fails and the file persists), so the
+/// stale-inode race this check guards against cannot occur.
+#[cfg(not(unix))]
+fn lock_path_names_handle(_locked: &std::fs::File, _path: &Path) -> io::Result<bool> {
+    Ok(true)
+}
+
 impl Drop for RunLock {
     fn drop(&mut self) {
-        // Best-effort explicit release. The kernel also drops the lock when the
-        // handle closes immediately after, so a failure here is not actionable.
+        // Unlink the lock file, then release the lock. The ordering is
+        // load-bearing: because the unlink happens while the exclusive lock is
+        // still held, the path can never name an inode whose lock has already
+        // been released. A concurrent `acquire` that opened this inode before
+        // the unlink obtains its lock only after the `unlock` below, then
+        // notices the path no longer names its inode and retries against the
+        // fresh file (see `RunLock::acquire`). Removing the file is what keeps
+        // a finished run from leaking bookkeeping into the caller's output
+        // directory, and a refused resume from mutating a directory it
+        // promised not to touch.
+        //
+        // Both calls are best-effort. On platforms where unlinking an open
+        // file fails (Windows), the file persists, which simply restores the
+        // historical leave-it-behind behaviour there; the kernel also drops
+        // the lock when the handle closes immediately after this.
+        let _ = std::fs::remove_file(&self.path);
         // `File::unlock` is stable since Rust 1.89 (see `acquire`).
         #[allow(clippy::incompatible_msrv)]
         let _ = self.file.unlock();
@@ -1592,6 +1659,36 @@ mod tests {
 
         // Releasing the guard frees the directory for the next run.
         drop(held);
+        let reacquired = RunLock::acquire(dir.path()).expect("acquire after release succeeds");
+        drop(reacquired);
+    }
+
+    // A finished (or refused) run must leave the checkpoint root exactly as it
+    // found it, so releasing the guard removes the lock file. The unlink runs
+    // while the exclusive lock is still held and `acquire` revalidates the
+    // path after locking, which keeps the removal safe against a concurrent
+    // acquirer; this test pins the on-disk outcome. Unix-only: on platforms
+    // where unlinking an open file fails, the file is deliberately left
+    // behind.
+    #[cfg(unix)]
+    #[test]
+    #[cfg_attr(miri, ignore)] // file locking unsupported under Miri isolation
+    fn run_lock_release_removes_the_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let held = RunLock::acquire(dir.path()).expect("first acquire succeeds");
+        assert!(
+            RunLock::lock_path(dir.path()).exists(),
+            "the lock file exists while the guard is held"
+        );
+
+        drop(held);
+        assert!(
+            !RunLock::lock_path(dir.path()).exists(),
+            "the lock file must be removed when the guard drops"
+        );
+
+        // The directory is immediately acquirable again after the removal.
         let reacquired = RunLock::acquire(dir.path()).expect("acquire after release succeeds");
         drop(reacquired);
     }


### PR DESCRIPTION
## Summary

Fixes three resume-path bugs pinned by the libviprs-tests suite (`phase3_resume.rs` `resume_mode_refuses_if_plan_hash_differs`, `phase3_validation_stress.rs` `restart_during_level_generation_resume_completes_output` and `restart_during_tile_encode_resume_completes_output`). All three reproduce on main at 0c1caf7 and share one root cause: the advisory run-lock file `.libviprs-job.lock`.

## Root cause

* A `Resume` refused on a plan-hash mismatch acquired the run lock (creating `.libviprs-job.lock` in the output directory) before the checkpoint was even read, so the refusal left a file behind in a directory it promised not to touch.
* `RunLock` deliberately left its lock file on disk when the guard dropped, because a naive unlink races a concurrent acquirer that already opened the same path. As a result every resumable run leaked bookkeeping into the output tree, and a crash+resume run could never be byte-identical to a clean single run.

## Fix

* `EngineBuilder::run_collect` now validates the checkpoint's plan hash and content contract before `RunLock::acquire`, so a mismatched Resume is refused with zero on-disk side effects. The existing check under the lock in `prepare_resume_state` stays authoritative for a checkpoint swapped in between (the preflight reads the same atomically-renamed file, so it never sees a torn header).
* `RunLock` now removes its lock file on drop, using a race-free protocol: the unlink happens while the exclusive lock is still held, and `acquire` revalidates after a successful `try_lock` that the path still names the inode it locked (same dev+ino), retrying against the fresh file otherwise. A lock on an orphaned inode excludes nobody, so this closes the unlink race the old leave-it-behind behaviour existed to avoid. On platforms where unlinking an open file fails (Windows) both calls degrade to the historical behaviour.

## Tests

New in-repo pins (all RED without the fix):

* `refused_plan_hash_mismatch_leaves_the_directory_untouched`: a refused Resume leaves the output directory exactly as found.
* `plan_hash_gate_refuses_before_the_run_lock_is_taken`: with a live lock holder AND a stale checkpoint, the mismatch refusal wins, proving the gate precedes lock acquisition.
* `crash_and_resume_at_concurrency_four_matches_a_clean_run_byte_for_byte`: crash partway (per-tile checkpoint flushes), resume at tile concurrency 4, byte-compare the full tree against a clean run (only the checkpoint header and segment log excluded, so a leftover lock or temp file fails the assertion).
* `run_lock_release_removes_the_lock_file` (unix): dropping the guard removes the file.

Validation: `make fmt`, `make clippy` (default + pdfium, `-D warnings`), `make test` all green; the three external libviprs-tests targets go RED on main and GREEN on this branch; the resume-related external suites (`phase3_resume`, `phase3_validation_stress`, `builder_resume_*`, `no_temp_files`, `pyramid_determinism`) pass. `phase3_tracing::queue_pressure_peak_bounded_by_concurrency` fails identically against pristine main and this branch (pre-existing, unrelated).
