### PR TITLE
feat(core): libvips IO, metadata, free functions, and compositing (imageio + composite modules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Image IO, metadata fields, and library-level free functions ported
+  from libvips (seventh batch of the ported-tests operation surface,
+  libviprs-tests issue #55), in the new `imageio` module:
+  `Raster::save` / `Raster::save_stripped` (extension-dispatched encode
+  to PNG, JPEG, or the native `.v` container, with `save_stripped`
+  writing pixels only), `Raster::encode_vips`, the named metadata field
+  system (`get_field` / `set_field` / `try_set_field` / `get_fields` /
+  `get_typeof` / `set_typeof` over the new `MetadataValue` enum, with
+  the built-in header fields reading through to the raster header),
+  `Raster::set_icc_profile` / `Raster::icc_profile`, and the free
+  functions `tokenize`, `parse_thumbnail_geometry` (returning the new
+  `ThumbnailGeometry`), `get_max_coord` / `set_max_coord`, and
+  `init_from_env` (re-exported at the crate root, where the ported
+  tests import them). JPEG save embeds the `icc-profile-data` and raw
+  `exif-data` blobs as APP2/APP1 segments and the decoder captures them
+  back; `.v` files round-trip the full header (both byte orders) plus
+  every attached field, and reject unsupported band formats (float `.v`
+  arrives with the float-format batch) and header geometry past the
+  `max_coord` ceiling. `decode_file` now also records the source path
+  in the `filename` field. Structured EXIF tag encoding (`exif-ifd*-*`
+  into the JPEG APP1 TIFF directory) and PNG iCCP embedding are
+  deferred to the foreign-format batch.
+- Porter-Duff and PDF blend-mode compositing ported from libvips, in
+  the new `composite` module: `Raster::composite` /
+  `Raster::composite2` with the typed `try_composite2` form
+  (`CompositeError`) and the `CompositeMode` enum covering the full
+  libvips `VipsBlendMode` set (Clear through Exclusion) plus the four
+  PDF non-separable modes (Hue, Saturation, Colour, Luminosity) the
+  ported conversion suite exercises. Inputs blend premultiplied in
+  `f64` on the libvips `max_alpha` scale (255 unless both inputs are
+  16-bit) and write back at the deeper input's depth, so every mode is
+  exact to the output quantisation with no float `PixelFormat`
+  required.
 - Band operations ported from libvips (first batch of the ported-tests
   operation surface, libviprs-tests issue #55), in the new `bands` module:
   `bandjoin`, `bandjoin_const`, `bandjoin_vec`, `bandfold`, `bandunfold`,

--- a/src/composite.rs
+++ b/src/composite.rs
@@ -1,0 +1,1061 @@
+//! Alpha compositing ported from libvips (`vips_composite2`).
+//!
+//! This module is the seventh batch of the libvips operation surface
+//! required by the ported integration tests (after [`crate::bands`],
+//! [`crate::arithmetic`], [`crate::extract`], [`crate::conversion`],
+//! [`crate::draw`], and [`crate::histogram`]): Porter-Duff compositing and
+//! the PDF blend modes, both the separable set (`multiply`, `screen`, ...)
+//! and the non-separable set (`hue`, `saturation`, `colour`,
+//! `luminosity`). Following the established convention the operation
+//! exists in two forms:
+//!
+//! * a fallible [`Raster::try_composite2`] returning
+//!   `Result<Raster, CompositeError>` with typed errors for mismatched
+//!   geometry and band counts; and
+//! * the panicking conveniences [`Raster::composite`] /
+//!   [`Raster::composite2`] matching the ported-test call surface
+//!   (`base.composite(&overlay, CompositeMode::Over)`) exactly, delegating
+//!   to the `try_` form.
+//!
+//! # Semantics
+//!
+//! `base.composite2(&overlay, mode)` composites `overlay` (the source in
+//! Porter-Duff terms) onto `base` (the backdrop), exactly as
+//! `vips_composite2(base, overlay, mode)`.
+//!
+//! * **Alpha.** An input with 2 or 4 bands treats its last band as alpha;
+//!   1- and 3-band inputs are opaque, matching how libvips detects alpha
+//!   in `composite`. The output always carries alpha: 1 colour band
+//!   composites to a 2-band grey+alpha raster
+//!   ([`PixelFormat::Multi8`]`(2)` / `Multi16(2)`), 3 colour bands to
+//!   RGBA.
+//! * **Bands.** Both inputs must have the same number of colour
+//!   (non-alpha) bands, either 1 or 3. The non-separable modes
+//!   ([`CompositeMode::Hue`], [`CompositeMode::Saturation`],
+//!   [`CompositeMode::Colour`], [`CompositeMode::Luminosity`]) operate on
+//!   RGB triples per the PDF specification and require 3 colour bands.
+//! * **Depth and scale.** The output container is the deeper of the two
+//!   inputs. Samples are normalised by the libvips `max_alpha`
+//!   resolution: 255 unless *both* inputs are 16-bit, then 65535
+//!   (`vips_composite`'s `max_alpha` parameter defaults to 255, with
+//!   65535 the documented choice for ushort pipelines). A mixed-depth
+//!   pair therefore reads its 16-bit side on the 0..255 numeric scale,
+//!   which is exactly the shape the crate's promoted 16-bit
+//!   intermediates carry (`add_const`, `linear`, ... promote 8-bit
+//!   numerically, standing in for libvips float images, whose
+//!   `max_alpha` is also 255). Alphas clamp to `0..1`; colour values
+//!   pass through the Porter-Duff arithmetic unclamped (numeric values
+//!   above the scale survive, as in libvips float) and clamp to `0..1`
+//!   only where the PDF blend functions require it. Results are blended
+//!   premultiplied in `f64`, unpremultiplied, and written back on the
+//!   same numeric scale with round-to-nearest and clamping to the
+//!   container range. Every mode is therefore exact to the output
+//!   quantisation; none of the blend modes is blocked on a float
+//!   `PixelFormat`. (The ported non-separable test additionally *casts
+//!   its inputs* to a float format before compositing; that cast target
+//!   arrives with the float-format batch and is independent of this
+//!   operation.)
+//! * **Metadata.** The result carries the base image's metadata
+//!   (interpretation, resolution, offsets, orientation, and attached
+//!   fields), like libvips which copies the header from the first input.
+//!
+//! # Blend mode table
+//!
+//! | Modes | Family |
+//! |---|---|
+//! | `Clear`, `Source`, `Over`, `In`, `Out`, `Atop`, `Dest`, `DestOver`, `DestIn`, `DestOut`, `DestAtop`, `Xor`, `Add`, `Saturate` | Porter-Duff |
+//! | `Multiply`, `Screen`, `Overlay`, `Darken`, `Lighten`, `ColourDodge`, `ColourBurn`, `HardLight`, `SoftLight`, `Difference`, `Exclusion` | PDF separable |
+//! | `Hue`, `Saturation`, `Colour`, `Luminosity` | PDF non-separable |
+//!
+//! The Porter-Duff and separable set matches libvips `VipsBlendMode`
+//! one-to-one; the four non-separable modes extend it (libvips stops at
+//! `exclusion`) because the ported conversion suite exercises them.
+
+use crate::pixel::PixelFormat;
+use crate::raster::{Raster, RasterError};
+use thiserror::Error;
+
+/// A compositing operator for [`Raster::composite2`]: the Porter-Duff
+/// operators plus the PDF separable and non-separable blend modes
+/// (libvips `VipsBlendMode`, extended with the non-separable four).
+///
+/// In every description below the *source* is the overlay argument and
+/// the *backdrop* is the base image the method is called on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CompositeMode {
+    /// Both source and backdrop are discarded; the result is fully
+    /// transparent black.
+    Clear,
+    /// The source only; the backdrop is discarded.
+    Source,
+    /// The source over the backdrop (the classic alpha blend).
+    Over,
+    /// The part of the source inside the backdrop; backdrop discarded.
+    In,
+    /// The part of the source outside the backdrop; backdrop discarded.
+    Out,
+    /// The source where the backdrop is opaque, backdrop elsewhere.
+    Atop,
+    /// The backdrop only; the source is discarded.
+    Dest,
+    /// The backdrop over the source.
+    DestOver,
+    /// The part of the backdrop inside the source; source discarded.
+    DestIn,
+    /// The part of the backdrop outside the source; source discarded.
+    DestOut,
+    /// The backdrop where the source is opaque, source elsewhere.
+    DestAtop,
+    /// Source and backdrop where they do not overlap.
+    Xor,
+    /// Source plus backdrop, clamped (additive blend).
+    Add,
+    /// Source limited to the transparency left by the backdrop, plus the
+    /// backdrop (Porter-Duff saturate).
+    Saturate,
+    /// PDF multiply: darkens by multiplying backdrop and source.
+    Multiply,
+    /// PDF screen: brightens by inverse-multiplying.
+    Screen,
+    /// PDF overlay: multiply or screen depending on the backdrop.
+    Overlay,
+    /// PDF darken: per-channel minimum.
+    Darken,
+    /// PDF lighten: per-channel maximum.
+    Lighten,
+    /// PDF colour dodge: brightens the backdrop toward the source.
+    ColourDodge,
+    /// PDF colour burn: darkens the backdrop toward the source.
+    ColourBurn,
+    /// PDF hard light: multiply or screen depending on the source.
+    HardLight,
+    /// PDF soft light: a softened hard light.
+    SoftLight,
+    /// PDF difference: absolute per-channel difference.
+    Difference,
+    /// PDF exclusion: a lower-contrast difference.
+    Exclusion,
+    /// PDF hue (non-separable): source hue with backdrop saturation and
+    /// luminosity.
+    Hue,
+    /// PDF saturation (non-separable): source saturation with backdrop
+    /// hue and luminosity.
+    Saturation,
+    /// PDF colour (non-separable): source hue and saturation with
+    /// backdrop luminosity.
+    Colour,
+    /// PDF luminosity (non-separable): source luminosity with backdrop
+    /// hue and saturation.
+    Luminosity,
+}
+
+impl CompositeMode {
+    /// Whether this is one of the four PDF non-separable modes, which
+    /// blend RGB triples rather than independent channels.
+    fn is_non_separable(self) -> bool {
+        matches!(
+            self,
+            Self::Hue | Self::Saturation | Self::Colour | Self::Luminosity
+        )
+    }
+
+    /// Whether this is a PDF blend mode (separable or non-separable)
+    /// rather than a plain Porter-Duff operator.
+    fn is_pdf_blend(self) -> bool {
+        !matches!(
+            self,
+            Self::Clear
+                | Self::Source
+                | Self::Over
+                | Self::In
+                | Self::Out
+                | Self::Atop
+                | Self::Dest
+                | Self::DestOver
+                | Self::DestIn
+                | Self::DestOut
+                | Self::DestAtop
+                | Self::Xor
+                | Self::Add
+                | Self::Saturate
+        )
+    }
+}
+
+/// Errors from [`Raster::try_composite2`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CompositeError {
+    #[error(
+        "composite: images differ in size: base {base_w}x{base_h}, overlay {overlay_w}x{overlay_h}"
+    )]
+    DimensionMismatch {
+        base_w: u32,
+        base_h: u32,
+        overlay_w: u32,
+        overlay_h: u32,
+    },
+    #[error(
+        "composite: images differ in colour band count: base has {base}, overlay has {overlay}"
+    )]
+    BandMismatch { base: usize, overlay: usize },
+    #[error(
+        "composite: {bands} bands unsupported; inputs must have 1 or 3 colour bands (plus optional alpha)"
+    )]
+    TooManyBands { bands: usize },
+    #[error(
+        "composite: non-separable mode {mode:?} needs 3 colour bands (RGB), input has {colour_bands}"
+    )]
+    NonSeparableNeedsRgb {
+        mode: CompositeMode,
+        colour_bands: usize,
+    },
+    #[error("composite: raster error: {0}")]
+    Raster(#[from] RasterError),
+}
+
+/// Unwrap a composite result, panicking with the operation name.
+#[track_caller]
+fn expect_composite(r: Result<Raster, CompositeError>) -> Raster {
+    match r {
+        Ok(v) => v,
+        Err(e) => panic!("composite: {e}"),
+    }
+}
+
+/// Colour band count and alpha presence for a composite input: bands 2
+/// and 4 carry alpha in the last band, 1 and 3 are opaque.
+fn colour_bands(format: PixelFormat) -> Result<(usize, bool), CompositeError> {
+    match format.channels() {
+        1 => Ok((1, false)),
+        2 => Ok((1, true)),
+        3 => Ok((3, false)),
+        4 => Ok((3, true)),
+        bands => Err(CompositeError::TooManyBands { bands }),
+    }
+}
+
+/// Read the flat `i`-th raw sample (not yet normalised: the caller
+/// divides by the working-depth maximum, so mixed-depth inputs share one
+/// scale, matching a value-preserving `vips_cast`).
+#[inline]
+fn read_raw(data: &[u8], bpc: usize, i: usize) -> f64 {
+    if bpc == 1 {
+        data[i] as f64
+    } else {
+        u16::from_ne_bytes([data[2 * i], data[2 * i + 1]]) as f64
+    }
+}
+
+/// Write a scale-normalised sample at the given depth: the value is
+/// multiplied back onto its numeric scale, rounded to nearest, and
+/// clamped to the container range.
+#[inline]
+fn write_scaled(data: &mut [u8], bpc: usize, i: usize, v: f64, scale: f64) {
+    if bpc == 1 {
+        data[i] = (v * scale).round().clamp(0.0, 255.0) as u8;
+    } else {
+        let b = ((v * scale).round().clamp(0.0, 65535.0) as u16).to_ne_bytes();
+        data[2 * i] = b[0];
+        data[2 * i + 1] = b[1];
+    }
+}
+
+/// Porter-Duff source/backdrop factors for the given source (`sa`) and
+/// backdrop (`ba`) alphas. Returns `None` for the PDF blend modes, which
+/// use the blend formula instead.
+fn porter_duff_factors(mode: CompositeMode, sa: f64, ba: f64) -> Option<(f64, f64)> {
+    Some(match mode {
+        CompositeMode::Clear => (0.0, 0.0),
+        CompositeMode::Source => (1.0, 0.0),
+        CompositeMode::Over => (1.0, 1.0 - sa),
+        CompositeMode::In => (ba, 0.0),
+        CompositeMode::Out => (1.0 - ba, 0.0),
+        CompositeMode::Atop => (ba, 1.0 - sa),
+        CompositeMode::Dest => (0.0, 1.0),
+        CompositeMode::DestOver => (1.0 - ba, 1.0),
+        CompositeMode::DestIn => (0.0, sa),
+        CompositeMode::DestOut => (0.0, 1.0 - sa),
+        CompositeMode::DestAtop => (1.0 - ba, sa),
+        CompositeMode::Xor => (1.0 - ba, 1.0 - sa),
+        CompositeMode::Add => (1.0, 1.0),
+        CompositeMode::Saturate => {
+            let fa = if sa > 0.0 {
+                (1.0 - ba).min(sa) / sa
+            } else {
+                0.0
+            };
+            (fa, 1.0)
+        }
+        _ => return None,
+    })
+}
+
+/// The PDF separable blend function `B(cb, cs)` on unpremultiplied
+/// channel values in `0..=1`.
+fn separable_blend(mode: CompositeMode, cb: f64, cs: f64) -> f64 {
+    match mode {
+        CompositeMode::Multiply => cb * cs,
+        CompositeMode::Screen => cb + cs - cb * cs,
+        CompositeMode::Overlay => separable_blend(CompositeMode::HardLight, cs, cb),
+        CompositeMode::Darken => cb.min(cs),
+        CompositeMode::Lighten => cb.max(cs),
+        CompositeMode::ColourDodge => {
+            if cb <= 0.0 {
+                0.0
+            } else if cs >= 1.0 {
+                1.0
+            } else {
+                (cb / (1.0 - cs)).min(1.0)
+            }
+        }
+        CompositeMode::ColourBurn => {
+            if cb >= 1.0 {
+                1.0
+            } else if cs <= 0.0 {
+                0.0
+            } else {
+                1.0 - ((1.0 - cb) / cs).min(1.0)
+            }
+        }
+        CompositeMode::HardLight => {
+            if cs <= 0.5 {
+                2.0 * cs * cb
+            } else {
+                1.0 - 2.0 * (1.0 - cs) * (1.0 - cb)
+            }
+        }
+        CompositeMode::SoftLight => {
+            if cs <= 0.5 {
+                cb - (1.0 - 2.0 * cs) * cb * (1.0 - cb)
+            } else {
+                let d = if cb <= 0.25 {
+                    ((16.0 * cb - 12.0) * cb + 4.0) * cb
+                } else {
+                    cb.sqrt()
+                };
+                cb + (2.0 * cs - 1.0) * (d - cb)
+            }
+        }
+        CompositeMode::Difference => (cb - cs).abs(),
+        CompositeMode::Exclusion => cb + cs - 2.0 * cb * cs,
+        _ => unreachable!("separable_blend called with non-blend mode {mode:?}"),
+    }
+}
+
+/// PDF luminosity of an RGB triple (the Rec. 601-style weights the PDF
+/// specification and libvips' non-separable helpers use).
+fn lum(c: [f64; 3]) -> f64 {
+    0.3 * c[0] + 0.59 * c[1] + 0.11 * c[2]
+}
+
+/// PDF `ClipColor`: pull out-of-range channels back toward the
+/// luminosity so the triple stays within `0..=1`.
+fn clip_colour(mut c: [f64; 3]) -> [f64; 3] {
+    let l = lum(c);
+    let n = c[0].min(c[1]).min(c[2]);
+    let x = c[0].max(c[1]).max(c[2]);
+    if n < 0.0 {
+        for v in &mut c {
+            *v = l + (*v - l) * l / (l - n);
+        }
+    }
+    if x > 1.0 {
+        for v in &mut c {
+            *v = l + (*v - l) * (1.0 - l) / (x - l);
+        }
+    }
+    c
+}
+
+/// PDF `SetLum`: shift the triple to the target luminosity, clipping.
+fn set_lum(mut c: [f64; 3], l: f64) -> [f64; 3] {
+    let d = l - lum(c);
+    for v in &mut c {
+        *v += d;
+    }
+    clip_colour(c)
+}
+
+/// PDF `Sat`: saturation (max minus min) of a triple.
+fn sat(c: [f64; 3]) -> f64 {
+    c[0].max(c[1]).max(c[2]) - c[0].min(c[1]).min(c[2])
+}
+
+/// PDF `SetSat`: rescale the triple to the target saturation, keeping
+/// the channel order and zeroing the minimum.
+fn set_sat(c: [f64; 3], s: f64) -> [f64; 3] {
+    // Rank the channel indices: min, mid, max.
+    let mut idx = [0usize, 1, 2];
+    idx.sort_by(|&a, &b| c[a].partial_cmp(&c[b]).unwrap_or(std::cmp::Ordering::Equal));
+    let (imin, imid, imax) = (idx[0], idx[1], idx[2]);
+    let mut out = [0.0; 3];
+    if c[imax] > c[imin] {
+        out[imid] = (c[imid] - c[imin]) * s / (c[imax] - c[imin]);
+        out[imax] = s;
+    }
+    out
+}
+
+/// The PDF non-separable blend function on unpremultiplied RGB triples.
+fn non_separable_blend(mode: CompositeMode, cb: [f64; 3], cs: [f64; 3]) -> [f64; 3] {
+    match mode {
+        CompositeMode::Hue => set_lum(set_sat(cs, sat(cb)), lum(cb)),
+        CompositeMode::Saturation => set_lum(set_sat(cb, sat(cs)), lum(cb)),
+        CompositeMode::Colour => set_lum(cs, lum(cb)),
+        CompositeMode::Luminosity => set_lum(cb, lum(cs)),
+        _ => unreachable!("non_separable_blend called with separable mode {mode:?}"),
+    }
+}
+
+impl Raster {
+    /// Fallible form of [`Raster::composite2`].
+    ///
+    /// # Errors
+    ///
+    /// [`CompositeError::DimensionMismatch`] if the images differ in
+    /// size, [`CompositeError::TooManyBands`] if an input has more than 4
+    /// bands, [`CompositeError::BandMismatch`] if the colour band counts
+    /// differ, [`CompositeError::NonSeparableNeedsRgb`] if a
+    /// non-separable mode is used on non-RGB input, or
+    /// [`CompositeError::Raster`] on allocation failure.
+    pub fn try_composite2(
+        &self,
+        overlay: &Raster,
+        mode: CompositeMode,
+    ) -> Result<Raster, CompositeError> {
+        if self.width() != overlay.width() || self.height() != overlay.height() {
+            return Err(CompositeError::DimensionMismatch {
+                base_w: self.width(),
+                base_h: self.height(),
+                overlay_w: overlay.width(),
+                overlay_h: overlay.height(),
+            });
+        }
+        let (colour, base_alpha) = colour_bands(self.format())?;
+        let (overlay_colour, overlay_alpha) = colour_bands(overlay.format())?;
+        if colour != overlay_colour {
+            return Err(CompositeError::BandMismatch {
+                base: colour,
+                overlay: overlay_colour,
+            });
+        }
+        if mode.is_non_separable() && colour != 3 {
+            return Err(CompositeError::NonSeparableNeedsRgb {
+                mode,
+                colour_bands: colour,
+            });
+        }
+
+        // Output container: the deeper input. Normalisation scale: the
+        // libvips max_alpha resolution (255 by default, 65535 only for a
+        // fully 16-bit pipeline); see the module docs.
+        let base_bpc = self.format().bytes_per_channel();
+        let overlay_bpc = overlay.format().bytes_per_channel();
+        let out_bpc = base_bpc.max(overlay_bpc);
+        let scale = if base_bpc == 2 && overlay_bpc == 2 {
+            65535.0
+        } else {
+            255.0
+        };
+        let inv_max = 1.0 / scale;
+
+        let out_format = PixelFormat::with_channels(colour + 1, out_bpc)
+            .expect("colour+1 is 2 or 4, always representable");
+        let mut out = Raster::zeroed(self.width(), self.height(), out_format)?;
+
+        let base_ch = self.format().channels();
+        let overlay_ch = overlay.format().channels();
+        let out_ch = colour + 1;
+        let bdata = self.data();
+        let sdata = overlay.data();
+        let pixels = self.width() as usize * self.height() as usize;
+        let odata = out.data_mut();
+
+        let pdf_blend = mode.is_pdf_blend();
+        let non_separable = mode.is_non_separable();
+
+        let mut cb = [0.0f64; 3];
+        let mut cs = [0.0f64; 3];
+        for p in 0..pixels {
+            // Unpremultiplied colour values and alphas, 0..1.
+            for k in 0..colour {
+                cb[k] = read_raw(bdata, base_bpc, p * base_ch + k) * inv_max;
+                cs[k] = read_raw(sdata, overlay_bpc, p * overlay_ch + k) * inv_max;
+            }
+            // Alphas are semantically 0..1; clamp in case a genuinely
+            // 16-bit alpha meets the mixed-depth 255 scale.
+            let ba = if base_alpha {
+                (read_raw(bdata, base_bpc, p * base_ch + colour) * inv_max).clamp(0.0, 1.0)
+            } else {
+                1.0
+            };
+            let sa = if overlay_alpha {
+                (read_raw(sdata, overlay_bpc, p * overlay_ch + colour) * inv_max).clamp(0.0, 1.0)
+            } else {
+                1.0
+            };
+
+            let (co, ao) = if pdf_blend {
+                // PDF blend formula: the source colour is mixed with
+                // B(cb, cs) by the backdrop alpha, then composited Over.
+                let ao = sa + ba * (1.0 - sa);
+                let mut co = [0.0f64; 3];
+                // The PDF blend functions B(cb, cs) are defined on 0..1;
+                // clamp their inputs (the linear mixing terms keep the
+                // unclamped values).
+                let c1 = |v: f64| v.clamp(0.0, 1.0);
+                if non_separable {
+                    let b = non_separable_blend(
+                        mode,
+                        [c1(cb[0]), c1(cb[1]), c1(cb[2])],
+                        [c1(cs[0]), c1(cs[1]), c1(cs[2])],
+                    );
+                    for k in 0..colour {
+                        co[k] = sa * (1.0 - ba) * cs[k] + ba * (1.0 - sa) * cb[k] + sa * ba * b[k];
+                    }
+                } else {
+                    for k in 0..colour {
+                        co[k] = sa * (1.0 - ba) * cs[k]
+                            + ba * (1.0 - sa) * cb[k]
+                            + sa * ba * separable_blend(mode, c1(cb[k]), c1(cs[k]));
+                    }
+                }
+                (co, ao)
+            } else {
+                let (fa, fb) =
+                    porter_duff_factors(mode, sa, ba).expect("porter-duff mode verified");
+                let mut co = [0.0f64; 3];
+                for k in 0..colour {
+                    co[k] = fa * sa * cs[k] + fb * ba * cb[k];
+                }
+                // Add can push the alpha past 1; clamp like VIPS_BLEND_ADD.
+                let ao = (fa * sa + fb * ba).min(1.0);
+                (co, ao)
+            };
+
+            // Unpremultiply and write back on the numeric scale.
+            for (k, &c_premul) in co.iter().enumerate().take(colour) {
+                let c = if ao > 0.0 { c_premul / ao } else { 0.0 };
+                write_scaled(odata, out_bpc, p * out_ch + k, c, scale);
+            }
+            write_scaled(odata, out_bpc, p * out_ch + colour, ao, scale);
+        }
+
+        out.meta = self.meta;
+        out.fields = self.fields.clone();
+        Ok(out)
+    }
+
+    /// Composite `overlay` onto `self` with the given blend mode
+    /// (libvips `vips_composite2`); see the [module docs](crate::composite)
+    /// for alpha, band, and depth semantics. Panicking form of
+    /// [`Raster::try_composite2`], matching the ported-test call surface.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`CompositeError`]; see [`Raster::try_composite2`].
+    #[track_caller]
+    pub fn composite(&self, overlay: &Raster, mode: CompositeMode) -> Raster {
+        expect_composite(self.try_composite2(overlay, mode))
+    }
+
+    /// Alias of [`Raster::composite`], named after the binary libvips
+    /// operation (`vips_composite2`).
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`CompositeError`]; see [`Raster::try_composite2`].
+    #[track_caller]
+    pub fn composite2(&self, overlay: &Raster, mode: CompositeMode) -> Raster {
+        expect_composite(self.try_composite2(overlay, mode))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 2x1 RGB base: left pixel [100, 100, 100], right [200, 50, 0].
+    fn base_rgb() -> Raster {
+        Raster::new(2, 1, PixelFormat::Rgb8, vec![100, 100, 100, 200, 50, 0]).unwrap()
+    }
+
+    /// A 2x1 RGBA overlay: left [255, 0, 0, 128], right [0, 255, 0, 255].
+    fn overlay_rgba() -> Raster {
+        Raster::new(
+            2,
+            1,
+            PixelFormat::Rgba8,
+            vec![255, 0, 0, 128, 0, 255, 0, 255],
+        )
+        .unwrap()
+    }
+
+    /**
+     * Tests the classic Over blend against hand-computed values.
+     * Works by compositing a half-transparent red overlay over an opaque
+     * grey base and checking the blend arithmetic per channel.
+     * Input: base [100,100,100] opaque, overlay [255,0,0] alpha 128.
+     * Output: c = 255*a + 100*(1-a), a = 128/255 -> [177.8, 49.8, 49.8, 255].
+     */
+    #[test]
+    fn over_blends_half_transparent_overlay() {
+        let out = base_rgb().composite(&overlay_rgba(), CompositeMode::Over);
+        assert_eq!(out.format(), PixelFormat::Rgba8);
+        let px = out.getpoint(0, 0);
+        let a = 128.0 / 255.0;
+        let want_r = 255.0 * a + 100.0 * (1.0 - a);
+        let want_gb = 100.0 * (1.0 - a);
+        assert!((px[0] - want_r).abs() <= 1.0, "r: {px:?}");
+        assert!((px[1] - want_gb).abs() <= 1.0, "g: {px:?}");
+        assert!((px[2] - want_gb).abs() <= 1.0, "b: {px:?}");
+        assert_eq!(px[3], 255.0);
+
+        // A fully opaque overlay replaces the base outright.
+        let px = out.getpoint(1, 0);
+        assert_eq!(&px[..3], &[0.0, 255.0, 0.0]);
+    }
+
+    /**
+     * Tests the ported test_composite arithmetic on the libvips fixture
+     * values. In the libvips suite the (0,0) pixel of `colour` is
+     * [2, 3, 4]; base = colour + 100, overlay = colour with alpha 128,
+     * and Over must produce [51.8, 52.8, 53.8, 255] within 1.
+     * Input: base [102,103,104], overlay [2,3,4,128].
+     * Output: getpoint(0,0) ~ [51.8, 52.8, 53.8, 255].
+     */
+    #[test]
+    fn over_matches_ported_expected_values() {
+        let base = Raster::new(1, 1, PixelFormat::Rgb8, vec![102, 103, 104]).unwrap();
+        let overlay = Raster::new(1, 1, PixelFormat::Rgba8, vec![2, 3, 4, 128]).unwrap();
+        let comp = base.composite(&overlay, CompositeMode::Over);
+        let px = comp.getpoint(0, 0);
+        assert!((px[0] - 51.8).abs() < 1.0, "{px:?}");
+        assert!((px[1] - 52.8).abs() < 1.0, "{px:?}");
+        assert!((px[2] - 53.8).abs() < 1.0, "{px:?}");
+        assert!((px[3] - 255.0).abs() < 0.5, "{px:?}");
+    }
+
+    /**
+     * Tests every Porter-Duff operator's alpha result on a transparent/
+     * opaque corner case. Works by compositing a half-transparent source
+     * over a half-transparent backdrop and checking the composite alpha
+     * formula fa*sa + fb*ba for each mode.
+     * Input: sa = ba = 0.5 everywhere.
+     * Output: mode-specific alpha (e.g. Over 0.75, Xor 0.5, Clear 0).
+     */
+    #[test]
+    fn porter_duff_alpha_formulas() {
+        let base = Raster::new(1, 1, PixelFormat::Rgba8, vec![80, 80, 80, 128]).unwrap();
+        let overlay = Raster::new(1, 1, PixelFormat::Rgba8, vec![160, 160, 160, 128]).unwrap();
+        let a = 128.0 / 255.0;
+        let cases: &[(CompositeMode, f64)] = &[
+            (CompositeMode::Clear, 0.0),
+            (CompositeMode::Source, a),
+            (CompositeMode::Over, a + a * (1.0 - a)),
+            (CompositeMode::In, a * a),
+            (CompositeMode::Out, a * (1.0 - a)),
+            (CompositeMode::Atop, a),
+            (CompositeMode::Dest, a),
+            (CompositeMode::DestOver, a + a * (1.0 - a)),
+            (CompositeMode::DestIn, a * a),
+            (CompositeMode::DestOut, a * (1.0 - a)),
+            (CompositeMode::DestAtop, a),
+            (CompositeMode::Xor, 2.0 * a * (1.0 - a)),
+            (CompositeMode::Add, 1.0),
+            (CompositeMode::Saturate, 1.0),
+        ];
+        for &(mode, want) in cases {
+            let out = base.composite(&overlay, mode);
+            let got = out.getpoint(0, 0)[3] / 255.0;
+            assert!((got - want).abs() < 0.01, "{mode:?}: alpha {got} != {want}");
+        }
+    }
+
+    /**
+     * Tests that Dest returns the base pixels and Source the overlay
+     * pixels, both with alpha attached.
+     * Works by compositing opaque RGB inputs and comparing the colour
+     * bands to the untouched inputs.
+     * Input: base [100,100,100]/[200,50,0], overlay [255,0,0,128]/[0,255,0,255].
+     */
+    #[test]
+    fn dest_and_source_pass_through() {
+        let base = base_rgb();
+        let overlay = overlay_rgba();
+
+        let dest = base.composite(&overlay, CompositeMode::Dest);
+        assert_eq!(&dest.getpoint(0, 0)[..3], &[100.0, 100.0, 100.0]);
+        assert_eq!(dest.getpoint(0, 0)[3], 255.0);
+        assert_eq!(&dest.getpoint(1, 0)[..3], &[200.0, 50.0, 0.0]);
+
+        let source = base.composite(&overlay, CompositeMode::Source);
+        // Unpremultiplied source colour is returned with its own alpha.
+        assert_eq!(&source.getpoint(0, 0)[..3], &[255.0, 0.0, 0.0]);
+        assert_eq!(source.getpoint(0, 0)[3], 128.0);
+    }
+
+    /**
+     * Tests the separable PDF blend functions on opaque inputs, where the
+     * result is exactly B(cb, cs) per channel.
+     * Works by compositing opaque single-value images and checking the
+     * blend function output for each separable mode.
+     * Input: cb = 0.4 (102), cs = 0.8 (204), all channels.
+     */
+    #[test]
+    fn separable_blends_on_opaque_inputs() {
+        let base = Raster::new(1, 1, PixelFormat::Rgb8, vec![102, 102, 102]).unwrap();
+        let overlay = Raster::new(1, 1, PixelFormat::Rgb8, vec![204, 204, 204]).unwrap();
+        let cb = 102.0 / 255.0;
+        let cs = 204.0 / 255.0;
+        let cases: &[(CompositeMode, f64)] = &[
+            (CompositeMode::Multiply, cb * cs),
+            (CompositeMode::Screen, cb + cs - cb * cs),
+            (CompositeMode::Darken, cb.min(cs)),
+            (CompositeMode::Lighten, cb.max(cs)),
+            (CompositeMode::Difference, (cb - cs).abs()),
+            (CompositeMode::Exclusion, cb + cs - 2.0 * cb * cs),
+            // cs > 0.5: hard light = 1 - 2(1-cs)(1-cb)
+            (
+                CompositeMode::HardLight,
+                1.0 - 2.0 * (1.0 - cs) * (1.0 - cb),
+            ),
+            // cb < 0.5: overlay = 2*cb*cs
+            (CompositeMode::Overlay, 2.0 * cb * cs),
+            (CompositeMode::ColourDodge, (cb / (1.0 - cs)).min(1.0)),
+            (CompositeMode::ColourBurn, 1.0 - ((1.0 - cb) / cs).min(1.0)),
+        ];
+        for &(mode, want) in cases {
+            let out = base.composite(&overlay, mode);
+            let got = out.getpoint(0, 0)[0] / 255.0;
+            assert!((got - want).abs() < 0.01, "{mode:?}: {got} != {want}");
+            assert_eq!(out.getpoint(0, 0)[3], 255.0, "{mode:?} alpha");
+        }
+    }
+
+    /**
+     * Tests SoftLight's two branches against the PDF spec formula.
+     * Works by blending a dark and a bright source over the same backdrop
+     * and comparing with the piecewise definition (including D(x)).
+     * Input: cb = 0.4; cs = 0.2 (first branch) and cs = 0.9 (second).
+     */
+    #[test]
+    fn soft_light_matches_pdf_spec() {
+        let cb = 102.0 / 255.0;
+        let base = Raster::new(1, 1, PixelFormat::Rgb8, vec![102, 102, 102]).unwrap();
+
+        let cs1 = 51.0 / 255.0;
+        let o1 = Raster::new(1, 1, PixelFormat::Rgb8, vec![51, 51, 51]).unwrap();
+        let want1 = cb - (1.0 - 2.0 * cs1) * cb * (1.0 - cb);
+        let got1 = base.composite(&o1, CompositeMode::SoftLight).getpoint(0, 0)[0] / 255.0;
+        assert!((got1 - want1).abs() < 0.01, "{got1} != {want1}");
+
+        let cs2 = 230.0 / 255.0;
+        let o2 = Raster::new(1, 1, PixelFormat::Rgb8, vec![230, 230, 230]).unwrap();
+        let d = cb.sqrt();
+        let want2 = cb + (2.0 * cs2 - 1.0) * (d - cb);
+        let got2 = base.composite(&o2, CompositeMode::SoftLight).getpoint(0, 0)[0] / 255.0;
+        assert!((got2 - want2).abs() < 0.01, "{got2} != {want2}");
+    }
+
+    /**
+     * Tests the non-separable modes' luminosity/saturation contracts.
+     * Works by blending a saturated red source over a grey backdrop:
+     * Luminosity keeps the backdrop hue (grey stays grey-ish with source
+     * luminosity), Colour keeps backdrop luminosity with source hue.
+     * Input: backdrop grey 0.5, source pure red.
+     */
+    #[test]
+    fn non_separable_contracts() {
+        let base = Raster::new(1, 1, PixelFormat::Rgb8, vec![128, 128, 128]).unwrap();
+        let overlay = Raster::new(1, 1, PixelFormat::Rgb8, vec![255, 0, 0]).unwrap();
+
+        // Luminosity: backdrop colour with source luminosity. A grey
+        // backdrop has zero saturation, so the result is the grey with
+        // Lum = lum(red) = 0.3.
+        let px = base
+            .composite(&overlay, CompositeMode::Luminosity)
+            .getpoint(0, 0);
+        for k in 0..3 {
+            assert!((px[k] / 255.0 - 0.3).abs() < 0.01, "luminosity: {px:?}");
+        }
+
+        // Colour: source hue and saturation at backdrop luminosity. The
+        // result keeps lum = 0.502 and is red-dominant.
+        let px = base
+            .composite(&overlay, CompositeMode::Colour)
+            .getpoint(0, 0);
+        let l = 0.3 * px[0] + 0.59 * px[1] + 0.11 * px[2];
+        assert!(
+            (l / 255.0 - 128.0 / 255.0).abs() < 0.01,
+            "colour lum: {px:?}"
+        );
+        assert!(px[0] > px[1] && px[1] >= px[2], "colour hue: {px:?}");
+
+        // Hue with a zero-saturation (grey) source collapses to the
+        // backdrop luminosity (SetSat(cs, 0) is black, SetLum lifts it).
+        let grey_src = Raster::new(1, 1, PixelFormat::Rgb8, vec![10, 10, 10]).unwrap();
+        let px = base.composite(&grey_src, CompositeMode::Hue).getpoint(0, 0);
+        for k in 0..3 {
+            assert!((px[k] - 128.0).abs() <= 1.0, "hue with grey source: {px:?}");
+        }
+
+        // Saturation of a grey source is zero, so the result is grey at
+        // backdrop luminosity.
+        let px = base
+            .composite(&grey_src, CompositeMode::Saturation)
+            .getpoint(0, 0);
+        for k in 0..3 {
+            assert!(
+                (px[k] - 128.0).abs() <= 1.0,
+                "saturation with grey source: {px:?}"
+            );
+        }
+    }
+
+    /**
+     * Tests non-separable output geometry on RGBA inputs: dimensions and
+     * band count carry through, matching the ported
+     * test_composite_non_separable assertions.
+     * Input: 3x2 RGBA base and overlay, all four non-separable modes.
+     * Output: 3x2, 4 channels.
+     */
+    #[test]
+    fn non_separable_geometry() {
+        let base = Raster::zeroed(3, 2, PixelFormat::Rgba8).unwrap();
+        let overlay = Raster::new(
+            3,
+            2,
+            PixelFormat::Rgba8,
+            vec![
+                200, 30, 40, 128, 200, 30, 40, 128, 200, 30, 40, 128, 200, 30, 40, 128, 200, 30,
+                40, 128, 200, 30, 40, 128,
+            ],
+        )
+        .unwrap();
+        for mode in [
+            CompositeMode::Hue,
+            CompositeMode::Saturation,
+            CompositeMode::Colour,
+            CompositeMode::Luminosity,
+        ] {
+            let comp = base.composite(&overlay, mode);
+            assert_eq!(comp.width(), base.width());
+            assert_eq!(comp.height(), base.height());
+            assert_eq!(comp.format().channels(), 4);
+        }
+    }
+
+    /**
+     * Tests grey (1 colour band) compositing: output is 2-band
+     * grey+alpha, and Over blends the single channel.
+     * Input: base Gray8 [100] opaque, overlay Multi8(2) [255, 128].
+     * Output: Multi8(2), value = 255*a + 100*(1-a), alpha 255.
+     */
+    #[test]
+    fn grey_plus_alpha_composites_to_two_bands() {
+        let base = Raster::new(1, 1, PixelFormat::Gray8, vec![100]).unwrap();
+        let overlay = Raster::new(
+            1,
+            1,
+            PixelFormat::with_channels(2, 1).unwrap(),
+            vec![255, 128],
+        )
+        .unwrap();
+        let out = base.composite(&overlay, CompositeMode::Over);
+        assert_eq!(out.format().channels(), 2);
+        let px = out.getpoint(0, 0);
+        let a = 128.0 / 255.0;
+        let want = 255.0 * a + 100.0 * (1.0 - a);
+        assert!((px[0] - want).abs() <= 1.0, "{px:?}");
+        assert_eq!(px[1], 255.0);
+    }
+
+    /**
+     * Tests mixed-depth inputs blend on the shared 0..255 numeric scale
+     * (the libvips max_alpha default and the crate's promoted-16-bit
+     * idiom): a linear mode mixes the raw numeric values directly, and
+     * the result lands in the deeper container.
+     * Input: Gray16 base 32768 opaque, Multi8(2) overlay [200, 128].
+     * Output: Multi16(2); value = 0.502*200 + 0.498*32768 ~ 16419,
+     * alpha raw 255 (the 0..255 scale in a 16-bit container).
+     */
+    #[test]
+    fn mixed_depth_blends_on_numeric_scale() {
+        let base = Raster::new(1, 1, PixelFormat::Gray16, 32768u16.to_ne_bytes().to_vec()).unwrap();
+        let overlay = Raster::new(
+            1,
+            1,
+            PixelFormat::with_channels(2, 1).unwrap(),
+            vec![200, 128],
+        )
+        .unwrap();
+        let out = base.composite(&overlay, CompositeMode::Over);
+        assert_eq!(out.format(), PixelFormat::with_channels(2, 2).unwrap());
+        let px = out.getpoint(0, 0);
+        let a = 128.0 / 255.0;
+        let want = a * 200.0 + (1.0 - a) * 32768.0;
+        assert!((px[0] - want).abs() <= 1.0, "{px:?} want {want}");
+        assert_eq!(px[1], 255.0);
+    }
+
+    /**
+     * Tests a fully 16-bit pipeline normalises by 65535 (the documented
+     * libvips max_alpha choice for ushort): a half-opaque 16-bit overlay
+     * mixes the raw 16-bit values directly.
+     * Input: Gray16 base 32768 opaque, Multi16(2) overlay [65535, 32768].
+     * Output: 0.5*65535 + 0.5*32768 ~ 49152, alpha 65535.
+     */
+    #[test]
+    fn full_16bit_uses_16bit_scale() {
+        let base = Raster::new(1, 1, PixelFormat::Gray16, 32768u16.to_ne_bytes().to_vec()).unwrap();
+        let overlay = Raster::new(
+            1,
+            1,
+            PixelFormat::with_channels(2, 2).unwrap(),
+            [65535u16, 32768]
+                .iter()
+                .flat_map(|v| v.to_ne_bytes())
+                .collect(),
+        )
+        .unwrap();
+        let out = base.composite(&overlay, CompositeMode::Over);
+        let px = out.getpoint(0, 0);
+        let a = 32768.0 / 65535.0;
+        let want = a * 65535.0 + (1.0 - a) * 32768.0;
+        assert!((px[0] - want).abs() <= 1.0, "{px:?} want {want}");
+        assert_eq!(px[1], 65535.0);
+    }
+
+    /**
+     * Tests Add clamps colour and alpha rather than wrapping.
+     * Input: two opaque near-white images.
+     * Output: exactly white, alpha 255.
+     */
+    #[test]
+    fn add_clamps() {
+        let base = Raster::new(1, 1, PixelFormat::Rgb8, vec![200, 200, 200]).unwrap();
+        let overlay = Raster::new(1, 1, PixelFormat::Rgb8, vec![200, 200, 200]).unwrap();
+        let px = base.composite(&overlay, CompositeMode::Add).getpoint(0, 0);
+        assert_eq!(px, vec![255.0, 255.0, 255.0, 255.0]);
+    }
+
+    /**
+     * Tests Clear produces transparent black regardless of inputs.
+     */
+    #[test]
+    fn clear_is_transparent_black() {
+        let px = base_rgb()
+            .composite(&overlay_rgba(), CompositeMode::Clear)
+            .getpoint(0, 0);
+        assert_eq!(px, vec![0.0, 0.0, 0.0, 0.0]);
+    }
+
+    /**
+     * Tests Saturate on an opaque backdrop: no transparency is left, so
+     * the source contributes nothing and the backdrop passes through.
+     */
+    #[test]
+    fn saturate_over_opaque_backdrop_keeps_backdrop() {
+        let px = base_rgb()
+            .composite(&overlay_rgba(), CompositeMode::Saturate)
+            .getpoint(0, 0);
+        assert_eq!(&px[..3], &[100.0, 100.0, 100.0]);
+        assert_eq!(px[3], 255.0);
+    }
+
+    /**
+     * Tests Xor on two half-transparent pixels: each contributes its
+     * colour weighted by the other's transparency.
+     * Input: sa = ba = 0.5, cs = 0.8, cb = 0.2.
+     * Output: c = (0.5*0.5*0.8 + 0.5*0.5*0.2) / 0.5 = 0.5.
+     */
+    #[test]
+    fn xor_blends_disjoint_regions() {
+        let base = Raster::new(1, 1, PixelFormat::Rgba8, vec![51, 51, 51, 128]).unwrap();
+        let overlay = Raster::new(1, 1, PixelFormat::Rgba8, vec![204, 204, 204, 128]).unwrap();
+        let px = base.composite(&overlay, CompositeMode::Xor).getpoint(0, 0);
+        assert!((px[0] / 255.0 - 0.5).abs() < 0.01, "{px:?}");
+        assert!((px[3] / 255.0 - 0.5).abs() < 0.01, "{px:?}");
+    }
+
+    /**
+     * Tests typed errors: size mismatch, band mismatch, non-separable on
+     * grey input, and too many bands.
+     */
+    #[test]
+    fn typed_errors() {
+        let rgb = Raster::zeroed(2, 2, PixelFormat::Rgb8).unwrap();
+        let small = Raster::zeroed(1, 2, PixelFormat::Rgb8).unwrap();
+        let grey = Raster::zeroed(2, 2, PixelFormat::Gray8).unwrap();
+        let five = Raster::zeroed(2, 2, PixelFormat::with_channels(5, 1).unwrap()).unwrap();
+
+        assert!(matches!(
+            rgb.try_composite2(&small, CompositeMode::Over),
+            Err(CompositeError::DimensionMismatch { .. })
+        ));
+        assert!(matches!(
+            rgb.try_composite2(&grey, CompositeMode::Over),
+            Err(CompositeError::BandMismatch { .. })
+        ));
+        assert!(matches!(
+            grey.try_composite2(&grey, CompositeMode::Hue),
+            Err(CompositeError::NonSeparableNeedsRgb { .. })
+        ));
+        assert!(matches!(
+            rgb.try_composite2(&five, CompositeMode::Over),
+            Err(CompositeError::TooManyBands { .. })
+        ));
+    }
+
+    /**
+     * Tests that the panicking form reports the typed error message.
+     */
+    #[test]
+    #[should_panic(expected = "composite: composite: images differ in size")]
+    fn composite_panics_on_mismatch() {
+        let rgb = Raster::zeroed(2, 2, PixelFormat::Rgb8).unwrap();
+        let small = Raster::zeroed(1, 2, PixelFormat::Rgb8).unwrap();
+        let _ = rgb.composite(&small, CompositeMode::Over);
+    }
+
+    /**
+     * Tests metadata carry-through: the result keeps the base image's
+     * resolution and orientation, like libvips copying the first input's
+     * header.
+     */
+    #[test]
+    fn composite_carries_base_metadata() {
+        let base = base_rgb().copy().xres(7.5).orientation(6).build();
+        let out = base.composite(&overlay_rgba(), CompositeMode::Over);
+        assert_eq!(out.xres(), 7.5);
+        assert_eq!(out.orientation(), 6);
+    }
+
+    /**
+     * Tests composite2 and composite agree (composite2 is the binary
+     * libvips name for the same operation).
+     */
+    #[test]
+    fn composite2_is_composite() {
+        let a = base_rgb().composite(&overlay_rgba(), CompositeMode::Screen);
+        let b = base_rgb().composite2(&overlay_rgba(), CompositeMode::Screen);
+        assert_eq!(a.data(), b.data());
+        assert_eq!(a.format(), b.format());
+    }
+
+    /**
+     * Tests unpremultiply safety: where both inputs are fully
+     * transparent, Over writes transparent black without dividing by the
+     * zero output alpha.
+     */
+    #[test]
+    fn zero_alpha_does_not_divide_by_zero() {
+        let base = Raster::new(1, 1, PixelFormat::Rgba8, vec![50, 60, 70, 0]).unwrap();
+        let overlay = Raster::new(1, 1, PixelFormat::Rgba8, vec![80, 90, 100, 0]).unwrap();
+        let px = base.composite(&overlay, CompositeMode::Over).getpoint(0, 0);
+        assert_eq!(px, vec![0.0, 0.0, 0.0, 0.0]);
+    }
+}

--- a/src/imageio.rs
+++ b/src/imageio.rs
@@ -1,0 +1,1759 @@
+//! Image IO, metadata fields, and library-level free functions ported
+//! from libvips.
+//!
+//! This module is the seventh batch of the libvips operation surface
+//! required by the ported integration tests (alongside
+//! [`crate::composite`]): saving a [`Raster`] to a file by extension, the
+//! named metadata field system (`vips_image_get` / `vips_image_set`), the
+//! native `.v` container, and the small library-level helpers
+//! ([`tokenize`], [`parse_thumbnail_geometry`], [`get_max_coord`] /
+//! [`set_max_coord`], [`init_from_env`]).
+//!
+//! # Saving
+//!
+//! [`Raster::save`] encodes by file extension and keeps attached metadata
+//! where the container supports it; [`Raster::save_stripped`] writes
+//! pixels only (libvips `strip`):
+//!
+//! | Extension | Encoder | Metadata kept by `save` |
+//! |---|---|---|
+//! | `.png` | [`crate::sink::encode_png`] | none yet (iCCP embedding is an open gap) |
+//! | `.jpg` / `.jpeg` | the sink JPEG encoder at quality 75 | `icc-profile-data` (APP2), `exif-data` (APP1, raw blob) |
+//! | `.v` / `.vips` | [`Raster::encode_vips`] | header geometry plus every attached field |
+//!
+//! Formats libviprs cannot encode yet (WebP, TIFF-with-metadata, ...)
+//! return [`SaveError::UnsupportedExtension`]; they arrive with the
+//! foreign-format batch. Structured EXIF tag writing (`exif-ifd0-*`
+//! fields into the TIFF directory of a JPEG APP1 segment) is also
+//! deferred to the foreign batch: those fields round-trip through `.v`
+//! and travel on the raster, but JPEG save only re-embeds the raw
+//! `exif-data` blob captured at decode time.
+//!
+//! # The `.v` container
+//!
+//! `encode_vips` writes the libvips native header (64 bytes: magic,
+//! geometry, band format, coding, interpretation, resolution, offsets)
+//! followed by the raw pixel data in the file's byte order, then a JSON
+//! trailer with the orientation tag and the attached metadata fields.
+//! libvips itself stores an XML trailer there; both readers treat an
+//! unparseable trailer as absent, so pixels and header survive either
+//! way. The reader accepts both byte orders (swapping 16-bit samples as
+//! needed), rejects band formats other than uchar/ushort (float `.v`
+//! arrives with the float-format batch), and enforces the
+//! [`get_max_coord`] dimension ceiling on untrusted header geometry.
+//!
+//! # Metadata fields
+//!
+//! [`Raster::get_field`] / [`Raster::set_field`] expose the libvips
+//! named-field system over a [`MetadataValue`] enum (int, double, string,
+//! blob). The built-in header fields (`width`, `height`, `bands`,
+//! `format`, `coding`, `interpretation`, `xoffset`, `yoffset`, `xres`,
+//! `yres`, `orientation`, `filename`) read through to the raster header
+//! and [`crate::conversion`] metadata block; every other name is an
+//! attached field carried with the raster (cloned with it, written to
+//! `.v`, and — for `icc-profile-data` / `exif-data` — embedded on JPEG
+//! save). Geometry fields are read-only, matching what a fixed pixel
+//! buffer can honour.
+//!
+//! # Free functions
+//!
+//! * [`tokenize`] — the libvips option-string tokeniser (whitespace
+//!   splitting with `"..."` / `'...'` quoting and backslash escapes).
+//! * [`parse_thumbnail_geometry`] — the vipsthumbnail size parser
+//!   (`W`, `WxH`, `Wx`, `xH`, with trailing `<` / `>` / `!` modifiers
+//!   tolerated).
+//! * [`get_max_coord`] / [`set_max_coord`] — the process-wide
+//!   `VIPS_MAX_COORD` dimension ceiling (default 10,000,000). It guards
+//!   untrusted dimensions flowing out of file headers (the `.v` reader
+//!   enforces it); wiring it into the in-memory [`Raster`] constructors
+//!   is deferred so their existing typed-error contracts stay stable.
+//! * [`init_from_env`] — library re-init from the environment: reads
+//!   `VIPS_MAX_COORD` (plain integer, or with a binary `k` / `m` / `g`
+//!   suffix, as libvips parses sizes).
+
+use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::conversion::Interpretation;
+use crate::pixel::PixelFormat;
+use crate::raster::Raster;
+use crate::sink::SinkError;
+use crate::source::{DecodeLimits, SourceError};
+
+// ---------------------------------------------------------------------------
+// Metadata values and the attached-field store
+// ---------------------------------------------------------------------------
+
+/// A typed metadata field value (libvips stores these as boxed `GValue`s;
+/// here the four kinds the ported suites read and write are first-class).
+///
+/// `From` conversions cover the literal shapes the ported tests use
+/// (`"TestSoftware".into()`, `format!(...).into()`), and the `as_*`
+/// accessors mirror pyvips-style coercing reads: they panic with a
+/// descriptive message when the variant does not match, in line with the
+/// panicking convenience layer of the operation modules.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum MetadataValue {
+    /// A signed integer field (`width`, `orientation`, counts, flags).
+    Int(i64),
+    /// A floating-point field (`xres`, `yres`).
+    Double(f64),
+    /// A text field (EXIF strings, `interpretation`, `filename`).
+    Str(String),
+    /// A binary field (`icc-profile-data`, `exif-data`).
+    Blob(Vec<u8>),
+}
+
+impl MetadataValue {
+    /// The value as a string slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not [`MetadataValue::Str`].
+    #[track_caller]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Str(s) => s,
+            other => panic!("metadata value is {}, not a string", other.kind()),
+        }
+    }
+
+    /// The value as a `u32`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not [`MetadataValue::Int`] or does not fit
+    /// in a `u32`.
+    #[track_caller]
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            Self::Int(i) => u32::try_from(*i)
+                .unwrap_or_else(|_| panic!("metadata int {i} does not fit in a u32")),
+            other => panic!("metadata value is {}, not an int", other.kind()),
+        }
+    }
+
+    /// The value as an `i64`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not [`MetadataValue::Int`].
+    #[track_caller]
+    pub fn as_i64(&self) -> i64 {
+        match self {
+            Self::Int(i) => *i,
+            other => panic!("metadata value is {}, not an int", other.kind()),
+        }
+    }
+
+    /// The value as an `f64`; an [`MetadataValue::Int`] coerces.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not numeric.
+    #[track_caller]
+    pub fn as_f64(&self) -> f64 {
+        match self {
+            Self::Double(d) => *d,
+            Self::Int(i) => *i as f64,
+            other => panic!("metadata value is {}, not numeric", other.kind()),
+        }
+    }
+
+    /// The value as a byte slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is not [`MetadataValue::Blob`].
+    #[track_caller]
+    pub fn as_blob(&self) -> &[u8] {
+        match self {
+            Self::Blob(b) => b,
+            other => panic!("metadata value is {}, not a blob", other.kind()),
+        }
+    }
+
+    /// The type code returned by [`Raster::get_typeof`] for this value:
+    /// 1 int, 2 double, 3 string, 4 blob. These are libviprs codes (the
+    /// C library returns GObject `GType` numbers); the ported call sites
+    /// only distinguish zero (absent) from non-zero (present).
+    pub fn type_code(&self) -> u64 {
+        match self {
+            Self::Int(_) => 1,
+            Self::Double(_) => 2,
+            Self::Str(_) => 3,
+            Self::Blob(_) => 4,
+        }
+    }
+
+    /// Human-readable kind name for panic messages.
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Int(_) => "an int",
+            Self::Double(_) => "a double",
+            Self::Str(_) => "a string",
+            Self::Blob(_) => "a blob",
+        }
+    }
+}
+
+impl From<&str> for MetadataValue {
+    fn from(s: &str) -> Self {
+        Self::Str(s.to_string())
+    }
+}
+impl From<String> for MetadataValue {
+    fn from(s: String) -> Self {
+        Self::Str(s)
+    }
+}
+impl From<i64> for MetadataValue {
+    fn from(i: i64) -> Self {
+        Self::Int(i)
+    }
+}
+impl From<i32> for MetadataValue {
+    fn from(i: i32) -> Self {
+        Self::Int(i64::from(i))
+    }
+}
+impl From<u32> for MetadataValue {
+    fn from(i: u32) -> Self {
+        Self::Int(i64::from(i))
+    }
+}
+impl From<f64> for MetadataValue {
+    fn from(d: f64) -> Self {
+        Self::Double(d)
+    }
+}
+impl From<Vec<u8>> for MetadataValue {
+    fn from(b: Vec<u8>) -> Self {
+        Self::Blob(b)
+    }
+}
+impl From<&[u8]> for MetadataValue {
+    fn from(b: &[u8]) -> Self {
+        Self::Blob(b.to_vec())
+    }
+}
+
+/// The attached (non-header) metadata fields carried by a [`Raster`]:
+/// an insertion-ordered name/value list, so [`Raster::get_fields`]
+/// reports attachments in the order they were set, like libvips.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub(crate) struct MetadataFields {
+    entries: Vec<(String, MetadataValue)>,
+}
+
+impl MetadataFields {
+    pub(crate) fn get(&self, name: &str) -> Option<&MetadataValue> {
+        self.entries
+            .iter()
+            .find_map(|(n, v)| (n == name).then_some(v))
+    }
+
+    /// Upsert keeping first-set order.
+    pub(crate) fn set(&mut self, name: &str, value: MetadataValue) {
+        if let Some(slot) = self
+            .entries
+            .iter_mut()
+            .find_map(|(n, v)| (n == name).then_some(v))
+        {
+            *slot = value;
+        } else {
+            self.entries.push((name.to_string(), value));
+        }
+    }
+
+    pub(crate) fn remove(&mut self, name: &str) -> Option<MetadataValue> {
+        let idx = self.entries.iter().position(|(n, _)| n == name)?;
+        Some(self.entries.remove(idx).1)
+    }
+
+    pub(crate) fn names(&self) -> impl Iterator<Item = &str> {
+        self.entries.iter().map(|(n, _)| n.as_str())
+    }
+}
+
+/// Errors from [`Raster::try_set_field`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MetadataError {
+    #[error("metadata field {name:?} is read-only (fixed by the pixel buffer)")]
+    ReadOnlyField { name: String },
+    #[error("metadata field {name:?} expects {expected}, got {got}")]
+    WrongType {
+        name: String,
+        expected: &'static str,
+        got: &'static str,
+    },
+    #[error("unknown interpretation nickname {value:?}")]
+    UnknownInterpretation { value: String },
+}
+
+/// The built-in header field names, in the order libvips reports them
+/// (header geometry first, `width` leading).
+const BUILTIN_FIELDS: [&str; 12] = [
+    "width",
+    "height",
+    "bands",
+    "format",
+    "coding",
+    "interpretation",
+    "xoffset",
+    "yoffset",
+    "xres",
+    "yres",
+    "orientation",
+    "filename",
+];
+
+/// The libvips nickname for an [`Interpretation`].
+fn interpretation_nickname(i: Interpretation) -> &'static str {
+    match i {
+        Interpretation::Multiband => "multiband",
+        Interpretation::Bw => "b-w",
+        Interpretation::Histogram => "histogram",
+        Interpretation::Xyz => "xyz",
+        Interpretation::Lab => "lab",
+        Interpretation::Cmyk => "cmyk",
+        Interpretation::Labq => "labq",
+        Interpretation::Rgb => "rgb",
+        Interpretation::Cmc => "cmc",
+        Interpretation::Lch => "lch",
+        Interpretation::Labs => "labs",
+        Interpretation::Srgb => "srgb",
+        Interpretation::Yxy => "yxy",
+        Interpretation::Fourier => "fourier",
+        Interpretation::Rgb16 => "rgb16",
+        Interpretation::Grey16 => "grey16",
+        Interpretation::Matrix => "matrix",
+        Interpretation::ScRgb => "scrgb",
+        Interpretation::Hsv => "hsv",
+        Interpretation::OkLab => "oklab",
+        Interpretation::OkLch => "oklch",
+    }
+}
+
+/// Parse a libvips interpretation nickname.
+fn interpretation_from_nickname(s: &str) -> Option<Interpretation> {
+    Some(match s {
+        "multiband" => Interpretation::Multiband,
+        "b-w" => Interpretation::Bw,
+        "histogram" => Interpretation::Histogram,
+        "xyz" => Interpretation::Xyz,
+        "lab" => Interpretation::Lab,
+        "cmyk" => Interpretation::Cmyk,
+        "labq" => Interpretation::Labq,
+        "rgb" => Interpretation::Rgb,
+        "cmc" => Interpretation::Cmc,
+        "lch" => Interpretation::Lch,
+        "labs" => Interpretation::Labs,
+        "srgb" => Interpretation::Srgb,
+        "yxy" => Interpretation::Yxy,
+        "fourier" => Interpretation::Fourier,
+        "rgb16" => Interpretation::Rgb16,
+        "grey16" => Interpretation::Grey16,
+        "matrix" => Interpretation::Matrix,
+        "scrgb" => Interpretation::ScRgb,
+        "hsv" => Interpretation::Hsv,
+        "oklab" => Interpretation::OkLab,
+        "oklch" => Interpretation::OkLch,
+        _ => return None,
+    })
+}
+
+/// The libvips `VipsInterpretation` enum value for the `.v` header
+/// `Type` word. `OkLab` / `OkLch` have no libvips code; they use
+/// libviprs extension codes above the libvips range and round-trip
+/// through libviprs-written files only.
+fn interpretation_code(i: Interpretation) -> i32 {
+    match i {
+        Interpretation::Multiband => 0,
+        Interpretation::Bw => 1,
+        Interpretation::Histogram => 10,
+        Interpretation::Xyz => 12,
+        Interpretation::Lab => 13,
+        Interpretation::Cmyk => 15,
+        Interpretation::Labq => 16,
+        Interpretation::Rgb => 17,
+        Interpretation::Cmc => 18,
+        Interpretation::Lch => 19,
+        Interpretation::Labs => 21,
+        Interpretation::Srgb => 22,
+        Interpretation::Yxy => 23,
+        Interpretation::Fourier => 24,
+        Interpretation::Rgb16 => 25,
+        Interpretation::Grey16 => 26,
+        Interpretation::Matrix => 27,
+        Interpretation::ScRgb => 28,
+        Interpretation::Hsv => 29,
+        Interpretation::OkLab => 1000,
+        Interpretation::OkLch => 1001,
+    }
+}
+
+/// Inverse of [`interpretation_code`]; unknown codes read as `None` and
+/// the raster falls back to format inference, like an untagged image.
+fn interpretation_from_code(code: i32) -> Option<Interpretation> {
+    Some(match code {
+        0 => Interpretation::Multiband,
+        1 => Interpretation::Bw,
+        10 => Interpretation::Histogram,
+        12 => Interpretation::Xyz,
+        13 => Interpretation::Lab,
+        15 => Interpretation::Cmyk,
+        16 => Interpretation::Labq,
+        17 => Interpretation::Rgb,
+        18 => Interpretation::Cmc,
+        19 => Interpretation::Lch,
+        21 => Interpretation::Labs,
+        22 => Interpretation::Srgb,
+        23 => Interpretation::Yxy,
+        24 => Interpretation::Fourier,
+        25 => Interpretation::Rgb16,
+        26 => Interpretation::Grey16,
+        27 => Interpretation::Matrix,
+        28 => Interpretation::ScRgb,
+        29 => Interpretation::Hsv,
+        1000 => Interpretation::OkLab,
+        1001 => Interpretation::OkLch,
+        _ => return None,
+    })
+}
+
+impl Raster {
+    /// Read a metadata field by name (libvips `vips_image_get`): the
+    /// built-in header fields (`width`, `height`, `bands`, `format`,
+    /// `coding`, `interpretation`, `xoffset`, `yoffset`, `xres`, `yres`,
+    /// `orientation`, `filename`) or any attached field previously set
+    /// with [`Raster::set_field`] / [`Raster::set_icc_profile`] or
+    /// captured at decode time (`icc-profile-data`, `exif-data`).
+    ///
+    /// Returns `None` for a name that is neither built-in nor attached.
+    pub fn get_field(&self, name: &str) -> Option<MetadataValue> {
+        Some(match name {
+            "width" => MetadataValue::Int(i64::from(self.width())),
+            "height" => MetadataValue::Int(i64::from(self.height())),
+            "bands" => MetadataValue::Int(self.format().channels() as i64),
+            "format" => MetadataValue::Str(
+                if self.format().bytes_per_channel() == 1 {
+                    "uchar"
+                } else {
+                    "ushort"
+                }
+                .to_string(),
+            ),
+            "coding" => MetadataValue::Str("none".to_string()),
+            "interpretation" => {
+                MetadataValue::Str(interpretation_nickname(self.interpretation()).to_string())
+            }
+            "xoffset" => MetadataValue::Int(i64::from(self.xoffset())),
+            "yoffset" => MetadataValue::Int(i64::from(self.yoffset())),
+            "xres" => MetadataValue::Double(self.xres()),
+            "yres" => MetadataValue::Double(self.yres()),
+            "orientation" => MetadataValue::Int(i64::from(self.orientation())),
+            "filename" => self
+                .fields
+                .get("filename")
+                .cloned()
+                .unwrap_or_else(|| MetadataValue::Str(String::new())),
+            other => return self.fields.get(other).cloned(),
+        })
+    }
+
+    /// Fallible form of [`Raster::set_field`].
+    ///
+    /// # Errors
+    ///
+    /// [`MetadataError::ReadOnlyField`] for the geometry fields fixed by
+    /// the pixel buffer (`width`, `height`, `bands`, `format`,
+    /// `coding`), [`MetadataError::WrongType`] when a built-in field is
+    /// given the wrong value kind or an out-of-range number, or
+    /// [`MetadataError::UnknownInterpretation`] for an unrecognised
+    /// interpretation nickname.
+    pub fn try_set_field(&mut self, name: &str, value: MetadataValue) -> Result<(), MetadataError> {
+        fn int_as<T: TryFrom<i64>>(
+            name: &str,
+            value: &MetadataValue,
+            expected: &'static str,
+        ) -> Result<T, MetadataError> {
+            match value {
+                MetadataValue::Int(i) => T::try_from(*i).map_err(|_| MetadataError::WrongType {
+                    name: name.to_string(),
+                    expected,
+                    got: "an out-of-range int",
+                }),
+                other => Err(MetadataError::WrongType {
+                    name: name.to_string(),
+                    expected,
+                    got: other.kind(),
+                }),
+            }
+        }
+        match name {
+            "width" | "height" | "bands" | "format" | "coding" => {
+                Err(MetadataError::ReadOnlyField {
+                    name: name.to_string(),
+                })
+            }
+            "xres" | "yres" => {
+                let v = match &value {
+                    MetadataValue::Double(d) => *d,
+                    MetadataValue::Int(i) => *i as f64,
+                    other => {
+                        return Err(MetadataError::WrongType {
+                            name: name.to_string(),
+                            expected: "a double",
+                            got: other.kind(),
+                        });
+                    }
+                };
+                if name == "xres" {
+                    self.meta.xres = v;
+                } else {
+                    self.meta.yres = v;
+                }
+                Ok(())
+            }
+            "xoffset" => {
+                self.meta.xoffset = int_as::<i32>(name, &value, "an int (i32 range)")?;
+                Ok(())
+            }
+            "yoffset" => {
+                self.meta.yoffset = int_as::<i32>(name, &value, "an int (i32 range)")?;
+                Ok(())
+            }
+            "orientation" => {
+                self.meta.orientation = int_as::<u8>(name, &value, "an int (u8 range)")?;
+                Ok(())
+            }
+            "interpretation" => match &value {
+                MetadataValue::Str(s) => match interpretation_from_nickname(s) {
+                    Some(i) => {
+                        self.meta.interpretation = Some(i);
+                        Ok(())
+                    }
+                    None => Err(MetadataError::UnknownInterpretation { value: s.clone() }),
+                },
+                other => Err(MetadataError::WrongType {
+                    name: name.to_string(),
+                    expected: "a string",
+                    got: other.kind(),
+                }),
+            },
+            other => {
+                self.fields.set(other, value);
+                Ok(())
+            }
+        }
+    }
+
+    /// Set a metadata field by name (libvips `vips_image_set`): built-in
+    /// header fields route into the raster metadata block, every other
+    /// name becomes an attached field carried with the raster. Panicking
+    /// form of [`Raster::try_set_field`], matching the ported-test call
+    /// surface.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`MetadataError`]; see [`Raster::try_set_field`].
+    #[track_caller]
+    pub fn set_field(&mut self, name: &str, value: MetadataValue) {
+        if let Err(e) = self.try_set_field(name, value) {
+            panic!("set_field: {e}");
+        }
+    }
+
+    /// Every readable field name: the built-in header fields (in libvips
+    /// order, `width` first) followed by the attached fields in the
+    /// order they were set (libvips `vips_image_get_fields`).
+    pub fn get_fields(&self) -> Vec<String> {
+        let mut out: Vec<String> = BUILTIN_FIELDS.iter().map(|s| s.to_string()).collect();
+        for name in self.fields.names() {
+            if !BUILTIN_FIELDS.contains(&name) {
+                out.push(name.to_string());
+            }
+        }
+        out
+    }
+
+    /// The type code of a field: 0 when the field does not exist,
+    /// otherwise the [`MetadataValue::type_code`] of its value (libvips
+    /// `vips_image_get_typeof`, which returns 0 or a `GType`).
+    pub fn get_typeof(&self, name: &str) -> u64 {
+        self.get_field(name).map_or(0, |v| v.type_code())
+    }
+
+    /// Remove an attached field by setting its type to 0, the libvips
+    /// removal idiom (`vips_image_set` with a zero `GType` /
+    /// `vips_image_remove`). Removing an absent field is a no-op.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `typeof_` is non-zero (retyping a field is not
+    /// supported; set a new value instead) or when `name` is a built-in
+    /// header field, which cannot be removed.
+    #[track_caller]
+    pub fn set_typeof(&mut self, name: &str, typeof_: u64) {
+        if typeof_ != 0 {
+            panic!("set_typeof: only 0 (remove) is supported, got {typeof_}");
+        }
+        if BUILTIN_FIELDS.contains(&name) {
+            panic!("set_typeof: cannot remove built-in field {name:?}");
+        }
+        self.fields.remove(name);
+    }
+
+    /// Attach an ICC profile, stored as the `icc-profile-data` blob
+    /// field (embedded on JPEG and `.v` save).
+    pub fn set_icc_profile(&mut self, profile: &[u8]) {
+        self.fields
+            .set("icc-profile-data", MetadataValue::Blob(profile.to_vec()));
+    }
+
+    /// The attached ICC profile, if any: the `icc-profile-data` blob set
+    /// by [`Raster::set_icc_profile`] or captured from a decoded JPEG.
+    pub fn icc_profile(&self) -> Option<&[u8]> {
+        match self.fields.get("icc-profile-data") {
+            Some(MetadataValue::Blob(b)) => Some(b),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Saving
+// ---------------------------------------------------------------------------
+
+/// Errors from [`Raster::save`] / [`Raster::save_stripped`] /
+/// [`Raster::encode_vips`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SaveError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("unsupported save extension {extension:?}; libviprs encodes png, jpg/jpeg, and v/vips")]
+    UnsupportedExtension { extension: String },
+    #[error("encode error: {0}")]
+    Encode(#[from] SinkError),
+}
+
+/// JPEG quality used by extension-dispatched [`Raster::save`], matching
+/// the libvips `jpegsave` default.
+const SAVE_JPEG_QUALITY: u8 = 75;
+
+impl Raster {
+    /// Save to a file, choosing the encoder from the extension (libvips
+    /// `vips_image_write_to_file`). Attached metadata is kept where the
+    /// container supports it; see the [module docs](crate::imageio) for
+    /// the per-format table.
+    ///
+    /// # Errors
+    ///
+    /// [`SaveError::UnsupportedExtension`] for extensions libviprs
+    /// cannot encode, [`SaveError::Encode`] if the encoder rejects the
+    /// pixel format, or [`SaveError::Io`] on write failure.
+    pub fn save(&self, path: &Path) -> Result<(), SaveError> {
+        self.save_impl(path, true)
+    }
+
+    /// Save with all metadata stripped (libvips `strip`): pixels and
+    /// geometry only, no ICC, EXIF, or attached fields.
+    ///
+    /// # Errors
+    ///
+    /// As [`Raster::save`].
+    pub fn save_stripped(&self, path: &Path) -> Result<(), SaveError> {
+        self.save_impl(path, false)
+    }
+
+    fn save_impl(&self, path: &Path, keep_metadata: bool) -> Result<(), SaveError> {
+        let extension = path
+            .extension()
+            .map(|e| e.to_string_lossy().to_ascii_lowercase())
+            .unwrap_or_default();
+        let bytes = match extension.as_str() {
+            "png" => crate::sink::encode_png(self)?,
+            "jpg" | "jpeg" => {
+                let encoded = crate::sink::encode_jpeg(self, SAVE_JPEG_QUALITY)?;
+                if keep_metadata {
+                    let exif = match self.fields.get("exif-data") {
+                        Some(MetadataValue::Blob(b)) => Some(b.as_slice()),
+                        _ => None,
+                    };
+                    inject_jpeg_metadata(encoded, exif, self.icc_profile())
+                } else {
+                    encoded
+                }
+            }
+            "v" | "vips" => self.encode_vips_impl(keep_metadata),
+            _ => return Err(SaveError::UnsupportedExtension { extension }),
+        };
+        std::fs::write(path, bytes)?;
+        Ok(())
+    }
+
+    /// Encode as native `.v` bytes (libvips `vipssave_buffer`): the
+    /// 64-byte libvips header, raw pixels, and a metadata trailer. See
+    /// the [module docs](crate::imageio) for the container contract.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible for every representable [`PixelFormat`];
+    /// the `Result` reserves room for unencodable future formats.
+    pub fn encode_vips(&self) -> Result<Vec<u8>, SaveError> {
+        Ok(self.encode_vips_impl(true))
+    }
+
+    fn encode_vips_impl(&self, keep_metadata: bool) -> Vec<u8> {
+        let bpc = self.format().bytes_per_channel();
+        let mut out = Vec::with_capacity(VIPS_HEADER_LEN + self.data().len());
+        out.extend_from_slice(&VIPS_MAGIC_NATIVE);
+        fn push_i32(out: &mut Vec<u8>, v: i32) {
+            out.extend_from_slice(&v.to_ne_bytes());
+        }
+        push_i32(&mut out, self.width() as i32);
+        push_i32(&mut out, self.height() as i32);
+        push_i32(&mut out, self.format().channels() as i32);
+        push_i32(&mut out, 8 * bpc as i32); // deprecated Bbits
+        push_i32(&mut out, if bpc == 1 { 0 } else { 2 }); // BandFmt: uchar / ushort
+        push_i32(&mut out, 0); // Coding: none
+        push_i32(&mut out, interpretation_code(self.interpretation()));
+        out.extend_from_slice(&(self.xres() as f32).to_ne_bytes());
+        out.extend_from_slice(&(self.yres() as f32).to_ne_bytes());
+        push_i32(&mut out, 0); // deprecated Length
+        out.extend_from_slice(&0i16.to_ne_bytes()); // deprecated Compression
+        out.extend_from_slice(&0i16.to_ne_bytes()); // deprecated Level
+        push_i32(&mut out, self.xoffset());
+        push_i32(&mut out, self.yoffset());
+        out.resize(VIPS_HEADER_LEN, 0); // reserved tail of the header
+        out.extend_from_slice(self.data());
+        if keep_metadata {
+            let trailer = VTrailer {
+                orientation: self.orientation(),
+                fields: self.fields.clone(),
+            };
+            if let Ok(json) = serde_json::to_vec(&trailer) {
+                out.extend_from_slice(&json);
+            }
+        }
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The .v container
+// ---------------------------------------------------------------------------
+
+/// Size of the on-disk libvips image header.
+const VIPS_HEADER_LEN: usize = 64;
+
+/// First four file bytes of a big-endian (SPARC-order) `.v` file.
+const VIPS_MAGIC_BE: [u8; 4] = [0x08, 0xf2, 0xa6, 0xb6];
+/// First four file bytes of a little-endian (Intel-order) `.v` file.
+const VIPS_MAGIC_LE: [u8; 4] = [0xb6, 0xa6, 0xf2, 0x08];
+
+/// The magic this build writes: native byte order, as libvips does.
+#[cfg(target_endian = "little")]
+const VIPS_MAGIC_NATIVE: [u8; 4] = VIPS_MAGIC_LE;
+#[cfg(target_endian = "big")]
+const VIPS_MAGIC_NATIVE: [u8; 4] = VIPS_MAGIC_BE;
+
+/// The JSON trailer libviprs writes after the pixel data: the
+/// orientation tag plus the attached fields. libvips stores XML here;
+/// both readers ignore a trailer they cannot parse.
+#[derive(Serialize, Deserialize)]
+struct VTrailer {
+    orientation: u8,
+    fields: MetadataFields,
+}
+
+/// Whether `bytes` begin with a `.v` magic (either byte order).
+pub(crate) fn is_vips_bytes(bytes: &[u8]) -> bool {
+    bytes.len() >= 4 && (bytes[..4] == VIPS_MAGIC_LE || bytes[..4] == VIPS_MAGIC_BE)
+}
+
+/// Decode a native `.v` file (both byte orders). Enforces the
+/// [`get_max_coord`] ceiling and the caller's [`DecodeLimits`] on the
+/// untrusted header geometry before allocating.
+pub(crate) fn decode_vips_bytes(bytes: &[u8], limits: DecodeLimits) -> Result<Raster, SourceError> {
+    if bytes.len() < VIPS_HEADER_LEN {
+        return Err(SourceError::VipsFormat(format!(
+            "file too short for a .v header: {} bytes",
+            bytes.len()
+        )));
+    }
+    let swapped = if bytes[..4] == VIPS_MAGIC_LE {
+        cfg!(target_endian = "big")
+    } else if bytes[..4] == VIPS_MAGIC_BE {
+        cfg!(target_endian = "little")
+    } else {
+        return Err(SourceError::VipsFormat("bad .v magic".to_string()));
+    };
+    let read_i32 = |off: usize| -> i32 {
+        let raw: [u8; 4] = bytes[off..off + 4].try_into().expect("length checked");
+        let v = i32::from_ne_bytes(raw);
+        if swapped { v.swap_bytes() } else { v }
+    };
+    let read_f32 = |off: usize| -> f32 { f32::from_bits(read_i32(off) as u32) };
+
+    let width = read_i32(4);
+    let height = read_i32(8);
+    let bands = read_i32(12);
+    let band_fmt = read_i32(20);
+    let coding = read_i32(24);
+    let type_code = read_i32(28);
+    let xres = read_f32(32);
+    let yres = read_f32(36);
+    let xoffset = read_i32(48);
+    let yoffset = read_i32(52);
+
+    if coding != 0 {
+        return Err(SourceError::VipsFormat(format!(
+            "unsupported .v coding {coding}; only uncoded images are supported"
+        )));
+    }
+    let bpc = match band_fmt {
+        0 => 1, // uchar
+        2 => 2, // ushort
+        other => {
+            return Err(SourceError::VipsFormat(format!(
+                "unsupported .v band format {other}; only uchar and ushort are supported \
+                 (float band formats arrive with the float-format batch)"
+            )));
+        }
+    };
+    if width <= 0 || height <= 0 || bands <= 0 {
+        return Err(SourceError::VipsFormat(format!(
+            "bad .v geometry {width}x{height} with {bands} bands"
+        )));
+    }
+    let (width, height) = (width as u32, height as u32);
+    let max_coord = get_max_coord();
+    if width > max_coord || height > max_coord {
+        return Err(SourceError::VipsFormat(format!(
+            "dimensions {width}x{height} exceed the max_coord ceiling ({max_coord}); \
+             raise it with set_max_coord or VIPS_MAX_COORD"
+        )));
+    }
+    limits.check_pixels(width, height)?;
+    let format = PixelFormat::with_channels(bands as usize, bpc)
+        .ok_or_else(|| SourceError::VipsFormat(format!("unrepresentable .v band count {bands}")))?;
+
+    let data_len = width as usize * height as usize * format.bytes_per_pixel();
+    let end = VIPS_HEADER_LEN
+        .checked_add(data_len)
+        .filter(|&e| e <= bytes.len())
+        .ok_or_else(|| {
+            SourceError::VipsFormat(format!(
+                "truncated .v pixel data: header promises {data_len} bytes, file has {}",
+                bytes.len().saturating_sub(VIPS_HEADER_LEN)
+            ))
+        })?;
+    let mut data = bytes[VIPS_HEADER_LEN..end].to_vec();
+    if swapped && bpc == 2 {
+        for pair in data.chunks_exact_mut(2) {
+            pair.swap(0, 1);
+        }
+    }
+
+    let mut raster = Raster::new(width, height, format, data)?;
+    raster.meta.xres = f64::from(xres);
+    raster.meta.yres = f64::from(yres);
+    raster.meta.xoffset = xoffset;
+    raster.meta.yoffset = yoffset;
+    raster.meta.interpretation = interpretation_from_code(type_code);
+    // Trailer: libviprs JSON, or (from real libvips) XML we treat as absent.
+    if end < bytes.len() {
+        if let Ok(trailer) = serde_json::from_slice::<VTrailer>(&bytes[end..]) {
+            raster.meta.orientation = trailer.orientation;
+            raster.fields = trailer.fields;
+        }
+    }
+    Ok(raster)
+}
+
+// ---------------------------------------------------------------------------
+// JPEG metadata segments
+// ---------------------------------------------------------------------------
+
+/// APP1 EXIF identifier.
+const EXIF_HEADER: &[u8] = b"Exif\0\0";
+/// APP2 ICC identifier.
+const ICC_HEADER: &[u8] = b"ICC_PROFILE\0";
+/// Maximum ICC payload bytes per APP2 segment: 65535 total segment
+/// length, minus 2 length bytes, 12 identifier bytes, and 2 chunk-index
+/// bytes.
+const ICC_CHUNK_MAX: usize = 65535 - 2 - 12 - 2;
+
+/// Scan a JPEG byte stream and attach the `exif-data` and
+/// `icc-profile-data` fields found in its APP1/APP2 segments, as libvips
+/// loaders populate the image header. Non-JPEG or malformed input
+/// attaches nothing.
+pub(crate) fn attach_jpeg_metadata(raster: &mut Raster, bytes: &[u8]) {
+    let (exif, icc) = extract_jpeg_metadata(bytes);
+    if let Some(exif) = exif {
+        raster.fields.set("exif-data", MetadataValue::Blob(exif));
+    }
+    if let Some(icc) = icc {
+        raster
+            .fields
+            .set("icc-profile-data", MetadataValue::Blob(icc));
+    }
+}
+
+/// Extract the EXIF payload (after `Exif\0\0`) and the reassembled ICC
+/// profile from a JPEG stream's application segments.
+fn extract_jpeg_metadata(bytes: &[u8]) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
+    let mut exif = None;
+    let mut icc_chunks: Vec<(u8, &[u8])> = Vec::new();
+    for (marker, data) in JpegSegments::new(bytes) {
+        match marker {
+            0xE1 if exif.is_none() && data.starts_with(EXIF_HEADER) => {
+                exif = Some(data[EXIF_HEADER.len()..].to_vec());
+            }
+            0xE2 if data.starts_with(ICC_HEADER) && data.len() >= ICC_HEADER.len() + 2 => {
+                let seq = data[ICC_HEADER.len()];
+                icc_chunks.push((seq, &data[ICC_HEADER.len() + 2..]));
+            }
+            _ => {}
+        }
+    }
+    let icc = if icc_chunks.is_empty() {
+        None
+    } else {
+        icc_chunks.sort_by_key(|(seq, _)| *seq);
+        let mut profile = Vec::with_capacity(icc_chunks.iter().map(|(_, d)| d.len()).sum());
+        for (_, d) in &icc_chunks {
+            profile.extend_from_slice(d);
+        }
+        Some(profile)
+    };
+    (exif, icc)
+}
+
+/// Iterator over JPEG marker segments: yields `(marker, segment data)`
+/// for every length-carrying segment before the scan data.
+struct JpegSegments<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> JpegSegments<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        // Require SOI; otherwise iterate nothing.
+        let pos = if bytes.starts_with(&[0xFF, 0xD8]) {
+            2
+        } else {
+            bytes.len()
+        };
+        Self { bytes, pos }
+    }
+}
+
+impl<'a> Iterator for JpegSegments<'a> {
+    type Item = (u8, &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // Marker: 0xFF then a non-fill byte.
+            while self.pos < self.bytes.len() && self.bytes[self.pos] == 0xFF {
+                self.pos += 1;
+            }
+            if self.pos == 0 || self.pos >= self.bytes.len() || self.bytes[self.pos - 1] != 0xFF {
+                return None;
+            }
+            let marker = self.bytes[self.pos];
+            self.pos += 1;
+            match marker {
+                // EOI or SOS: nothing structured follows.
+                0xD9 | 0xDA => return None,
+                // Standalone markers with no length word.
+                0x01 | 0xD0..=0xD7 => continue,
+                _ => {
+                    if self.pos + 2 > self.bytes.len() {
+                        return None;
+                    }
+                    let len = u16::from_be_bytes([self.bytes[self.pos], self.bytes[self.pos + 1]])
+                        as usize;
+                    if len < 2 || self.pos + len > self.bytes.len() {
+                        return None;
+                    }
+                    let data = &self.bytes[self.pos + 2..self.pos + len];
+                    self.pos += len;
+                    return Some((marker, data));
+                }
+            }
+        }
+    }
+}
+
+/// Insert APP1 (EXIF) and APP2 (ICC) segments into an encoded JPEG,
+/// after the SOI and any APP0 (JFIF) segment the encoder wrote. Payloads
+/// too large for their segment framing are skipped rather than
+/// corrupting the stream (EXIF cannot be split; ICC splits into up to
+/// 255 chunks).
+fn inject_jpeg_metadata(jpeg: Vec<u8>, exif: Option<&[u8]>, icc: Option<&[u8]>) -> Vec<u8> {
+    if !jpeg.starts_with(&[0xFF, 0xD8]) {
+        return jpeg;
+    }
+    // Find the insertion point: after SOI and consecutive APP0 segments.
+    let mut insert_at = 2;
+    while insert_at + 4 <= jpeg.len() && jpeg[insert_at] == 0xFF && jpeg[insert_at + 1] == 0xE0 {
+        let len = u16::from_be_bytes([jpeg[insert_at + 2], jpeg[insert_at + 3]]) as usize;
+        if len < 2 || insert_at + 2 + len > jpeg.len() {
+            break;
+        }
+        insert_at += 2 + len;
+    }
+
+    let mut segments = Vec::new();
+    if let Some(exif) = exif {
+        let payload_len = EXIF_HEADER.len() + exif.len();
+        if payload_len + 2 <= u16::MAX as usize {
+            segments.extend_from_slice(&[0xFF, 0xE1]);
+            segments.extend_from_slice(&((payload_len + 2) as u16).to_be_bytes());
+            segments.extend_from_slice(EXIF_HEADER);
+            segments.extend_from_slice(exif);
+        }
+    }
+    if let Some(icc) = icc {
+        let chunks: Vec<&[u8]> = icc.chunks(ICC_CHUNK_MAX).collect();
+        if !chunks.is_empty() && chunks.len() <= 255 {
+            let total = chunks.len() as u8;
+            for (i, chunk) in chunks.iter().enumerate() {
+                let payload_len = ICC_HEADER.len() + 2 + chunk.len();
+                segments.extend_from_slice(&[0xFF, 0xE2]);
+                segments.extend_from_slice(&((payload_len + 2) as u16).to_be_bytes());
+                segments.extend_from_slice(ICC_HEADER);
+                segments.push(i as u8 + 1);
+                segments.push(total);
+                segments.extend_from_slice(chunk);
+            }
+        }
+    }
+    if segments.is_empty() {
+        return jpeg;
+    }
+    let mut out = Vec::with_capacity(jpeg.len() + segments.len());
+    out.extend_from_slice(&jpeg[..insert_at]);
+    out.extend_from_slice(&segments);
+    out.extend_from_slice(&jpeg[insert_at..]);
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Free functions: tokeniser, thumbnail geometry, max_coord, env init
+// ---------------------------------------------------------------------------
+
+/// Split an option string into tokens the way the libvips tokeniser
+/// (`vips__token_get`) does: whitespace separates tokens, double or
+/// single quotes group a token, and a backslash escapes the next
+/// character both inside and outside quotes.
+///
+/// ```
+/// assert_eq!(libviprs::tokenize("a \"b c\" d"), vec!["a", "b c", "d"]);
+/// ```
+pub fn tokenize(input: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut chars = input.chars().peekable();
+    loop {
+        while chars.next_if(|c| c.is_whitespace()).is_some() {}
+        let Some(&first) = chars.peek() else { break };
+        let mut token = String::new();
+        if first == '"' || first == '\'' {
+            let quote = first;
+            chars.next();
+            while let Some(c) = chars.next() {
+                match c {
+                    c if c == quote => break,
+                    '\\' => {
+                        if let Some(escaped) = chars.next() {
+                            token.push(escaped);
+                        }
+                    }
+                    c => token.push(c),
+                }
+            }
+        } else {
+            while let Some(&c) = chars.peek() {
+                if c.is_whitespace() {
+                    break;
+                }
+                chars.next();
+                if c == '\\' {
+                    if let Some(escaped) = chars.next() {
+                        token.push(escaped);
+                    }
+                } else {
+                    token.push(c);
+                }
+            }
+        }
+        out.push(token);
+    }
+    out
+}
+
+/// A parsed thumbnail size specification; see
+/// [`parse_thumbnail_geometry`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ThumbnailGeometry {
+    /// Requested width bound, if the spec named one.
+    pub width: Option<u32>,
+    /// Requested height bound, if the spec named one.
+    pub height: Option<u32>,
+}
+
+/// Parse a vipsthumbnail-style geometry string: `"200"` (width only),
+/// `"200x150"`, `"200x"` (width only), `"x150"` (height only), with the
+/// trailing vipsthumbnail modifiers `<` (only enlarge), `>` (only
+/// shrink), and `!` (force) tolerated and stripped. Unparseable parts
+/// read as `None`, so garbage yields an empty geometry rather than an
+/// error, matching the forgiving CLI parser.
+pub fn parse_thumbnail_geometry(spec: &str) -> ThumbnailGeometry {
+    let s = spec.trim().trim_end_matches(['<', '>', '!']).trim();
+    let (w, h) = match s.split_once(['x', 'X']) {
+        Some((w, h)) => (w, Some(h)),
+        None => (s, None),
+    };
+    ThumbnailGeometry {
+        width: w.trim().parse().ok(),
+        height: h.and_then(|h| h.trim().parse().ok()),
+    }
+}
+
+/// The default [`get_max_coord`] ceiling: 10,000,000 pixels per axis,
+/// the libvips `VIPS_MAX_COORD` value.
+pub const DEFAULT_MAX_COORD: u32 = 10_000_000;
+
+/// Process-wide dimension ceiling, mirrored from libvips'
+/// `VIPS_MAX_COORD`.
+static MAX_COORD: AtomicU32 = AtomicU32::new(DEFAULT_MAX_COORD);
+
+/// The current process-wide maximum image dimension applied to untrusted
+/// header geometry (the `.v` reader enforces it; see the
+/// [module docs](crate::imageio)).
+pub fn get_max_coord() -> u32 {
+    MAX_COORD.load(Ordering::Relaxed)
+}
+
+/// Set the process-wide maximum image dimension; see [`get_max_coord`].
+pub fn set_max_coord(max: u32) {
+    MAX_COORD.store(max, Ordering::Relaxed);
+}
+
+/// Re-initialise library settings from the environment, as the libvips
+/// startup does: reads `VIPS_MAX_COORD` (a plain integer, optionally
+/// with a binary `k` / `m` / `g` suffix) into [`set_max_coord`]. Unset
+/// or unparseable variables leave the current settings untouched.
+pub fn init_from_env() {
+    if let Some(n) = std::env::var("VIPS_MAX_COORD")
+        .ok()
+        .and_then(|v| parse_size(&v))
+    {
+        set_max_coord(n);
+    }
+}
+
+/// Parse a libvips-style size string: digits with an optional binary
+/// `k` / `m` / `g` suffix (case-insensitive), saturating at `u32::MAX`.
+fn parse_size(s: &str) -> Option<u32> {
+    let s = s.trim();
+    let (digits, multiplier) = match s.chars().last() {
+        Some('k') | Some('K') => (&s[..s.len() - 1], 1u64 << 10),
+        Some('m') | Some('M') => (&s[..s.len() - 1], 1u64 << 20),
+        Some('g') | Some('G') => (&s[..s.len() - 1], 1u64 << 30),
+        _ => (s, 1),
+    };
+    let n: u64 = digits.trim().parse().ok()?;
+    Some(u32::try_from(n.saturating_mul(multiplier)).unwrap_or(u32::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::{decode_bytes, decode_file};
+
+    fn rgb_2x2() -> Raster {
+        Raster::new(
+            2,
+            2,
+            PixelFormat::Rgb8,
+            vec![10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120],
+        )
+        .unwrap()
+    }
+
+    // -- metadata fields ---------------------------------------------------
+
+    /**
+     * Tests the built-in header fields read through get_field with the
+     * libvips names and value kinds.
+     * Input: 2x2 Rgb8 with default metadata.
+     * Output: width/height/bands ints, format "uchar", coding "none",
+     * interpretation "srgb", xres/yres doubles, orientation 1.
+     */
+    #[test]
+    fn builtin_fields_read_through() {
+        let im = rgb_2x2();
+        assert_eq!(im.get_field("width"), Some(MetadataValue::Int(2)));
+        assert_eq!(im.get_field("height"), Some(MetadataValue::Int(2)));
+        assert_eq!(im.get_field("bands"), Some(MetadataValue::Int(3)));
+        assert_eq!(im.get_field("format").unwrap().as_str(), "uchar");
+        assert_eq!(im.get_field("coding").unwrap().as_str(), "none");
+        assert_eq!(im.get_field("interpretation").unwrap().as_str(), "srgb");
+        assert_eq!(im.get_field("xres"), Some(MetadataValue::Double(1.0)));
+        assert_eq!(im.get_field("yres"), Some(MetadataValue::Double(1.0)));
+        assert_eq!(im.get_field("xoffset"), Some(MetadataValue::Int(0)));
+        assert_eq!(im.get_field("yoffset"), Some(MetadataValue::Int(0)));
+        assert_eq!(im.get_field("orientation"), Some(MetadataValue::Int(1)));
+        assert_eq!(im.get_field("filename").unwrap().as_str(), "");
+        assert_eq!(im.get_field("no-such-field"), None);
+
+        let im16 = Raster::zeroed(1, 1, PixelFormat::Gray16).unwrap();
+        assert_eq!(im16.get_field("format").unwrap().as_str(), "ushort");
+        assert_eq!(im16.get_field("interpretation").unwrap().as_str(), "grey16");
+    }
+
+    /**
+     * Tests get_fields: more than 10 names, "width" first, attached
+     * fields listed after the built-ins in insertion order.
+     */
+    #[test]
+    fn get_fields_order_and_count() {
+        let mut im = rgb_2x2();
+        let fields = im.get_fields();
+        assert!(fields.len() > 10, "got {}", fields.len());
+        assert_eq!(fields[0], "width");
+
+        im.set_field("zz-custom", 7i32.into());
+        im.set_field("aa-custom", "x".into());
+        let fields = im.get_fields();
+        let zz = fields.iter().position(|f| f == "zz-custom").unwrap();
+        let aa = fields.iter().position(|f| f == "aa-custom").unwrap();
+        assert!(zz < aa, "insertion order, not name order: {fields:?}");
+    }
+
+    /**
+     * Tests set_field routing: header fields update the metadata block,
+     * arbitrary string/int/double fields round-trip, and the geometry
+     * fields reject writes with a typed error.
+     */
+    #[test]
+    fn set_field_routes_builtins_and_attachments() {
+        let mut im = rgb_2x2();
+        im.set_field("xres", 2.5f64.into());
+        im.set_field("yres", MetadataValue::Int(3));
+        im.set_field("xoffset", 7i32.into());
+        im.set_field("yoffset", (-4i32).into());
+        im.set_field("orientation", 6i32.into());
+        im.set_field("interpretation", "b-w".into());
+        assert_eq!(im.xres(), 2.5);
+        assert_eq!(im.yres(), 3.0);
+        assert_eq!(im.xoffset(), 7);
+        assert_eq!(im.yoffset(), -4);
+        assert_eq!(im.orientation(), 6);
+        assert_eq!(im.interpretation(), Interpretation::Bw);
+
+        im.set_field("exif-ifd0-Software", "TestSoftware".into());
+        im.set_field("page-count", 3i32.into());
+        im.set_field("gamma", 2.2f64.into());
+        assert_eq!(
+            im.get_field("exif-ifd0-Software").unwrap().as_str(),
+            "TestSoftware"
+        );
+        assert_eq!(im.get_field("page-count").unwrap().as_i64(), 3);
+        assert_eq!(im.get_field("gamma").unwrap().as_f64(), 2.2);
+
+        assert!(matches!(
+            im.try_set_field("width", MetadataValue::Int(99)),
+            Err(MetadataError::ReadOnlyField { .. })
+        ));
+        assert!(matches!(
+            im.try_set_field("orientation", "sideways".into()),
+            Err(MetadataError::WrongType { .. })
+        ));
+        assert!(matches!(
+            im.try_set_field("orientation", MetadataValue::Int(999)),
+            Err(MetadataError::WrongType { .. })
+        ));
+        assert!(matches!(
+            im.try_set_field("interpretation", "plaid".into()),
+            Err(MetadataError::UnknownInterpretation { .. })
+        ));
+    }
+
+    /**
+     * Tests get_typeof/set_typeof: 0 for absent fields, the value kind
+     * code for present ones, and set_typeof(_, 0) removes an attachment
+     * (the libvips removal idiom the ported EXIF test uses).
+     */
+    #[test]
+    fn typeof_reports_and_removes() {
+        let mut im = rgb_2x2();
+        assert_eq!(im.get_typeof("exif-ifd0-Software"), 0);
+        im.set_field("exif-ifd0-Software", "TestSoftware".into());
+        assert_ne!(im.get_typeof("exif-ifd0-Software"), 0);
+        assert_eq!(im.get_typeof("width"), MetadataValue::Int(0).type_code());
+        assert_eq!(
+            im.get_typeof("xres"),
+            MetadataValue::Double(0.0).type_code()
+        );
+
+        im.set_typeof("exif-ifd0-Software", 0);
+        assert_eq!(im.get_typeof("exif-ifd0-Software"), 0);
+        assert_eq!(im.get_field("exif-ifd0-Software"), None);
+        // Removing an absent field is a no-op.
+        im.set_typeof("never-set", 0);
+    }
+
+    /**
+     * Tests set_typeof rejects non-zero codes and built-in removal.
+     */
+    #[test]
+    #[should_panic(expected = "only 0 (remove) is supported")]
+    fn set_typeof_rejects_retype() {
+        rgb_2x2().set_typeof("x", 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot remove built-in field")]
+    fn set_typeof_rejects_builtin_removal() {
+        rgb_2x2().set_typeof("width", 0);
+    }
+
+    /**
+     * Tests the ICC profile accessors and that the profile travels with
+     * clones (the copy builder path every op uses for metadata).
+     */
+    #[test]
+    fn icc_profile_roundtrip_and_clone() {
+        let mut im = rgb_2x2();
+        assert_eq!(im.icc_profile(), None);
+        im.set_icc_profile(&[1, 2, 3, 4]);
+        assert_eq!(im.icc_profile(), Some(&[1u8, 2, 3, 4][..]));
+        assert_eq!(
+            im.get_field("icc-profile-data"),
+            Some(MetadataValue::Blob(vec![1, 2, 3, 4]))
+        );
+        let copy = im.copy().xres(9.0).build();
+        assert_eq!(copy.icc_profile(), Some(&[1u8, 2, 3, 4][..]));
+    }
+
+    /**
+     * Tests MetadataValue accessors panic descriptively on kind
+     * mismatches and coerce where documented (Int -> f64).
+     */
+    #[test]
+    fn metadata_value_accessors() {
+        assert_eq!(MetadataValue::from("x").as_str(), "x");
+        assert_eq!(MetadataValue::from(7u32).as_u32(), 7);
+        assert_eq!(MetadataValue::from(-7i64).as_i64(), -7);
+        assert_eq!(MetadataValue::from(2i32).as_f64(), 2.0);
+        assert_eq!(MetadataValue::from(vec![9u8]).as_blob(), &[9]);
+        let r = std::panic::catch_unwind(|| MetadataValue::Int(1).as_str());
+        assert!(r.is_err());
+        let r = std::panic::catch_unwind(|| MetadataValue::Int(-1).as_u32());
+        assert!(r.is_err());
+    }
+
+    // -- save / .v ----------------------------------------------------------
+
+    /**
+     * Tests the .v container round-trip: pixels, header metadata
+     * (interpretation, resolution, offsets), orientation, and attached
+     * fields (string and blob) all survive encode_vips + decode.
+     */
+    #[test]
+    fn vips_roundtrip_preserves_pixels_and_metadata() {
+        let mut im = rgb_2x2()
+            .copy()
+            .interpretation(Interpretation::Bw)
+            .xres(4.5)
+            .yres(2.25)
+            .xoffset(-3)
+            .yoffset(9)
+            .orientation(6)
+            .build();
+        im.set_field("exif-data", MetadataValue::Blob(vec![9, 8, 7]));
+        im.set_field("note", "hello".into());
+        im.set_icc_profile(&[5, 5, 5]);
+
+        let bytes = im.encode_vips().unwrap();
+        assert!(is_vips_bytes(&bytes));
+        let back = decode_bytes(&bytes).unwrap();
+        assert_eq!(back.width(), 2);
+        assert_eq!(back.height(), 2);
+        assert_eq!(back.format(), PixelFormat::Rgb8);
+        assert_eq!(back.data(), im.data());
+        assert_eq!(back.interpretation(), Interpretation::Bw);
+        assert_eq!(back.xres(), 4.5);
+        assert_eq!(back.yres(), 2.25);
+        assert_eq!(back.xoffset(), -3);
+        assert_eq!(back.yoffset(), 9);
+        assert_eq!(back.orientation(), 6);
+        assert_eq!(back.get_field("exif-data"), im.get_field("exif-data"));
+        assert_eq!(back.get_field("note").unwrap().as_str(), "hello");
+        assert_eq!(back.icc_profile(), Some(&[5u8, 5, 5][..]));
+    }
+
+    /**
+     * Tests 16-bit .v round-trip including the byte-swap path: a file
+     * written in the foreign byte order decodes to the same samples.
+     */
+    #[test]
+    fn vips_16bit_and_foreign_endian() {
+        let im = Raster::new(
+            2,
+            1,
+            PixelFormat::Gray16,
+            [513u16, 65534]
+                .iter()
+                .flat_map(|v| v.to_ne_bytes())
+                .collect(),
+        )
+        .unwrap();
+        let bytes = im.encode_vips().unwrap();
+        let back = decode_bytes(&bytes).unwrap();
+        assert_eq!(back.data(), im.data());
+
+        // Flip the file to the foreign byte order by hand: swap the
+        // magic, every header word, and the 16-bit samples.
+        let mut foreign = bytes.clone();
+        foreign[..4].reverse();
+        for off in (4..VIPS_HEADER_LEN).step_by(4) {
+            // The header is i32 words except the two i16 words at 44/46,
+            // which are zero here, so a 4-byte reverse is safe for this
+            // all-zero region too... except it would swap their order.
+            // Keep it exact: reverse i32 words, then fix the i16 pair.
+            foreign[off..off + 4].reverse();
+        }
+        // Both i16 words are zero, so no fix-up is needed after the
+        // 4-byte reverse of bytes 44..48.
+        for off in (VIPS_HEADER_LEN..VIPS_HEADER_LEN + 4).step_by(2) {
+            foreign[off..off + 2].reverse();
+        }
+        // Drop the trailer: its JSON does not participate in byte order,
+        // and hand-flipping only covers header + pixels.
+        foreign.truncate(VIPS_HEADER_LEN + 4);
+        let swapped = decode_bytes(&foreign).unwrap();
+        assert_eq!(swapped.data(), im.data());
+        assert_eq!(swapped.format(), PixelFormat::Gray16);
+    }
+
+    /**
+     * Tests save/save_stripped through the extension dispatcher for .v:
+     * save keeps attached fields, save_stripped drops them but keeps
+     * pixels and header geometry.
+     */
+    #[test]
+    fn save_v_and_stripped() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut im = rgb_2x2();
+        im.set_icc_profile(&[1, 2, 3]);
+        im.set_field("note", "keep me".into());
+
+        let kept = dir.path().join("kept.v");
+        im.save(&kept).unwrap();
+        let back = decode_file(&kept).unwrap();
+        assert_eq!(back.icc_profile(), Some(&[1u8, 2, 3][..]));
+        assert_eq!(back.get_field("note").unwrap().as_str(), "keep me");
+
+        let stripped = dir.path().join("stripped.v");
+        im.save_stripped(&stripped).unwrap();
+        let back = decode_file(&stripped).unwrap();
+        assert_eq!(back.data(), im.data());
+        assert_eq!(back.icc_profile(), None);
+        assert_eq!(back.get_field("note"), None);
+        assert_eq!(back.get_field("exif-data"), None);
+    }
+
+    /**
+     * Tests save dispatch to PNG: the file decodes back to the same
+     * pixels (PNG is lossless), and unknown extensions error.
+     */
+    #[test]
+    fn save_png_and_unknown_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let im = rgb_2x2();
+        let png = dir.path().join("out.png");
+        im.save(&png).unwrap();
+        let back = decode_file(&png).unwrap();
+        assert_eq!(back.width(), 2);
+        assert_eq!(back.data(), im.data());
+
+        let err = im.save(&dir.path().join("out.webp")).unwrap_err();
+        assert!(
+            matches!(err, SaveError::UnsupportedExtension { .. }),
+            "{err}"
+        );
+        let err = im.save(&dir.path().join("noextension")).unwrap_err();
+        assert!(
+            matches!(err, SaveError::UnsupportedExtension { .. }),
+            "{err}"
+        );
+    }
+
+    /**
+     * Tests JPEG save keeps the ICC profile and EXIF blob while
+     * save_stripped drops them: the keep_icc/keep_none contract of the
+     * ported infrastructure suite, end to end through the decoder's
+     * segment scan.
+     */
+    #[test]
+    fn save_jpeg_keeps_and_strips_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut im = Raster::zeroed(8, 8, PixelFormat::Rgb8).unwrap();
+        let icc: Vec<u8> = (0u8..=255).cycle().take(400).collect();
+        im.set_icc_profile(&icc);
+        im.set_field("exif-data", MetadataValue::Blob(vec![0x4D, 0x4D, 0, 42]));
+
+        let kept = dir.path().join("kept.jpg");
+        im.save(&kept).unwrap();
+        let back = decode_file(&kept).unwrap();
+        assert_eq!(back.icc_profile(), Some(icc.as_slice()));
+        assert_eq!(
+            back.get_field("exif-data"),
+            Some(MetadataValue::Blob(vec![0x4D, 0x4D, 0, 42]))
+        );
+
+        let stripped = dir.path().join("stripped.jpg");
+        im.save_stripped(&stripped).unwrap();
+        let back = decode_file(&stripped).unwrap();
+        assert_eq!(back.icc_profile(), None);
+        assert_eq!(back.get_field("icc-profile-data"), None);
+        assert_eq!(back.get_field("exif-data"), None);
+    }
+
+    /**
+     * Tests decode_file attaches the filename field, like the libvips
+     * header's filename slot.
+     */
+    #[test]
+    fn decode_file_sets_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("named.v");
+        rgb_2x2().save(&path).unwrap();
+        let back = decode_file(&path).unwrap();
+        assert_eq!(
+            back.get_field("filename").unwrap().as_str(),
+            path.display().to_string()
+        );
+    }
+
+    /**
+     * Tests multi-chunk ICC embedding: a profile larger than one APP2
+     * segment splits into ordered chunks and reassembles on decode.
+     */
+    #[test]
+    fn jpeg_icc_multichunk_roundtrip() {
+        let icc: Vec<u8> = (0..(ICC_CHUNK_MAX + 1234))
+            .map(|i| (i % 251) as u8)
+            .collect();
+        let im = Raster::zeroed(4, 4, PixelFormat::Gray8).unwrap();
+        let jpeg = crate::sink::encode_jpeg(&im, 75).unwrap();
+        let with_icc = inject_jpeg_metadata(jpeg, None, Some(&icc));
+        let (exif, got) = extract_jpeg_metadata(&with_icc);
+        assert_eq!(exif, None);
+        assert_eq!(got.as_deref(), Some(icc.as_slice()));
+        // The stream still decodes as a JPEG.
+        assert!(decode_bytes(&with_icc).is_ok());
+    }
+
+    /**
+     * Tests the .v reader's typed rejections: bad magic, truncated
+     * header, truncated pixels, unsupported band format, and coding.
+     */
+    #[test]
+    fn vips_decode_rejects_malformed() {
+        let im = rgb_2x2();
+        let good = im.encode_vips().unwrap();
+
+        assert!(matches!(
+            decode_vips_bytes(&good[..10], DecodeLimits::default()),
+            Err(SourceError::VipsFormat(_))
+        ));
+
+        let mut bad_magic = good.clone();
+        bad_magic[0] = 0;
+        assert!(matches!(
+            decode_vips_bytes(&bad_magic, DecodeLimits::default()),
+            Err(SourceError::VipsFormat(_))
+        ));
+
+        let mut truncated = good.clone();
+        truncated.truncate(VIPS_HEADER_LEN + 2);
+        assert!(matches!(
+            decode_vips_bytes(&truncated, DecodeLimits::default()),
+            Err(SourceError::VipsFormat(_))
+        ));
+
+        let mut float_fmt = good.clone();
+        float_fmt[20..24].copy_from_slice(&6i32.to_ne_bytes()); // FLOAT
+        assert!(matches!(
+            decode_vips_bytes(&float_fmt, DecodeLimits::default()),
+            Err(SourceError::VipsFormat(_))
+        ));
+
+        let mut coded = good.clone();
+        coded[24..28].copy_from_slice(&1i32.to_ne_bytes()); // LABQ coding
+        assert!(matches!(
+            decode_vips_bytes(&coded, DecodeLimits::default()),
+            Err(SourceError::VipsFormat(_))
+        ));
+    }
+
+    /**
+     * Tests a real-libvips-style trailer (XML, not JSON) is tolerated:
+     * pixels and header decode, attached fields read as absent.
+     */
+    #[test]
+    fn vips_decode_ignores_foreign_trailer() {
+        let im = rgb_2x2();
+        let mut bytes = im.encode_vips_impl(false);
+        bytes.extend_from_slice(b"<root xmlns=\"http://www.vips.ecs.soton.ac.uk//dsim\"/>");
+        let back = decode_bytes(&bytes).unwrap();
+        assert_eq!(back.data(), im.data());
+        assert_eq!(back.get_field("note"), None);
+    }
+
+    // -- free functions -----------------------------------------------------
+
+    /**
+     * Tests the libvips tokeniser cases from the ported infrastructure
+     * suite plus escape handling.
+     */
+    #[test]
+    fn tokenize_quoting_and_escapes() {
+        assert_eq!(tokenize("hello world"), vec!["hello", "world"]);
+        assert_eq!(tokenize("\"hello world\""), vec!["hello world"]);
+        assert_eq!(tokenize("a \"b c\" d"), vec!["a", "b c", "d"]);
+        assert_eq!(tokenize("hello\\ world"), vec!["hello world"]);
+        assert_eq!(tokenize("'single quoted'"), vec!["single quoted"]);
+        assert_eq!(tokenize("\"esc \\\" quote\""), vec!["esc \" quote"]);
+        assert_eq!(tokenize("   "), Vec::<String>::new());
+        assert_eq!(tokenize(""), Vec::<String>::new());
+        // Unterminated quote: the rest of the string is one token.
+        assert_eq!(tokenize("\"open ended"), vec!["open ended"]);
+    }
+
+    /**
+     * Tests the thumbnail geometry parser forms: W, WxH, Wx, xH,
+     * modifiers, and garbage.
+     */
+    #[test]
+    fn thumbnail_geometry_forms() {
+        assert_eq!(
+            parse_thumbnail_geometry("200"),
+            ThumbnailGeometry {
+                width: Some(200),
+                height: None
+            }
+        );
+        assert_eq!(
+            parse_thumbnail_geometry("200x150"),
+            ThumbnailGeometry {
+                width: Some(200),
+                height: Some(150)
+            }
+        );
+        assert_eq!(
+            parse_thumbnail_geometry("200x"),
+            ThumbnailGeometry {
+                width: Some(200),
+                height: None
+            }
+        );
+        assert_eq!(
+            parse_thumbnail_geometry("x150"),
+            ThumbnailGeometry {
+                width: None,
+                height: Some(150)
+            }
+        );
+        assert_eq!(
+            parse_thumbnail_geometry(" 200x150> "),
+            ThumbnailGeometry {
+                width: Some(200),
+                height: Some(150)
+            }
+        );
+        assert_eq!(
+            parse_thumbnail_geometry("128X128!"),
+            ThumbnailGeometry {
+                width: Some(128),
+                height: Some(128)
+            }
+        );
+        assert_eq!(
+            parse_thumbnail_geometry("banana"),
+            ThumbnailGeometry::default()
+        );
+    }
+
+    /**
+     * Tests the max_coord global: default, set/get round-trip, env
+     * re-init (with suffix parsing), and enforcement in the .v reader.
+     * Runs as one test so the process-global state is exercised
+     * sequentially and restored.
+     */
+    #[test]
+    fn max_coord_accessors_env_and_enforcement() {
+        assert_eq!(get_max_coord(), DEFAULT_MAX_COORD);
+
+        set_max_coord(1000);
+        assert_eq!(get_max_coord(), 1000);
+
+        // Enforcement: a .v header claiming 2000 px is rejected while the
+        // ceiling is 1000, and accepted once the ceiling is raised.
+        let im = Raster::zeroed(2000, 1, PixelFormat::Gray8).unwrap();
+        let bytes = im.encode_vips().unwrap();
+        let err = decode_vips_bytes(&bytes, DecodeLimits::default()).unwrap_err();
+        assert!(
+            matches!(err, SourceError::VipsFormat(ref m) if m.contains("max_coord")),
+            "{err}"
+        );
+        set_max_coord(DEFAULT_MAX_COORD);
+        assert!(decode_vips_bytes(&bytes, DecodeLimits::default()).is_ok());
+
+        // Env re-init, including the binary suffix form.
+        // SAFETY: test-local mutation of this process's environment; the
+        // variable is removed again before the test ends.
+        unsafe { std::env::set_var("VIPS_MAX_COORD", "500") };
+        init_from_env();
+        assert_eq!(get_max_coord(), 500);
+        unsafe { std::env::set_var("VIPS_MAX_COORD", "2k") };
+        init_from_env();
+        assert_eq!(get_max_coord(), 2048);
+        // Garbage leaves the setting untouched.
+        unsafe { std::env::set_var("VIPS_MAX_COORD", "lots") };
+        init_from_env();
+        assert_eq!(get_max_coord(), 2048);
+        unsafe { std::env::remove_var("VIPS_MAX_COORD") };
+        init_from_env();
+        assert_eq!(get_max_coord(), 2048);
+
+        set_max_coord(DEFAULT_MAX_COORD);
+    }
+
+    /**
+     * Tests parse_size suffixes and saturation.
+     */
+    #[test]
+    fn parse_size_suffixes() {
+        assert_eq!(parse_size("123"), Some(123));
+        assert_eq!(parse_size("2k"), Some(2048));
+        assert_eq!(parse_size("3M"), Some(3 * 1024 * 1024));
+        assert_eq!(parse_size("1g"), Some(1 << 30));
+        assert_eq!(parse_size("999g"), Some(u32::MAX));
+        assert_eq!(parse_size(""), None);
+        assert_eq!(parse_size("k"), None);
+        assert_eq!(parse_size("-5"), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod arithmetic;
 pub mod bands;
 pub mod cancel;
 pub mod checksum;
+pub mod composite;
 pub mod conversion;
 pub mod dedupe;
 pub mod draw;
@@ -61,6 +62,7 @@ pub mod extensions;
 pub mod extract;
 pub mod geo;
 pub mod histogram;
+pub mod imageio;
 pub(crate) mod level_walk;
 #[cfg(loom)]
 mod loom_tests;
@@ -98,6 +100,7 @@ pub use arithmetic::ArithmeticError;
 pub use bands::BandError;
 pub use cancel::CancelToken;
 pub use checksum::{ChecksumMode, VerifyError, VerifyReport};
+pub use composite::{CompositeError, CompositeMode};
 pub use conversion::{Angle, ConversionError, Interpretation, RasterCopyBuilder};
 pub use dedupe::{DedupeDecision, DedupeIndex, DedupeStrategy, LinkResult};
 pub use draw::{Circle, DrawError, DrawOp, Flood, Line, Mask, Paste, Rectangle, Smudge};
@@ -108,6 +111,13 @@ pub use engine_builder::{EngineBuilder, EngineKind, EngineSource, IntoEngineSour
 pub use extract::{CompassDirection, Extend, ExtractError, SmartcropInteresting};
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};
 pub use histogram::HistogramError;
+// The imageio free functions are re-exported at the root (not just behind
+// the module path) because the ported tests import them from the crate
+// root (`use libviprs::{tokenize, get_max_coord, ...}`).
+pub use imageio::{
+    MetadataError, MetadataValue, SaveError, ThumbnailGeometry, get_max_coord, init_from_env,
+    parse_thumbnail_geometry, set_max_coord, tokenize,
+};
 pub use manifest::{
     ChecksumAlgo, Checksums, GenerationSettings, LevelMetadata, Manifest, ManifestBuilder,
     ManifestError, ManifestV1, SourceMetadata, SparsePolicy,

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -1,4 +1,5 @@
 use crate::conversion::RasterMeta;
+use crate::imageio::MetadataFields;
 use crate::pixel::PixelFormat;
 use thiserror::Error;
 
@@ -160,6 +161,12 @@ pub struct Raster {
     /// starts from [`RasterMeta::default`]; [`Raster::copy`] and
     /// [`Raster::autorot`] are the mutation surface.
     pub(crate) meta: RasterMeta,
+    /// Attached metadata fields (ICC profile, EXIF blob, arbitrary named
+    /// values), managed by the IO operations (see [`crate::imageio`]).
+    /// Every constructor starts empty; [`Raster::set_field`] and the
+    /// decoders are the mutation surface, and the fields travel with
+    /// clones and [`Raster::copy`].
+    pub(crate) fields: MetadataFields,
 }
 
 impl Raster {
@@ -232,6 +239,7 @@ impl Raster {
             format,
             data,
             meta: RasterMeta::default(),
+            fields: MetadataFields::default(),
         })
     }
 
@@ -279,6 +287,7 @@ impl Raster {
             format,
             data,
             meta: RasterMeta::default(),
+            fields: MetadataFields::default(),
         })
     }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1841,7 +1841,9 @@ pub fn encode_png(raster: &Raster) -> Result<Vec<u8>, SinkError> {
     Ok(buf)
 }
 
-fn encode_jpeg(raster: &Raster, quality: u8) -> Result<Vec<u8>, SinkError> {
+// Crate-visible so extension-dispatched save (`crate::imageio`) reuses the
+// sink's JPEG encode path.
+pub(crate) fn encode_jpeg(raster: &Raster, quality: u8) -> Result<Vec<u8>, SinkError> {
     let mut buf = Vec::new();
     let encoder =
         image::codecs::jpeg::JpegEncoder::new_with_quality(std::io::Cursor::new(&mut buf), quality);

--- a/src/source.rs
+++ b/src/source.rs
@@ -34,6 +34,11 @@ pub enum SourceError {
         height: u32,
         max_pixels: u64,
     },
+    /// A malformed or unsupported native `.v` file (bad magic, truncated
+    /// header or pixel data, unsupported coding/band format, or header
+    /// geometry past the [`crate::imageio::get_max_coord`] ceiling).
+    #[error("vips .v file error: {0}")]
+    VipsFormat(String),
 }
 
 /// Resource limits applied to a single image decode.
@@ -84,7 +89,9 @@ impl DecodeLimits {
     }
 
     /// Enforce the `width * height` ceiling before a [`Raster`] is built.
-    fn check_pixels(self, width: u32, height: u32) -> Result<(), SourceError> {
+    /// Crate-visible so the `.v` decoder in [`crate::imageio`] applies
+    /// the same budget to its untrusted header geometry.
+    pub(crate) fn check_pixels(self, width: u32, height: u32) -> Result<(), SourceError> {
         let pixels = u64::from(width).saturating_mul(u64::from(height));
         if pixels > self.max_pixels {
             return Err(SourceError::DimensionLimitExceeded {
@@ -141,7 +148,34 @@ pub fn decode_file(path: &Path) -> Result<Raster, SourceError> {
 /// allocated, and the `width * height` ceiling is checked before the
 /// [`Raster`] is constructed.
 pub fn decode_file_with_limits(path: &Path, limits: DecodeLimits) -> Result<Raster, SourceError> {
-    decode_reader(ImageReader::open(path)?, limits)
+    // Sniff the leading magic: native .v files and JPEGs take the
+    // in-memory path (the .v decoder parses the libvips header itself,
+    // and the JPEG path scans APP1/APP2 segments for EXIF/ICC metadata
+    // after pixel decode). Every other format keeps the original
+    // streaming reader so its memory profile is unchanged.
+    let mut head = [0u8; 4];
+    {
+        use std::io::Read;
+        let mut file = std::fs::File::open(path)?;
+        let mut filled = 0;
+        while filled < head.len() {
+            let n = file.read(&mut head[filled..])?;
+            if n == 0 {
+                break;
+            }
+            filled += n;
+        }
+    }
+    let mut raster = if crate::imageio::is_vips_bytes(&head) || head[..3] == [0xFF, 0xD8, 0xFF] {
+        decode_bytes_with_limits(&std::fs::read(path)?, limits)?
+    } else {
+        decode_reader(ImageReader::open(path)?, limits)?
+    };
+    // Record the source path, like the libvips header's filename slot.
+    raster
+        .fields
+        .set("filename", path.display().to_string().into());
+    Ok(raster)
 }
 
 /// Decode from an in-memory buffer (format auto-detected).
@@ -171,10 +205,18 @@ pub fn decode_bytes(bytes: &[u8]) -> Result<Raster, SourceError> {
 /// before any pixel data is allocated, and the `width * height` ceiling
 /// is checked before the [`Raster`] is constructed.
 pub fn decode_bytes_with_limits(bytes: &[u8], limits: DecodeLimits) -> Result<Raster, SourceError> {
-    decode_reader(
-        ImageReader::new(Cursor::new(bytes)).with_guessed_format()?,
-        limits,
-    )
+    if crate::imageio::is_vips_bytes(bytes) {
+        return crate::imageio::decode_vips_bytes(bytes, limits);
+    }
+    let reader = ImageReader::new(Cursor::new(bytes)).with_guessed_format()?;
+    let is_jpeg = reader.format() == Some(image::ImageFormat::Jpeg);
+    let mut raster = decode_reader(reader, limits)?;
+    if is_jpeg {
+        // Attach the EXIF/ICC metadata segments the pixel decoder skips,
+        // as the libvips JPEG loader populates the image header.
+        crate::imageio::attach_jpeg_metadata(&mut raster, bytes);
+    }
+    Ok(raster)
 }
 
 /// Apply the shared decode budget to a configured [`ImageReader`] and

--- a/tests/composite_ported_surface.rs
+++ b/tests/composite_ported_surface.rs
@@ -1,0 +1,137 @@
+//! Pins the compositing call surface required by the libviprs-tests
+//! ported suite (libviprs-tests issue #55, the `test_composite` and
+//! `test_composite_non_separable` call sites in
+//! `tests/ported_conversion.rs`).
+//!
+//! Integration tests compile as an external crate, exactly the position
+//! the ported tests are in, so this file proves the surface they call
+//! compiles and behaves: `base.composite(&overlay, CompositeMode::...)`
+//! with the mode names the ported suite constructs, composed with the
+//! already-landed `add_const` / `bandjoin_const` / `getpoint` surface.
+//! Behaviour depth is covered by the unit tests in `src/composite.rs`;
+//! this file is the API contract.
+//!
+//! The ported `test_composite` fixture is `mask_ideal(100, 100, 0.5,
+//! reject, optical)`, whose (0, 0) pixel is 0, making `colour`'s (0, 0)
+//! pixel `[2, 3, 4]`. The fixture is reproduced with those exact corner
+//! values so the ported expected values (51.8 / 52.8 / 53.8) stay
+//! literal. The ported non-separable test additionally casts its inputs
+//! to a float pixel format before compositing; that cast target arrives
+//! with the float-format batch, so the non-separable pin runs on the
+//! integer inputs the operation accepts today and keeps the ported
+//! geometry assertions.
+
+use libviprs::{CompositeMode, PixelFormat, Raster};
+
+/// Stand-in for the ported `colour` fixture: a 100x100 Rgb8 image whose
+/// (0, 0) pixel is `[2, 3, 4]` (the libvips mask_ideal optical-reject
+/// origin value) with a radial texture elsewhere.
+fn make_test_colour() -> Raster {
+    let w = 100u32;
+    let h = 100u32;
+    let mut data = vec![0u8; (w * h * 3) as usize];
+    for y in 0..h {
+        for x in 0..w {
+            let dx = x as f64 / w as f64;
+            let dy = y as f64 / h as f64;
+            let r = (dx * dx + dy * dy).sqrt();
+            let v = if r > 0.5 { (r * 200.0).min(255.0) } else { 0.0 };
+            let off = ((y * w + x) * 3) as usize;
+            data[off] = ((v + 2.0) as u16).min(255) as u8;
+            data[off + 1] = ((v * 2.0 + 3.0) as u16).min(255) as u8;
+            data[off + 2] = ((v * 3.0 + 4.0) as u16).min(255) as u8;
+        }
+    }
+    Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+}
+
+/// The ported `test_composite` body: overlay `colour` with alpha 128
+/// Over `colour + 100`, expecting the libvips values at (0, 0).
+#[test]
+fn ported_composite_call_site() {
+    let colour = make_test_colour();
+    let overlay = colour.bandjoin_const(128.0);
+    let base = colour.add_const(100.0);
+
+    let comp = base.composite(&overlay, CompositeMode::Over);
+    let px = comp.getpoint(0, 0);
+    assert!((px[0] - 51.8).abs() < 1.0, "{px:?}");
+    assert!((px[1] - 52.8).abs() < 1.0, "{px:?}");
+    assert!((px[2] - 53.8).abs() < 1.0, "{px:?}");
+}
+
+/// The ported `test_composite_non_separable` body (minus the
+/// float-format cast; see the module docs): every non-separable mode
+/// preserves geometry and produces a 4-channel result.
+#[test]
+fn ported_composite_non_separable_call_site() {
+    let colour = make_test_colour();
+    let base = colour.add_const(100.0).bandjoin_const(255.0);
+    let overlay = colour.bandjoin_const(128.0);
+
+    for mode in &[
+        CompositeMode::Hue,
+        CompositeMode::Saturation,
+        CompositeMode::Colour,
+        CompositeMode::Luminosity,
+    ] {
+        let comp = base.composite(&overlay, *mode);
+        assert_eq!(comp.width(), base.width());
+        assert_eq!(comp.height(), base.height());
+        assert_eq!(comp.format().channels(), 4);
+    }
+}
+
+/// `composite2` is the binary libvips name for the same call shape.
+#[test]
+fn composite2_call_site() {
+    let colour = make_test_colour();
+    let overlay = colour.bandjoin_const(128.0);
+    let a = colour.composite(&overlay, CompositeMode::Over);
+    let b = colour.composite2(&overlay, CompositeMode::Over);
+    assert_eq!(a.data(), b.data());
+}
+
+/// Compile-position pin for every blend mode name the ported suites can
+/// construct: the full Porter-Duff set, the PDF separable set, and the
+/// PDF non-separable set.
+#[test]
+fn all_mode_names_construct() {
+    let modes = [
+        CompositeMode::Clear,
+        CompositeMode::Source,
+        CompositeMode::Over,
+        CompositeMode::In,
+        CompositeMode::Out,
+        CompositeMode::Atop,
+        CompositeMode::Dest,
+        CompositeMode::DestOver,
+        CompositeMode::DestIn,
+        CompositeMode::DestOut,
+        CompositeMode::DestAtop,
+        CompositeMode::Xor,
+        CompositeMode::Add,
+        CompositeMode::Saturate,
+        CompositeMode::Multiply,
+        CompositeMode::Screen,
+        CompositeMode::Overlay,
+        CompositeMode::Darken,
+        CompositeMode::Lighten,
+        CompositeMode::ColourDodge,
+        CompositeMode::ColourBurn,
+        CompositeMode::HardLight,
+        CompositeMode::SoftLight,
+        CompositeMode::Difference,
+        CompositeMode::Exclusion,
+        CompositeMode::Hue,
+        CompositeMode::Saturation,
+        CompositeMode::Colour,
+        CompositeMode::Luminosity,
+    ];
+    let base = Raster::zeroed(2, 2, PixelFormat::Rgba8).unwrap();
+    let overlay = Raster::zeroed(2, 2, PixelFormat::Rgba8).unwrap();
+    for mode in modes {
+        let out = base.composite(&overlay, mode);
+        assert_eq!(out.format().channels(), 4, "{mode:?}");
+    }
+}

--- a/tests/io_ported_surface.rs
+++ b/tests/io_ported_surface.rs
@@ -1,0 +1,261 @@
+//! Pins the IO / metadata / free-function call surface required by the
+//! libviprs-tests ported suite (libviprs-tests issue #55:
+//! `tests/ported_infrastructure.rs` metadata + tokenization + CLI
+//! sections, the `save` / `get_field` / `set_field` / `set_typeof` call
+//! sites in `ported_foreign.rs`, and the `save` call sites in
+//! `ported_iofuncs.rs`).
+//!
+//! Integration tests compile as an external crate, exactly the position
+//! the ported tests are in, so this file proves the surface they call
+//! compiles and behaves: method names, argument types, `.into()`
+//! conversions, and return types. Behaviour depth is covered by the unit
+//! tests in `src/imageio.rs`; this file is the API contract.
+//!
+//! Where a ported test's setup decodes a fixture (`sample.jpg` with its
+//! embedded ICC profile), the setup is reproduced with a synthetic
+//! raster carrying a synthetic profile, and the metadata expressions are
+//! kept literal.
+
+use std::path::Path;
+
+use libviprs::{MetadataValue, PixelFormat, Raster, decode_file};
+
+/// Stand-in for the `sample.jpg` decode: a small RGB image with an ICC
+/// profile and an EXIF blob attached, the two fields the keep/strip
+/// ported tests read back.
+fn sample_like() -> Raster {
+    let mut data = vec![0u8; 32 * 32 * 3];
+    for (i, b) in data.iter_mut().enumerate() {
+        *b = (i % 251) as u8;
+    }
+    let mut im = Raster::new(32, 32, PixelFormat::Rgb8, data).unwrap();
+    im.set_icc_profile(&[0, 0, 1, 44, 65, 68, 66, 69]);
+    im.set_field("exif-data", MetadataValue::Blob(vec![0x49, 0x49, 42, 0]));
+    im
+}
+
+/// The ported `test_keep_icc` body: save keeps the ICC profile.
+#[test]
+fn ported_keep_icc_call_site() {
+    let im = sample_like();
+    let profile = im.get_field("icc-profile-data");
+    assert!(profile.is_some(), "fixture should have an ICC profile");
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("keep_icc.jpg");
+    im.save(&out).unwrap();
+
+    let im2 = decode_file(&out).unwrap();
+    let profile2 = im2.get_field("icc-profile-data");
+    assert!(
+        profile2.is_some(),
+        "ICC profile should be preserved after save"
+    );
+}
+
+/// The ported `test_keep_none` body: save_stripped drops ICC and EXIF.
+#[test]
+fn ported_keep_none_call_site() {
+    let im = sample_like();
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("stripped.jpg");
+    im.save_stripped(&out).unwrap();
+
+    let im2 = decode_file(&out).unwrap();
+    assert!(
+        im2.get_field("icc-profile-data").is_none(),
+        "ICC should be stripped"
+    );
+    assert!(
+        im2.get_field("exif-data").is_none(),
+        "EXIF should be stripped"
+    );
+}
+
+/// The ported `test_keep_custom_profile` body: attach a profile, save,
+/// reload, and match the `MetadataValue::Blob` pattern on the field.
+#[test]
+fn ported_keep_custom_profile_call_site() {
+    let mut im = sample_like();
+    let srgb_icc = vec![7u8; 480];
+    im.set_icc_profile(&srgb_icc);
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("custom_icc.jpg");
+    im.save(&out).unwrap();
+
+    let im2 = decode_file(&out).unwrap();
+    if let Some(MetadataValue::Blob(profile)) = im2.get_field("icc-profile-data") {
+        assert_eq!(
+            profile.len(),
+            srgb_icc.len(),
+            "ICC profile size should match"
+        );
+        assert_eq!(profile, srgb_icc);
+    } else {
+        panic!("Custom ICC profile should be preserved");
+    }
+}
+
+/// The ported `test_vips` body: `.v` save/load round-trip preserving
+/// EXIF and pixels (`Path::join` produces the `&PathBuf` argument shape
+/// the ported tests pass to `save`).
+#[test]
+fn ported_test_vips_call_site() {
+    let im = sample_like();
+    let dir = tempfile::tempdir().unwrap();
+    let out_v = dir.path().join("test.v");
+    im.save(&out_v).unwrap();
+    let im2 = decode_file(&out_v).unwrap();
+    assert_eq!(im2.width(), im.width());
+    assert_eq!(im2.height(), im.height());
+    assert_eq!(im.get_field("exif-data"), im2.get_field("exif-data"));
+
+    // Part 2: synthetic 16x16 constant image round-trip.
+    let data = vec![128u8; 16 * 16 * 3];
+    let synth = Raster::new(16, 16, PixelFormat::Rgb8, data).unwrap();
+    let out_v2 = dir.path().join("synth.v");
+    synth.save(&out_v2).unwrap();
+    let synth2 = decode_file(&out_v2).unwrap();
+    assert_eq!(synth2.width(), 16);
+    assert_eq!(synth2.height(), 16);
+    assert_eq!(synth2.data(), synth.data());
+}
+
+/// The ported `test_jpegsave_exif` field expressions: `set_field` with
+/// `.into()` string conversions, `get_field(...).unwrap().as_str()`, and
+/// tag removal via `set_typeof(..., 0)` observed with `get_typeof`.
+/// Structured EXIF embedding in the JPEG APP1 TIFF directory is deferred
+/// to the foreign batch, so the round-trip here goes through `.v`, which
+/// carries every attached field.
+#[test]
+fn ported_exif_field_call_sites() {
+    let mut im = sample_like();
+    im.set_field("exif-ifd2-UserComment", "Hello UserComment".into());
+    im.set_field("exif-ifd0-Software", "TestSoftware".into());
+    im.set_field("exif-ifd0-XPComment", "TestXPComment".into());
+    let tag = "exif-ifd0-CameraOwnerName";
+    im.set_field(tag, format!("test-{tag}").into());
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("exif_fields.v");
+    im.save(&out).unwrap();
+    let im2 = decode_file(&out).unwrap();
+    assert_eq!(
+        im2.get_field("exif-ifd2-UserComment").unwrap().as_str(),
+        "Hello UserComment"
+    );
+    assert_eq!(
+        im2.get_field("exif-ifd0-Software").unwrap().as_str(),
+        "TestSoftware"
+    );
+    assert_eq!(
+        im2.get_field("exif-ifd0-XPComment").unwrap().as_str(),
+        "TestXPComment"
+    );
+    assert_eq!(im2.get_field(tag).unwrap().as_str(), format!("test-{tag}"));
+
+    // Tag removal via typeof == 0.
+    im.set_typeof("exif-ifd0-Software", 0);
+    let out2 = dir.path().join("exif_removed.v");
+    im.save(&out2).unwrap();
+    let im3 = decode_file(&out2).unwrap();
+    assert_eq!(im3.get_typeof("exif-ifd0-Software"), 0);
+}
+
+/// The ported `test_get_fields` body (from `ported_iofuncs.rs`): more
+/// than 10 fields, "width" first.
+#[test]
+fn ported_get_fields_call_site() {
+    let im = Raster::zeroed(10, 10, PixelFormat::Gray8).unwrap();
+    let fields = im.get_fields();
+    assert!(
+        fields.len() > 10,
+        "Should have more than 10 fields, got {}",
+        fields.len()
+    );
+    assert_eq!(fields[0], "width");
+}
+
+/// The metadata getters the ported suites read alongside `get_field`:
+/// width/height/bands via fields, format/interpretation/resolution/
+/// offsets/orientation via both the typed getters and the field system.
+#[test]
+fn ported_header_getter_call_sites() {
+    let im = sample_like();
+    assert_eq!(im.get_field("width").unwrap().as_u32(), 32);
+    assert_eq!(im.get_field("height").unwrap().as_u32(), 32);
+    assert_eq!(im.get_field("bands").unwrap().as_u32(), 3);
+    assert_eq!(im.get_field("format").unwrap().as_str(), "uchar");
+    assert_eq!(im.get_field("interpretation").unwrap().as_str(), "srgb");
+    assert_eq!(im.get_field("orientation").unwrap().as_u32(), 1);
+    assert_eq!(im.get_field("xres").unwrap().as_f64(), im.xres());
+    assert_eq!(im.get_field("yres").unwrap().as_f64(), im.yres());
+    assert_eq!(im.get_field("xoffset").unwrap().as_i64(), 0);
+    assert_eq!(im.get_field("yoffset").unwrap().as_i64(), 0);
+}
+
+/// The ported `test_token_parsing` body (13.7 Tokenization).
+#[test]
+fn ported_token_parsing_call_site() {
+    use libviprs::tokenize;
+
+    let result = tokenize("hello world");
+    assert_eq!(result, vec!["hello", "world"]);
+
+    let result = tokenize("\"hello world\"");
+    assert_eq!(result, vec!["hello world"]);
+
+    let result = tokenize("a \"b c\" d");
+    assert_eq!(result, vec!["a", "b c", "d"]);
+}
+
+/// The ported `test_cli_thumbnail` geometry expressions (13.8 CLI).
+#[test]
+fn ported_thumbnail_geometry_call_site() {
+    use libviprs::parse_thumbnail_geometry;
+
+    let geom = parse_thumbnail_geometry("200");
+    assert_eq!(geom.width, Some(200));
+
+    let geom = parse_thumbnail_geometry("200x150");
+    assert_eq!(geom.width, Some(200));
+    assert_eq!(geom.height, Some(150));
+}
+
+/// The ported `test_cli_max_coord_flag` and `test_cli_max_coord_env`
+/// bodies, run sequentially in one test because they exercise the same
+/// process-wide setting (and restored afterwards so parallel tests are
+/// unaffected: the values used stay far above any fixture size).
+#[test]
+fn ported_max_coord_call_sites() {
+    use libviprs::{get_max_coord, init_from_env, set_max_coord};
+
+    set_max_coord(1000);
+    assert_eq!(get_max_coord(), 1000);
+
+    // A small image should succeed regardless of the ceiling.
+    let result = Raster::zeroed(500, 500, PixelFormat::Gray8).unwrap();
+    assert_eq!(result.width(), 500);
+
+    // SAFETY: test-local mutation of this process's environment; the
+    // variable is removed again before the test ends.
+    unsafe { std::env::set_var("VIPS_MAX_COORD", "500") };
+    init_from_env();
+    assert_eq!(get_max_coord(), 500);
+    unsafe { std::env::remove_var("VIPS_MAX_COORD") };
+
+    set_max_coord(libviprs::imageio::DEFAULT_MAX_COORD);
+}
+
+/// `Raster::save` accepts a `&Path` directly, the other argument shape
+/// the ported tests use.
+#[test]
+fn save_accepts_path_ref() {
+    let dir = tempfile::tempdir().unwrap();
+    let owned = dir.path().join("as_path.png");
+    let path: &Path = owned.as_path();
+    sample_like().save(path).unwrap();
+    assert!(path.exists());
+}


### PR DESCRIPTION
Seventh batch of the incremental libvips op port for libviprs-tests#55: the IO / metadata / free-function surface plus the compositing op, in two new modules disjoint from the six existing op modules.

## src/imageio.rs

- `Raster::save(path)` / `Raster::save_stripped(path)`: extension-dispatched encode (PNG, JPEG at quality 75, native `.v`), with `save_stripped` writing pixels only. Unknown extensions return the typed `SaveError::UnsupportedExtension`.
- `Raster::encode_vips()`: the libvips 64-byte native header (both byte orders on read, native order on write), raw pixels, and a JSON metadata trailer. The reader rejects non-uchar/ushort band formats (float `.v` waits for the float-format batch), tolerates foreign (XML) trailers, and enforces the `max_coord` ceiling plus `DecodeLimits` on untrusted header geometry.
- Named metadata fields over the new `MetadataValue` enum (int / double / string / blob): `get_field`, `set_field` / `try_set_field` (typed `MetadataError`), `get_fields` (built-ins first, `width` leading), `get_typeof` / `set_typeof` (0 removes, the libvips idiom), `set_icc_profile` / `icc_profile`. Built-in header fields read through to the raster header; geometry fields are read-only.
- JPEG save embeds `icc-profile-data` (APP2, multi-chunk) and the raw `exif-data` blob (APP1); the decoder scans the segments back into fields. `decode_file` also records the source path in `filename`.
- Free functions at the crate root, matching the ported-test imports: `tokenize`, `parse_thumbnail_geometry` -> `ThumbnailGeometry { width, height }`, `get_max_coord` / `set_max_coord` (default 10,000,000, the libvips `VIPS_MAX_COORD`), `init_from_env` (reads `VIPS_MAX_COORD`, binary k/m/g suffixes).

## src/composite.rs

- `Raster::composite` / `composite2` (+ typed `try_composite2`) with `CompositeMode`: the full libvips `VipsBlendMode` set (Clear, Source, Over, In, Out, Atop, Dest, DestOver, DestIn, DestOut, DestAtop, Xor, Add, Saturate, Multiply, Screen, Overlay, Darken, Lighten, ColourDodge, ColourBurn, HardLight, SoftLight, Difference, Exclusion) plus the four PDF non-separable modes (Hue, Saturation, Colour, Luminosity) the ported conversion suite constructs.
- Blending runs premultiplied in f64 on the libvips `max_alpha` scale (255 unless both inputs are 16-bit) and writes back at the deeper input's depth, so every mode is exact to the output quantisation; no mode is blocked on a float `PixelFormat`. The ported non-separable test's `cast(RgbaF32)` setup remains a float-format-batch item, independent of this op.

## Deferred (noted in module docs)

- Structured EXIF tag encoding (`exif-ifd*-*` into the JPEG APP1 TIFF directory) and PNG iCCP embedding: foreign-format batch. The fields round-trip via `.v` and travel on the raster.
- Float `.v` band formats and the `RgbaF32` cast target: float-format batch.
- `max_coord` enforcement inside the in-memory `Raster` constructors stays deferred so their existing typed-error contracts are untouched; the `.v` reader enforces it on untrusted headers.

Existing behavior unchanged: `Raster` gains a crate-private attached-fields block (empty by default, travels with clones/`copy()`), sink's JPEG encoder becomes crate-visible, `SourceError` gains the additive `VipsFormat` variant, and non-JPEG/non-`.v` file decodes keep the original streaming reader.

Local mirror green: `make fmt`, `make clippy` (default + pdfium, -D warnings), `make test` (21/21 binaries, including the new unit suites and the two ported-surface pin files `tests/io_ported_surface.rs` / `tests/composite_ported_surface.rs`).