### PR TITLE
feat(core): libvips morphology and mosaicing ops in two new modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ pub(crate) mod level_walk;
 mod loom_tests;
 pub mod manifest;
 pub(crate) mod mapreduce_hot_cache;
+pub mod morphology;
+pub mod mosaicing;
 pub mod observe;
 pub mod pdf;
 pub mod pixel;
@@ -124,6 +126,8 @@ pub use manifest::{
     ChecksumAlgo, Checksums, GenerationSettings, LevelMetadata, Manifest, ManifestBuilder,
     ManifestError, ManifestV1, SourceMetadata, SparsePolicy,
 };
+pub use morphology::{Direction, MorphologyError};
+pub use mosaicing::{MergeDirection, MosaicError};
 pub use observe::{
     CollectingObserver, EngineEvent, EngineObserver, FanOutObserver, MemoryTracker, WorkerId,
 };

--- a/src/morphology.rs
+++ b/src/morphology.rs
@@ -1,0 +1,1014 @@
+//! Morphological operations ported from libvips.
+//!
+//! This module is the next batch of the libvips operation surface required
+//! by the ported integration tests (after [`crate::bands`],
+//! [`crate::arithmetic`], [`crate::extract`], [`crate::conversion`],
+//! [`crate::draw`], [`crate::histogram`], [`crate::imageio`],
+//! [`crate::composite`], and [`crate::colour`]): binary erosion and
+//! dilation with a structuring element, the rank (order-statistic) filter,
+//! line counting, and connected-component labelling. Operations that can
+//! fail on caller input exist in two forms, following the established
+//! convention:
+//!
+//! * a fallible `try_*` method returning `Result<_, MorphologyError>` with
+//!   typed errors for bad structuring elements, out-of-range windows, and
+//!   unsupported formats; and
+//! * a panicking convenience method matching the ported-test call surface
+//!   (`erode`, `dilate`, `rank`, `countlines`, `label_regions`) exactly,
+//!   delegating to the `try_*` form.
+//!
+//! # Operations
+//!
+//! | Method | libvips equivalent | Result |
+//! |---|---|---|
+//! | [`Raster::erode`] | `vips_morph` with `VIPS_OPERATION_MORPHOLOGY_ERODE` | eroded image |
+//! | [`Raster::dilate`] | `vips_morph` with `VIPS_OPERATION_MORPHOLOGY_DILATE` | dilated image |
+//! | [`Raster::rank`] | `vips_rank` | order-statistic filtered image |
+//! | [`Raster::countlines`] | `vips_countlines` | average line count, `f64` |
+//! | [`Raster::label_regions`] | `vips_labelregions` | (label mask, segment count) |
+//!
+//! # Semantics shared with libvips
+//!
+//! * **Structuring elements.** `erode` / `dilate` take the mask as rows of
+//!   bytes where `255` means the input must be non-zero (object), `0`
+//!   means it must be zero (background), and `128` means don't care. Any
+//!   other value is a typed error, exactly like the libvips "bad mask
+//!   element" check. The mask origin is at `(width / 2, height / 2)`,
+//!   integer division.
+//! * **Bitwise combination.** libvips combines mask hits with bitwise
+//!   AND/OR over the sample bytes (`vips_erode_gen` starts at 255 and
+//!   ANDs `coeff ? p : ~p`; dilate starts at 0 and ORs). For the 0/255
+//!   binary images the operations are defined over this is boolean
+//!   erosion/dilation; for intermediate grey values the same bitwise
+//!   behaviour is reproduced here.
+//! * **Edges.** The input is notionally extended by replicating its edge
+//!   pixels (`VIPS_EXTEND_COPY`), so the output has the same dimensions as
+//!   the input. The rank filter extends the same way.
+//! * **Bands.** All operations except `countlines` treat each band
+//!   independently. `countlines` requires a one-band image, as in libvips.
+//! * **Depths.** `erode` and `dilate` accept 8-bit images (libvips casts
+//!   other depths to uchar first; here the cast is left to the caller and
+//!   deeper formats are a typed error). `rank` accepts unsigned 8- and
+//!   16-bit images. `countlines` and `label_regions` accept unsigned 8-
+//!   and 16-bit images; float rasters are a typed error for every
+//!   operation, matching the "cast first" convention used by the
+//!   histogram batch.
+//! * **`label_regions` labels.** libvips scans row-major for the first
+//!   unlabelled pixel and flood-fills the 4-connected region of equal
+//!   pixel value with the next serial, *starting from 1*; the reported
+//!   segment count is the final serial, i.e. `regions + 1`. A black
+//!   image with one white circle therefore yields labels 1 (background)
+//!   and 2 (circle) and a segment count of 3, exactly as
+//!   `test_morphology.py::test_labelregions` pins. libvips stores labels
+//!   in a 32-bit int mask; [`crate::pixel::PixelFormat`] has no int-32
+//!   depth, so the mask here is `Gray16` and stored labels saturate at
+//!   65535 (the returned count stays exact).
+//! * **`countlines`.** Pixels are thresholded at `>= 128`, transitions
+//!   from below- to above-threshold are counted along the axis
+//!   perpendicular to the requested line direction, and the total is
+//!   divided by the image width (horizontal) or height (vertical). This
+//!   reproduces the libvips pipeline (`moreeq_const 128`, integer `conv`
+//!   with a `[-1, 1]` mask whose negative lobe clips to zero in uchar,
+//!   `project`, `avg`, `/255`).
+
+use crate::pixel::PixelFormat;
+use crate::raster::{Raster, RasterError};
+use thiserror::Error;
+
+/// Direction selector for [`Raster::countlines`].
+///
+/// `Horizontal` counts horizontal lines (scanning down each column for
+/// threshold transitions); `Vertical` counts vertical lines (scanning along
+/// each row). Mirrors `VipsDirection`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Direction {
+    /// Count horizontal lines.
+    Horizontal,
+    /// Count vertical lines.
+    Vertical,
+}
+
+/// Typed errors for the morphology operations in [`crate::morphology`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MorphologyError {
+    /// The structuring element has no rows or an empty row.
+    #[error("empty structuring element")]
+    EmptyKernel,
+    /// The structuring element rows have differing lengths.
+    #[error("ragged structuring element: row {row} has {got} elements, expected {expected}")]
+    RaggedKernel {
+        row: usize,
+        got: usize,
+        expected: usize,
+    },
+    /// A structuring-element value is not 0, 128, or 255.
+    #[error("bad mask element ({value} should be 0, 128 or 255)")]
+    BadKernelElement { value: u8 },
+    /// The operation supports 8-bit images only.
+    #[error("{op} supports 8-bit images only; cast deeper formats to an 8-bit format first")]
+    EightBitOnly { op: &'static str },
+    /// The operation supports unsigned 8/16-bit images only.
+    #[error("{op} does not support float rasters; cast to an unsigned 8/16-bit format first")]
+    UnsignedOnly { op: &'static str },
+    /// The operation requires a one-band image.
+    #[error("{op} requires a one-band image, got {bands} bands")]
+    OneBandOnly { op: &'static str, bands: usize },
+    /// The rank window does not fit inside the image.
+    #[error("window too large: {width}x{height} window on a {image_w}x{image_h} image")]
+    WindowTooLarge {
+        width: u32,
+        height: u32,
+        image_w: u32,
+        image_h: u32,
+    },
+    /// The rank window has a zero dimension.
+    #[error("window dimensions must be greater than zero")]
+    ZeroWindow,
+    /// The rank index is outside `0..width * height`.
+    #[error("index out of range: {index} not below {n}")]
+    IndexOutOfRange { index: u32, n: u32 },
+    /// Constructing the result raster failed (allocation budget, size
+    /// overflow).
+    #[error(transparent)]
+    Raster(#[from] RasterError),
+}
+
+#[track_caller]
+fn expect_morph<T>(op: &str, r: Result<T, MorphologyError>) -> T {
+    match r {
+        Ok(v) => v,
+        Err(e) => panic!("{op}: {e}"),
+    }
+}
+
+/// A validated, dense copy of a caller-supplied structuring element.
+struct Kernel {
+    width: usize,
+    height: usize,
+    /// Row-major mask bytes, each 0, 128, or 255.
+    coeff: Vec<u8>,
+}
+
+impl Kernel {
+    fn from_rows(rows: &[&[u8]]) -> Result<Self, MorphologyError> {
+        if rows.is_empty() || rows[0].is_empty() {
+            return Err(MorphologyError::EmptyKernel);
+        }
+        let width = rows[0].len();
+        let mut coeff = Vec::with_capacity(width * rows.len());
+        for (row, r) in rows.iter().enumerate() {
+            if r.len() != width {
+                return Err(MorphologyError::RaggedKernel {
+                    row,
+                    got: r.len(),
+                    expected: width,
+                });
+            }
+            for &v in *r {
+                if v != 0 && v != 128 && v != 255 {
+                    return Err(MorphologyError::BadKernelElement { value: v });
+                }
+                coeff.push(v);
+            }
+        }
+        Ok(Kernel {
+            width,
+            height: rows.len(),
+            coeff,
+        })
+    }
+}
+
+/// Which of the two morphological operations to run.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MorphOp {
+    Erode,
+    Dilate,
+}
+
+/// Clamp a mask-relative coordinate to the image, replicating edge pixels
+/// (`VIPS_EXTEND_COPY`).
+#[inline]
+fn clamp_coord(v: i64, size: u32) -> usize {
+    v.clamp(0, size as i64 - 1) as usize
+}
+
+/// Shared erode/dilate walker over an 8-bit raster, treating each band
+/// independently and replicating edges.
+fn morph(src: &Raster, kernel: &Kernel, op: MorphOp) -> Result<Raster, MorphologyError> {
+    let fmt = src.format();
+    if fmt.bytes_per_channel() != 1 {
+        return Err(MorphologyError::EightBitOnly {
+            op: match op {
+                MorphOp::Erode => "erode",
+                MorphOp::Dilate => "dilate",
+            },
+        });
+    }
+    let (w, h) = (src.width(), src.height());
+    let bands = fmt.channels();
+    let stride = src.stride();
+    let data = src.data();
+    let mut out = Raster::zeroed(w, h, fmt)?;
+    let out_stride = out.stride();
+    let out_data = out.data_mut();
+
+    // Anchor at (width / 2, height / 2), as vips_morph places the mask
+    // origin.
+    let ax = (kernel.width / 2) as i64;
+    let ay = (kernel.height / 2) as i64;
+
+    for y in 0..h as i64 {
+        for x in 0..w as i64 {
+            for b in 0..bands {
+                // Erode starts from all-ones and ANDs; dilate starts from
+                // zero and ORs. `coeff == 0` complements the sample first,
+                // reproducing the bitwise `~p` in vips_erode_gen /
+                // vips_dilate_gen.
+                let mut acc: u8 = match op {
+                    MorphOp::Erode => 255,
+                    MorphOp::Dilate => 0,
+                };
+                for my in 0..kernel.height as i64 {
+                    let sy = clamp_coord(y + my - ay, h);
+                    let row = sy * stride;
+                    for mx in 0..kernel.width as i64 {
+                        let coeff = kernel.coeff[(my as usize) * kernel.width + mx as usize];
+                        if coeff == 128 {
+                            continue;
+                        }
+                        let sx = clamp_coord(x + mx - ax, w);
+                        let p = data[row + sx * bands + b];
+                        let v = if coeff == 0 { !p } else { p };
+                        match op {
+                            MorphOp::Erode => acc &= v,
+                            MorphOp::Dilate => acc |= v,
+                        }
+                    }
+                }
+                out_data[y as usize * out_stride + x as usize * bands + b] = acc;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Read the one-band sample at `(x, y)` as `u32` for the unsigned 8/16-bit
+/// depths (native byte order for 16-bit, matching [`crate::raster_ops`]).
+#[inline]
+fn sample_u32(data: &[u8], stride: usize, bpc: usize, x: usize, y: usize) -> u32 {
+    match bpc {
+        1 => data[y * stride + x] as u32,
+        _ => {
+            let b = y * stride + x * 2;
+            u16::from_ne_bytes([data[b], data[b + 1]]) as u32
+        }
+    }
+}
+
+impl Raster {
+    /// Erode with a structuring element, the fallible form of
+    /// [`Raster::erode`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MorphologyError::EmptyKernel`] /
+    /// [`MorphologyError::RaggedKernel`] /
+    /// [`MorphologyError::BadKernelElement`] for a malformed structuring
+    /// element and [`MorphologyError::EightBitOnly`] for a non-8-bit
+    /// raster.
+    pub fn try_erode(&self, kernel: &[&[u8]]) -> Result<Raster, MorphologyError> {
+        morph(self, &Kernel::from_rows(kernel)?, MorphOp::Erode)
+    }
+
+    /// Erode this image with the given structuring element (libvips
+    /// `vips_morph` with `VIPS_OPERATION_MORPHOLOGY_ERODE`).
+    ///
+    /// `kernel` rows hold `255` (input must be non-zero), `0` (input must
+    /// be zero), or `128` (don't care). The output pixel is set (255) only
+    /// when every non-don't-care element matches; the image should be a
+    /// 0/255 binary image, with 255 meaning object. The output has the
+    /// same dimensions and format as the input; edge pixels are made by
+    /// replicating the input edges.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a malformed structuring element or a non-8-bit raster;
+    /// use [`Raster::try_erode`] to handle those as errors.
+    pub fn erode(&self, kernel: &[&[u8]]) -> Raster {
+        expect_morph("erode", self.try_erode(kernel))
+    }
+
+    /// Dilate with a structuring element, the fallible form of
+    /// [`Raster::dilate`].
+    ///
+    /// # Errors
+    ///
+    /// As [`Raster::try_erode`].
+    pub fn try_dilate(&self, kernel: &[&[u8]]) -> Result<Raster, MorphologyError> {
+        morph(self, &Kernel::from_rows(kernel)?, MorphOp::Dilate)
+    }
+
+    /// Dilate this image with the given structuring element (libvips
+    /// `vips_morph` with `VIPS_OPERATION_MORPHOLOGY_DILATE`).
+    ///
+    /// Same mask encoding as [`Raster::erode`]; the output pixel is set
+    /// when *any* non-don't-care element matches (a `255` over a non-zero
+    /// pixel, or a `0` over a zero pixel).
+    ///
+    /// # Panics
+    ///
+    /// Panics on a malformed structuring element or a non-8-bit raster;
+    /// use [`Raster::try_dilate`] to handle those as errors.
+    pub fn dilate(&self, kernel: &[&[u8]]) -> Raster {
+        expect_morph("dilate", self.try_dilate(kernel))
+    }
+
+    /// Rank filter, the fallible form of [`Raster::rank`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MorphologyError::ZeroWindow`] /
+    /// [`MorphologyError::WindowTooLarge`] /
+    /// [`MorphologyError::IndexOutOfRange`] for bad window geometry and
+    /// [`MorphologyError::UnsignedOnly`] for float rasters.
+    pub fn try_rank(&self, width: u32, height: u32, index: u32) -> Result<Raster, MorphologyError> {
+        if width == 0 || height == 0 {
+            return Err(MorphologyError::ZeroWindow);
+        }
+        if width > self.width() || height > self.height() {
+            return Err(MorphologyError::WindowTooLarge {
+                width,
+                height,
+                image_w: self.width(),
+                image_h: self.height(),
+            });
+        }
+        let n = width * height;
+        if index >= n {
+            return Err(MorphologyError::IndexOutOfRange { index, n });
+        }
+        let fmt = self.format();
+        let bpc = fmt.bytes_per_channel();
+        if bpc == 4 {
+            return Err(MorphologyError::UnsignedOnly { op: "rank" });
+        }
+        let (w, h) = (self.width(), self.height());
+        let bands = fmt.channels();
+        let stride = self.stride();
+        let data = self.data();
+        let mut out = Raster::zeroed(w, h, fmt)?;
+        let out_stride = out.stride();
+        let out_data = out.data_mut();
+
+        // Window anchor at (width / 2, height / 2), as vips_rank embeds.
+        let ax = (width / 2) as i64;
+        let ay = (height / 2) as i64;
+        let mut window: Vec<u32> = Vec::with_capacity(n as usize);
+
+        for y in 0..h as i64 {
+            for x in 0..w as i64 {
+                for b in 0..bands {
+                    window.clear();
+                    for wy in 0..height as i64 {
+                        let sy = clamp_coord(y + wy - ay, h);
+                        for wx in 0..width as i64 {
+                            let sx = clamp_coord(x + wx - ax, w);
+                            window.push(sample_u32(data, stride, bpc, sx * bands + b, sy));
+                        }
+                    }
+                    window.sort_unstable();
+                    let v = window[index as usize];
+                    let off = y as usize * out_stride + (x as usize * bands + b) * bpc;
+                    match bpc {
+                        1 => out_data[off] = v as u8,
+                        _ => out_data[off..off + 2].copy_from_slice(&(v as u16).to_ne_bytes()),
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Rank filter (libvips `vips_rank`): move a `width` x `height` window
+    /// across the image and output the sample at position `index` in the
+    /// sorted window (0 = minimum, `width * height - 1` = maximum; the
+    /// middle index is the median). Bands are filtered independently and
+    /// edge pixels are made by replicating the input edges.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the window is empty or larger than the image, when
+    /// `index` is out of range, or on a float raster; use
+    /// [`Raster::try_rank`] to handle those as errors.
+    pub fn rank(&self, width: u32, height: u32, index: u32) -> Raster {
+        expect_morph("rank", self.try_rank(width, height, index))
+    }
+
+    /// Count lines, the fallible form of [`Raster::countlines`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MorphologyError::OneBandOnly`] for a multi-band raster
+    /// and [`MorphologyError::UnsignedOnly`] for float rasters.
+    pub fn try_countlines(&self, direction: Direction) -> Result<f64, MorphologyError> {
+        let fmt = self.format();
+        if fmt.channels() != 1 {
+            return Err(MorphologyError::OneBandOnly {
+                op: "countlines",
+                bands: fmt.channels(),
+            });
+        }
+        let bpc = fmt.bytes_per_channel();
+        if bpc == 4 {
+            return Err(MorphologyError::UnsignedOnly { op: "countlines" });
+        }
+        let (w, h) = (self.width() as usize, self.height() as usize);
+        let stride = self.stride();
+        let data = self.data();
+        let above = |x: usize, y: usize| sample_u32(data, stride, bpc, x, y) >= 128;
+
+        // Count below-to-above transitions of the 128 threshold. The
+        // libvips pipeline convolves the thresholded image with [-1, 1] in
+        // integer precision; the uchar output clips the falling edges to
+        // zero, so only rising transitions contribute. Edge extension is
+        // EXTEND_COPY, so there is never a transition into the first
+        // row/column.
+        let mut transitions: u64 = 0;
+        match direction {
+            Direction::Horizontal => {
+                for x in 0..w {
+                    for y in 1..h {
+                        if above(x, y) && !above(x, y - 1) {
+                            transitions += 1;
+                        }
+                    }
+                }
+                Ok(transitions as f64 / w as f64)
+            }
+            Direction::Vertical => {
+                for y in 0..h {
+                    for x in 1..w {
+                        if above(x, y) && !above(x - 1, y) {
+                            transitions += 1;
+                        }
+                    }
+                }
+                Ok(transitions as f64 / h as f64)
+            }
+        }
+    }
+
+    /// Count the average number of lines in a one-band image (libvips
+    /// `vips_countlines`).
+    ///
+    /// Pixels are thresholded at 128; a "line" is a rising transition
+    /// through the threshold, counted down every column for
+    /// [`Direction::Horizontal`] or along every row for
+    /// [`Direction::Vertical`], and averaged over the columns / rows. A
+    /// single one-pixel-wide full-width white line on black therefore
+    /// counts as exactly `1.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a multi-band or float raster; use
+    /// [`Raster::try_countlines`] to handle those as errors.
+    pub fn countlines(&self, direction: Direction) -> f64 {
+        expect_morph("countlines", self.try_countlines(direction))
+    }
+
+    /// Label regions, the fallible form of [`Raster::label_regions`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MorphologyError::UnsignedOnly`] for float rasters.
+    pub fn try_label_regions(&self) -> Result<(Raster, u32), MorphologyError> {
+        let fmt = self.format();
+        if fmt.bytes_per_channel() == 4 {
+            return Err(MorphologyError::UnsignedOnly {
+                op: "label_regions",
+            });
+        }
+        let (w, h) = (self.width() as usize, self.height() as usize);
+        let bpp = fmt.bytes_per_pixel();
+        let stride = self.stride();
+        let data = self.data();
+        // Full-pixel equality (all bands), exactly like the
+        // vips__draw_flood_direct blob test.
+        let pixel = |x: usize, y: usize| -> &[u8] {
+            let off = y * stride + x * bpp;
+            &data[off..off + bpp]
+        };
+
+        let mut labels: Vec<u32> = vec![0; w * h];
+        // libvips starts the serial at 1 and reports the *final* serial as
+        // the segment count, i.e. regions + 1.
+        let mut serial: u32 = 1;
+        let mut stack: Vec<(usize, usize)> = Vec::new();
+
+        for sy in 0..h {
+            for sx in 0..w {
+                if labels[sy * w + sx] != 0 {
+                    continue;
+                }
+                // Flood-fill the 4-connected region of pixels equal to the
+                // seed value with the current serial.
+                let seed = pixel(sx, sy);
+                labels[sy * w + sx] = serial;
+                stack.push((sx, sy));
+                while let Some((x, y)) = stack.pop() {
+                    let mut visit = |nx: usize, ny: usize| {
+                        let i = ny * w + nx;
+                        if labels[i] == 0 && pixel(nx, ny) == seed {
+                            labels[i] = serial;
+                            stack.push((nx, ny));
+                        }
+                    };
+                    if x > 0 {
+                        visit(x - 1, y);
+                    }
+                    if x + 1 < w {
+                        visit(x + 1, y);
+                    }
+                    if y > 0 {
+                        visit(x, y - 1);
+                    }
+                    if y + 1 < h {
+                        visit(x, y + 1);
+                    }
+                }
+                serial += 1;
+            }
+        }
+
+        // libvips writes int-32 labels; Gray16 is the widest unsigned
+        // PixelFormat depth, so stored labels saturate at 65535 while the
+        // returned segment count stays exact.
+        let mut mask = Raster::zeroed(self.width(), self.height(), PixelFormat::Gray16)?;
+        let mask_stride = mask.stride();
+        let mask_data = mask.data_mut();
+        for y in 0..h {
+            for x in 0..w {
+                let v = labels[y * w + x].min(65535) as u16;
+                let off = y * mask_stride + x * 2;
+                mask_data[off..off + 2].copy_from_slice(&v.to_ne_bytes());
+            }
+        }
+        Ok((mask, serial))
+    }
+
+    /// Label the 4-connected regions of equal pixel value (libvips
+    /// `vips_labelregions`).
+    ///
+    /// Scans row-major for the first unlabelled pixel and flood-fills its
+    /// region with the next serial, starting from 1, so the first region
+    /// found (usually the background) gets label 1. Returns the `Gray16`
+    /// label mask and the segment count, which is the final serial:
+    /// `number of regions + 1`, exactly as libvips reports it.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a float raster; use [`Raster::try_label_regions`] to
+    /// handle that as an error.
+    pub fn label_regions(&self) -> (Raster, u32) {
+        expect_morph("label_regions", self.try_label_regions())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn black(w: u32, h: u32) -> Raster {
+        Raster::zeroed(w, h, PixelFormat::Gray8).unwrap()
+    }
+
+    fn avg(r: &Raster) -> f64 {
+        r.data().iter().map(|&b| b as f64).sum::<f64>() / r.data().len() as f64
+    }
+
+    const CROSS: &[&[u8]] = &[&[128, 255, 128], &[255, 255, 255], &[128, 255, 128]];
+
+    /**
+     * Compile-position pin for the exact ported-test call surface of the
+     * morphology batch (ported_morphology.rs): erode/dilate over a
+     * `&[&[u8]]` structuring element, rank, countlines with the Direction
+     * enum, and label_regions returning `(Raster, u32)`.
+     * Works by invoking every call site shape the ported tests use.
+     */
+    #[test]
+    fn ported_call_surface_compiles() {
+        let mut im = black(20, 20);
+        im.draw_line(&[255], 0, 10, 20, 10);
+        let kernel: &[&[u8]] = CROSS;
+        let _: Raster = im.erode(kernel);
+        let _: Raster = im.dilate(kernel);
+        let _: Raster = im.rank(3, 3, 8);
+        let n_lines: f64 = im.countlines(Direction::Horizontal);
+        assert!(n_lines > 0.0);
+        let (mask, segments): (Raster, u32) = im.label_regions();
+        let _ = mask.data().iter().copied().max().unwrap();
+        assert!(segments >= 2);
+    }
+
+    /**
+     * Tests the ported erode scenario: a filled white circle on black,
+     * eroded with the 3x3 cross element, keeps its dimensions and format
+     * and loses mass (fewer white pixels).
+     * Works by mirroring test_morphology.py::test_erode and comparing
+     * averages. Input: 100x100 black + circle r=25 at (50,50).
+     */
+    #[test]
+    fn erode_circle_shrinks() {
+        let mut im = black(100, 100);
+        im.draw_circle_filled(&[255], 50, 50, 25);
+        let im2 = im.erode(CROSS);
+        assert_eq!(im.width(), im2.width());
+        assert_eq!(im.height(), im2.height());
+        assert_eq!(im.format(), im2.format());
+        assert!(avg(&im) > avg(&im2));
+    }
+
+    /**
+     * Tests the ported dilate scenario: the same circle dilated with the
+     * cross element gains mass.
+     * Works by mirroring test_morphology.py::test_dilate.
+     */
+    #[test]
+    fn dilate_circle_grows() {
+        let mut im = black(100, 100);
+        im.draw_circle_filled(&[255], 50, 50, 25);
+        let im2 = im.dilate(CROSS);
+        assert_eq!(im.width(), im2.width());
+        assert_eq!(im.height(), im2.height());
+        assert_eq!(im.format(), im2.format());
+        assert!(avg(&im2) > avg(&im));
+    }
+
+    /**
+     * Tests exact erode pixels on a known square: a 3x3 all-255 element
+     * erodes a 5x5 white square centred in an 11x11 black image down to
+     * the 3x3 core (only pixels whose full 3x3 neighbourhood is white
+     * survive).
+     * Works by checking every pixel of the output against the expected
+     * shrunken square.
+     */
+    #[test]
+    fn erode_square_exact() {
+        let mut im = black(11, 11);
+        im.draw_rect_filled(&[255], 3, 3, 5, 5);
+        let all: &[&[u8]] = &[&[255, 255, 255], &[255, 255, 255], &[255, 255, 255]];
+        let out = im.erode(all);
+        for y in 0..11u32 {
+            for x in 0..11u32 {
+                let expected = (4..=6).contains(&x) && (4..=6).contains(&y);
+                assert_eq!(
+                    out.getpoint(x, y)[0] != 0.0,
+                    expected,
+                    "pixel ({x},{y}) after erode"
+                );
+            }
+        }
+    }
+
+    /**
+     * Tests exact dilate pixels: dilating a single white pixel with the
+     * cross element paints the 4-connected plus shape.
+     * Works by checking the five expected white pixels and a corner that
+     * must stay black.
+     */
+    #[test]
+    fn dilate_point_exact() {
+        let mut im = black(7, 7);
+        im.put_pixel(3, 3, &[255]);
+        let out = im.dilate(CROSS);
+        for (x, y) in [(3, 3), (2, 3), (4, 3), (3, 2), (3, 4)] {
+            assert_eq!(out.getpoint(x, y)[0], 255.0, "plus arm at ({x},{y})");
+        }
+        assert_eq!(out.getpoint(2, 2)[0], 0.0, "diagonal stays black");
+        assert_eq!(out.getpoint(0, 0)[0], 0.0);
+    }
+
+    /**
+     * Tests the must-be-zero (0) mask encoding: a hit-miss element that
+     * requires the centre white and the left neighbour black fires only
+     * on left edges of white runs.
+     * Works by eroding a two-pixel white run with [[0, 255]] (anchor at
+     * index 1) and checking only the run's first column matches.
+     */
+    #[test]
+    fn erode_hit_miss_left_edge() {
+        let mut im = black(7, 1);
+        im.put_pixel(3, 0, &[255]);
+        im.put_pixel(4, 0, &[255]);
+        let elem: &[&[u8]] = &[&[0, 255]];
+        let out = im.erode(elem);
+        let hits: Vec<u32> = (0..7).filter(|&x| out.getpoint(x, 0)[0] != 0.0).collect();
+        assert_eq!(hits, vec![3], "only the left edge of the run matches");
+    }
+
+    /**
+     * Tests edge replication: a fully white image erodes to fully white
+     * because the off-canvas neighbourhood replicates the white edges
+     * (VIPS_EXTEND_COPY), never introducing black.
+     * Works by eroding an all-255 image and asserting it is unchanged.
+     */
+    #[test]
+    fn erode_edge_replication_keeps_white() {
+        let im = Raster::new(4, 4, PixelFormat::Gray8, vec![255; 16]).unwrap();
+        let all: &[&[u8]] = &[&[255, 255, 255], &[255, 255, 255], &[255, 255, 255]];
+        let out = im.erode(all);
+        assert!(out.data().iter().all(|&b| b == 255));
+    }
+
+    /**
+     * Tests erode/dilate treat bands independently: an Rgb8 image with a
+     * white square in the red band only dilates red without leaking into
+     * green or blue.
+     * Works by dilating and inspecting per-band samples next to the
+     * square.
+     */
+    #[test]
+    fn morph_is_bandwise() {
+        let mut im = Raster::zeroed(7, 7, PixelFormat::Rgb8).unwrap();
+        im.put_pixel(3, 3, &[255, 0, 0]);
+        let out = im.dilate(CROSS);
+        let p = out.getpoint(2, 3);
+        assert_eq!(p, vec![255.0, 0.0, 0.0], "red dilates, green/blue stay");
+    }
+
+    /**
+     * Tests structuring-element validation: empty, ragged, and non-0/128/255
+     * elements are typed errors, and deeper depths are rejected.
+     * Works by asserting each try_erode error variant.
+     */
+    #[test]
+    fn erode_validation_errors() {
+        let im = black(4, 4);
+        assert!(matches!(
+            im.try_erode(&[]),
+            Err(MorphologyError::EmptyKernel)
+        ));
+        let ragged: &[&[u8]] = &[&[255, 255], &[255]];
+        assert!(matches!(
+            im.try_erode(ragged),
+            Err(MorphologyError::RaggedKernel { row: 1, .. })
+        ));
+        let bad: &[&[u8]] = &[&[7]];
+        assert!(matches!(
+            im.try_erode(bad),
+            Err(MorphologyError::BadKernelElement { value: 7 })
+        ));
+        let deep = Raster::zeroed(4, 4, PixelFormat::Gray16).unwrap();
+        assert!(matches!(
+            deep.try_erode(CROSS),
+            Err(MorphologyError::EightBitOnly { .. })
+        ));
+    }
+
+    /**
+     * Tests the ported rank scenario: rank(3, 3, 8) is a maximum filter,
+     * so the circle grows and dimensions/format are preserved.
+     * Works by mirroring test_morphology.py::test_rank.
+     */
+    #[test]
+    fn rank_max_grows_circle() {
+        let mut im = black(100, 100);
+        im.draw_circle_filled(&[255], 50, 50, 25);
+        let im2 = im.rank(3, 3, 8);
+        assert_eq!(im.width(), im2.width());
+        assert_eq!(im.height(), im2.height());
+        assert_eq!(im.format(), im2.format());
+        assert!(avg(&im2) > avg(&im));
+    }
+
+    /**
+     * Tests rank order statistics on a known 3x3 window: index 0 is the
+     * minimum, the middle index the median, and n-1 the maximum.
+     * Works by ranking a 3x3 image holding 10..90 and reading the centre
+     * pixel, whose window is the whole image.
+     */
+    #[test]
+    fn rank_order_statistics_exact() {
+        let data: Vec<u8> = vec![50, 10, 30, 90, 70, 20, 40, 80, 60];
+        let im = Raster::new(3, 3, PixelFormat::Gray8, data).unwrap();
+        assert_eq!(im.rank(3, 3, 0).getpoint(1, 1)[0], 10.0, "minimum");
+        assert_eq!(im.rank(3, 3, 4).getpoint(1, 1)[0], 50.0, "median");
+        assert_eq!(im.rank(3, 3, 8).getpoint(1, 1)[0], 90.0, "maximum");
+    }
+
+    /**
+     * Tests that a 1x1 rank window is the identity for any index 0.
+     * Works by comparing the output bytes to the input.
+     */
+    #[test]
+    fn rank_identity_window() {
+        let mut im = black(9, 9);
+        im.draw_circle_filled(&[200], 4, 4, 3);
+        let out = im.rank(1, 1, 0);
+        assert_eq!(out.data(), im.data());
+    }
+
+    /**
+     * Tests rank on Gray16 samples: the median of a 16-bit window uses
+     * full sample precision (values above 255).
+     * Works by ranking a 3x1 Gray16 image and reading the middle pixel.
+     */
+    #[test]
+    fn rank_gray16() {
+        let mut data = Vec::new();
+        for v in [1000u16, 3000, 2000] {
+            data.extend_from_slice(&v.to_ne_bytes());
+        }
+        let im = Raster::new(3, 1, PixelFormat::Gray16, data).unwrap();
+        let out = im.rank(3, 1, 1);
+        assert_eq!(out.getpoint(1, 0)[0], 2000.0, "median of 16-bit window");
+    }
+
+    /**
+     * Tests rank window/index validation: zero windows, windows larger
+     * than the image, and out-of-range indices are typed errors.
+     * Works by asserting each try_rank error variant.
+     */
+    #[test]
+    fn rank_validation_errors() {
+        let im = black(4, 4);
+        assert!(matches!(
+            im.try_rank(0, 3, 0),
+            Err(MorphologyError::ZeroWindow)
+        ));
+        assert!(matches!(
+            im.try_rank(5, 3, 0),
+            Err(MorphologyError::WindowTooLarge { .. })
+        ));
+        assert!(matches!(
+            im.try_rank(3, 3, 9),
+            Err(MorphologyError::IndexOutOfRange { index: 9, n: 9 })
+        ));
+    }
+
+    /**
+     * Tests the ported countlines scenario: one horizontal white line
+     * across a black image counts as exactly 1.0.
+     * Works by mirroring test_morphology.py::test_countlines.
+     */
+    #[test]
+    fn countlines_single_horizontal() {
+        let mut im = black(100, 100);
+        im.draw_line(&[255], 0, 50, 100, 50);
+        assert_eq!(im.countlines(Direction::Horizontal), 1.0);
+    }
+
+    /**
+     * Tests countlines in the vertical direction and with several lines:
+     * two full-height vertical lines count as 2.0.
+     * Works by drawing two vertical lines and counting.
+     */
+    #[test]
+    fn countlines_two_vertical() {
+        let mut im = black(100, 100);
+        im.draw_line(&[255], 20, 0, 20, 99);
+        im.draw_line(&[255], 60, 0, 60, 99);
+        assert_eq!(im.countlines(Direction::Vertical), 2.0);
+    }
+
+    /**
+     * Tests the 128 threshold boundary: ink 127 is below threshold and
+     * counts zero lines, ink 128 counts one, matching moreeq_const 128.
+     * Works by drawing a line at each intensity and comparing counts.
+     */
+    #[test]
+    fn countlines_threshold_at_128() {
+        let mut dim = black(10, 10);
+        dim.draw_line(&[127], 0, 5, 10, 5);
+        assert_eq!(dim.countlines(Direction::Horizontal), 0.0);
+        let mut lit = black(10, 10);
+        lit.draw_line(&[128], 0, 5, 10, 5);
+        assert_eq!(lit.countlines(Direction::Horizontal), 1.0);
+    }
+
+    /**
+     * Tests countlines only counts rising transitions: a line that runs
+     * to the bottom edge has no falling edge inside the image and still
+     * counts once, and a half-width line averages to 0.5.
+     * Works on a bottom-row line and a half-width line.
+     */
+    #[test]
+    fn countlines_partial_and_edge_lines() {
+        let mut im = black(10, 10);
+        im.draw_line(&[255], 0, 9, 10, 9);
+        assert_eq!(im.countlines(Direction::Horizontal), 1.0, "bottom row");
+        let mut half = black(10, 10);
+        half.draw_line(&[255], 0, 5, 4, 5);
+        assert_eq!(
+            half.countlines(Direction::Horizontal),
+            0.5,
+            "line across half the columns"
+        );
+    }
+
+    /**
+     * Tests countlines input validation: multi-band and float rasters are
+     * typed errors.
+     * Works by asserting the try_countlines error variants.
+     */
+    #[test]
+    fn countlines_validation_errors() {
+        let rgb = Raster::zeroed(4, 4, PixelFormat::Rgb8).unwrap();
+        assert!(matches!(
+            rgb.try_countlines(Direction::Horizontal),
+            Err(MorphologyError::OneBandOnly { bands: 3, .. })
+        ));
+    }
+
+    /**
+     * Tests the ported label_regions scenario: a filled circle on black
+     * yields two regions labelled 1 (background) and 2 (circle), and the
+     * libvips segment count regions + 1 = 3.
+     * Works by mirroring test_morphology.py::test_labelregions, including
+     * the byte-level max the ported test reads (labels below 256 keep the
+     * Gray16 mask's byte maximum equal to the label maximum).
+     */
+    #[test]
+    fn label_regions_circle() {
+        let mut im = black(100, 100);
+        im.draw_circle_filled(&[255], 50, 50, 25);
+        let (mask, segments) = im.label_regions();
+        assert_eq!(segments, 3);
+        let max_label = mask.data().iter().copied().max().unwrap();
+        assert_eq!(max_label, 2);
+        assert_eq!(mask.format(), PixelFormat::Gray16);
+    }
+
+    /**
+     * Tests label_regions on a uniform image: one region, labelled 1
+     * everywhere, segment count 2.
+     * Works by labelling an all-black image and checking every mask
+     * sample.
+     */
+    #[test]
+    fn label_regions_uniform() {
+        let im = black(8, 8);
+        let (mask, segments) = im.label_regions();
+        assert_eq!(segments, 2);
+        for y in 0..8 {
+            for x in 0..8 {
+                assert_eq!(mask.getpoint(x, y)[0], 1.0);
+            }
+        }
+    }
+
+    /**
+     * Tests 4-connectivity: two white pixels touching only diagonally are
+     * separate regions (labels 2 and 3 in scan order), giving four
+     * segments in total with the background.
+     * Works by placing pixels at (1,1) and (2,2) and counting.
+     */
+    #[test]
+    fn label_regions_diagonal_not_connected() {
+        let mut im = black(4, 4);
+        im.put_pixel(1, 1, &[255]);
+        im.put_pixel(2, 2, &[255]);
+        let (mask, segments) = im.label_regions();
+        assert_eq!(segments, 4, "background + two diagonal blobs + 1");
+        assert_eq!(mask.getpoint(1, 1)[0], 2.0, "first blob in scan order");
+        assert_eq!(mask.getpoint(2, 2)[0], 3.0, "second blob in scan order");
+    }
+
+    /**
+     * Tests scan-order label assignment on equal-value regions split by a
+     * barrier: a white column splits the black background into two
+     * regions of the same value with distinct labels.
+     * Works by labelling a black image with a full-height white line and
+     * checking the left background is 1, the line 2, and the right
+     * background 3.
+     */
+    #[test]
+    fn label_regions_equal_values_distinct_regions() {
+        let mut im = black(5, 3);
+        im.draw_line(&[255], 2, 0, 2, 2);
+        let (mask, segments) = im.label_regions();
+        assert_eq!(segments, 4);
+        assert_eq!(mask.getpoint(0, 1)[0], 1.0, "left background first");
+        assert_eq!(mask.getpoint(2, 1)[0], 2.0, "line second");
+        assert_eq!(mask.getpoint(4, 1)[0], 3.0, "right background third");
+    }
+
+    /**
+     * Tests label_regions uses full-pixel equality on multi-band images:
+     * two rectangles differing only in the green band are separate
+     * regions.
+     * Works by drawing [10,0,0] and [10,9,0] rectangles that tile the
+     * whole canvas and expecting 3 segments (2 regions + 1).
+     */
+    #[test]
+    fn label_regions_multiband_pixel_equality() {
+        let mut im = Raster::zeroed(6, 2, PixelFormat::Rgb8).unwrap();
+        im.draw_rect_filled(&[10, 0, 0], 0, 0, 3, 2);
+        im.draw_rect_filled(&[10, 9, 0], 3, 0, 3, 2);
+        let (_, segments) = im.label_regions();
+        assert_eq!(segments, 3, "two touching rects of distinct colour + 1");
+    }
+}

--- a/src/mosaicing.rs
+++ b/src/mosaicing.rs
@@ -1,0 +1,2446 @@
+//! Mosaicing operations ported from libvips.
+//!
+//! This module is the next batch of the libvips operation surface required
+//! by the ported integration tests (after [`crate::bands`],
+//! [`crate::arithmetic`], [`crate::extract`], [`crate::conversion`],
+//! [`crate::draw`], [`crate::histogram`], [`crate::imageio`],
+//! [`crate::composite`], [`crate::colour`], and [`crate::morphology`]):
+//! feathered merging of two overlapping images, automatic tie-point
+//! mosaicing, and global brightness balancing of an assembled mosaic.
+//! Operations that can fail on caller input exist in two forms, following
+//! the established convention:
+//!
+//! * a fallible `try_*` method returning `Result<_, MosaicError>` with
+//!   typed errors for mismatched formats, missing overlap, and failed
+//!   tie-point searches; and
+//! * a panicking convenience method matching the ported-test call surface
+//!   (`merge`, `mosaic`, `global_balance`) exactly, delegating to the
+//!   `try_*` form.
+//!
+//! # Operations
+//!
+//! | Method | libvips equivalent | Result |
+//! |---|---|---|
+//! | [`Raster::merge`] | `vips_merge` | feathered join of two images |
+//! | [`Raster::mosaic`] | `vips_mosaic` | tie-point aligned join |
+//! | [`Raster::global_balance`] | `vips_globalbalance` | brightness-balanced mosaic, float |
+//!
+//! # Merge semantics (from `lrmerge.c` / `tbmerge.c`)
+//!
+//! `self` is the reference image at `(0, 0)`; `other` is displaced to
+//! `(-dx, -dy)`. The output is the union bounding box of the two placed
+//! images, with uncovered corners black. Over the overlap, each scan-line
+//! (horizontal merge) or column (vertical merge) is feathered with the
+//! libvips raised-cosine ramp between `first` (the first non-zero `other`
+//! pixel) and `last` (the last non-zero `self` pixel), the ramp width
+//! clipped to the `mblend` maximum of 10 pixels (the libvips default) by
+//! shrinking both ends towards the middle. Zero pixels are treated as
+//! transparent on both sides, integer depths blend through the
+//! `BLEND_SCALE` integer coefficient tables with truncating division, and
+//! float depths blend with the double-precision coefficients, all exactly
+//! as the C does. When `other` lies entirely on the wrong side (`dx > 0`
+//! or beyond the reference edge), libvips falls back to `vips_insert`
+//! with expansion; the same paste-without-blend fallback happens here.
+//!
+//! # Mosaic semantics (from `lrmosaic.c` / `im_lrcalcon.c` / `chkpair.c`)
+//!
+//! [`Raster::mosaic`] refines the caller's tie-point guess exactly like
+//! `vips_mosaic` with the default parameters (`bandno` 0, `hwindow` 5,
+//! `harea` 15, `mblend` 10): band 0 of each overlap estimate is
+//! contrast-stretched to 8-bit (`vips_scale`), the reference overlap is
+//! divided into three strips and the twenty highest-contrast 11x11
+//! windows found in each on a 5-pixel grid, each of the sixty points is
+//! located in the secondary image by normalised spatial correlation
+//! (`vips_spcor`, edge-replicated) over a +-15 pixel search square, a
+//! first-order linear model is fitted (`im_clinear`), outliers are
+//! discarded and the model refitted until stable (`im_improve`), and the
+//! surviving displacements are averaged with round-half-to-even
+//! (`im_avgdxdy`). The corrected offset then drives [`Raster::merge`].
+//! Failures surface as typed errors exactly where libvips errors: an
+//! overlap smaller than the search geometry, fewer than twenty usable
+//! high-contrast windows per strip, no tie-points surviving the fit, or a
+//! singular fit matrix.
+//!
+//! # Global balance semantics (from `global_balance.c`)
+//!
+//! libvips reconstructs the mosaic tree by parsing `#LRJOIN` / `#TBJOIN`
+//! image-history lines and re-opening the named source files. Rasters
+//! here have no filenames, so [`Raster::merge`] and [`Raster::mosaic`]
+//! attach the equivalent information structurally: a `mosaic-join-tree`
+//! metadata blob carrying the join parameters and the leaf images
+//! themselves. [`Raster::global_balance`] rebuilds the tree from that
+//! blob, finds every leaf-pair overlap of at least 20x20 pixels, masks
+//! each overlap to the pixels non-zero in both leaves, computes the
+//! libvips overlap statistic (masked mean scaled by the masked pixel
+//! fraction), solves the least-mean-square factor system anchored on the
+//! first leaf with the default source gamma 1.6, normalises the factors
+//! to a mean of one, scales every leaf by `v -> (v^(1/gamma) * factor)^gamma`
+//! through a lookup table, and re-merges the tree in float. The output is
+//! always float (`int_output` is not ported), one factor per leaf, same
+//! geometry as the input mosaic.
+//!
+//! # Documented deviations from libvips
+//!
+//! * Both images must share one [`crate::pixel::PixelFormat`]; libvips
+//!   instead casts the inputs to a common format and band count. Cast
+//!   first when formats differ.
+//! * The join metadata travels in the structured `mosaic-join-tree` blob
+//!   (native byte order, process-internal) rather than filename-based
+//!   history, so `global_balance` works on in-memory rasters; a raster
+//!   without that field is a typed error, as an image without mosaic
+//!   history is in libvips.
+//! * Contrast-candidate ties are broken by stable scan order where the C
+//!   `qsort` tie order is unspecified, and correlation-surface ties take
+//!   the first maximum in row-major order where threaded `vips_max` is
+//!   unspecified.
+//! * `mblend` is fixed at the libvips default of 10 on the public
+//!   surface; the ported tests never pass another value.
+
+use crate::imageio::MetadataValue;
+use crate::pixel::PixelFormat;
+use crate::raster::{Raster, RasterError};
+use std::sync::OnceLock;
+use thiserror::Error;
+
+/// Join direction for [`Raster::merge`] and [`Raster::mosaic`].
+///
+/// `Horizontal` joins left-right with `self` on the left; `Vertical`
+/// joins top-bottom with `self` on top. Mirrors `VipsDirection`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum MergeDirection {
+    /// Left-right join, `self` on the left.
+    Horizontal,
+    /// Top-bottom join, `self` on top.
+    Vertical,
+}
+
+/// Typed errors for the mosaicing operations in [`crate::mosaicing`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MosaicError {
+    /// The two images do not share a pixel format.
+    #[error("pixel formats differ: {reference:?} vs {secondary:?}; cast to a common format first")]
+    FormatMismatch {
+        reference: PixelFormat,
+        secondary: PixelFormat,
+    },
+    /// The placed images do not overlap.
+    #[error("no overlap")]
+    NoOverlap,
+    /// The reference image extends past the secondary on the trailing
+    /// edge (or starts after it), so a feathered join is impossible.
+    #[error("too much overlap")]
+    TooMuchOverlap,
+    /// The tie-point overlap estimate is smaller than the search geometry
+    /// needs.
+    #[error("overlap too small for the search size")]
+    OverlapTooSmall,
+    /// A search strip holds fewer than the required high-contrast
+    /// windows.
+    #[error("found {found} tie-points, need at least {needed}")]
+    TooFewPoints { found: usize, needed: usize },
+    /// No tie-points survived correlation and filtering.
+    #[error("no tie points")]
+    NoTiePoints,
+    /// A least-squares fit matrix was singular.
+    #[error("singular matrix in mosaic fit")]
+    SingularMatrix,
+    /// The raster carries no `mosaic-join-tree` metadata, so it was not
+    /// built by [`Raster::merge`] / [`Raster::mosaic`].
+    #[error("no mosaic metadata: input was not built by merge or mosaic")]
+    NoMosaicMetadata,
+    /// The `mosaic-join-tree` metadata failed to deserialize.
+    #[error("corrupt mosaic metadata")]
+    CorruptMosaicMetadata,
+    /// Constructing a result raster failed (allocation budget, size
+    /// overflow).
+    #[error(transparent)]
+    Raster(#[from] RasterError),
+}
+
+#[track_caller]
+fn expect_mosaic<T>(op: &str, r: Result<T, MosaicError>) -> T {
+    match r {
+        Ok(v) => v,
+        Err(e) => panic!("{op}: {e}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared constants (pmosaicing.h / mosaic.c defaults)
+// ---------------------------------------------------------------------------
+
+/// Number of entries in the raised-cosine blend table (`BLEND_SIZE`).
+const BLEND_SHIFT: u32 = 10;
+const BLEND_SIZE: usize = 1 << BLEND_SHIFT;
+/// Integer blend coefficient scale (`BLEND_SCALE`).
+const BLEND_SCALE: i64 = 4096;
+/// Default maximum blend width (`mblend`).
+const DEFAULT_MBLEND: i64 = 10;
+/// Half correlation window size (`hwindow`).
+const HWINDOW: i64 = 5;
+/// Half search area size (`harea`).
+const HAREA: i64 = 15;
+/// Total tie-points searched (`VIPS_MAXPOINTS`).
+const MAXPOINTS: usize = 60;
+/// Number of overlap strips (`AREAS`).
+const AREAS: usize = 3;
+/// Minimum significant overlap in pixels (`TRIVIAL`, 20 * 20).
+const TRIVIAL: i64 = 400;
+/// Default source gamma for global balancing.
+const BALANCE_GAMMA: f64 = 1.6;
+/// Metadata field carrying the serialized join tree.
+const JOIN_TREE_FIELD: &str = "mosaic-join-tree";
+
+// ---------------------------------------------------------------------------
+// Rect helpers (vips_rect_*)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Rect {
+    left: i64,
+    top: i64,
+    width: i64,
+    height: i64,
+}
+
+impl Rect {
+    fn right(&self) -> i64 {
+        self.left + self.width
+    }
+
+    fn bottom(&self) -> i64 {
+        self.top + self.height
+    }
+
+    fn is_empty(&self) -> bool {
+        self.width <= 0 || self.height <= 0
+    }
+
+    fn intersect(&self, other: &Rect) -> Rect {
+        let left = self.left.max(other.left);
+        let top = self.top.max(other.top);
+        Rect {
+            left,
+            top,
+            width: (self.right().min(other.right()) - left).max(0),
+            height: (self.bottom().min(other.bottom()) - top).max(0),
+        }
+    }
+
+    fn union(&self, other: &Rect) -> Rect {
+        let left = self.left.min(other.left);
+        let top = self.top.min(other.top);
+        Rect {
+            left,
+            top,
+            width: self.right().max(other.right()) - left,
+            height: self.bottom().max(other.bottom()) - top,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Blend tables (vips__make_blend_luts)
+// ---------------------------------------------------------------------------
+
+struct BlendLuts {
+    coef1: Vec<f64>,
+    coef2: Vec<f64>,
+    icoef1: Vec<i64>,
+    icoef2: Vec<i64>,
+}
+
+fn blend_luts() -> &'static BlendLuts {
+    static LUTS: OnceLock<BlendLuts> = OnceLock::new();
+    LUTS.get_or_init(|| {
+        let mut luts = BlendLuts {
+            coef1: Vec::with_capacity(BLEND_SIZE),
+            coef2: Vec::with_capacity(BLEND_SIZE),
+            icoef1: Vec::with_capacity(BLEND_SIZE),
+            icoef2: Vec::with_capacity(BLEND_SIZE),
+        };
+        for x in 0..BLEND_SIZE {
+            let a = std::f64::consts::PI * x as f64 / (BLEND_SIZE as f64 - 1.0);
+            let c1 = (a.cos() + 1.0) / 2.0;
+            let c2 = 1.0 - c1;
+            luts.coef1.push(c1);
+            luts.coef2.push(c2);
+            // The C fills the int tables with a double -> int cast, which
+            // truncates toward zero.
+            luts.icoef1.push((c1 * BLEND_SCALE as f64) as i64);
+            luts.icoef2.push((c2 * BLEND_SCALE as f64) as i64);
+        }
+        luts
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Sample plumbing: one code path per depth, like the C's iblend / fblend
+// ---------------------------------------------------------------------------
+
+trait BlendSample: Copy + PartialEq {
+    fn get(data: &[u8], elem: usize) -> Self;
+    fn put(data: &mut [u8], elem: usize, v: Self);
+    fn is_nonzero(self) -> bool;
+    /// Blend `r` (reference) with `s` (secondary) at ramp index `inx`.
+    fn blend(inx: usize, r: Self, s: Self) -> Self;
+}
+
+impl BlendSample for u8 {
+    fn get(data: &[u8], elem: usize) -> Self {
+        data[elem]
+    }
+
+    fn put(data: &mut [u8], elem: usize, v: Self) {
+        data[elem] = v;
+    }
+
+    fn is_nonzero(self) -> bool {
+        self != 0
+    }
+
+    fn blend(inx: usize, r: Self, s: Self) -> Self {
+        let luts = blend_luts();
+        // Integer blend with truncating division on each term (iblend).
+        (luts.icoef1[inx] * r as i64 / BLEND_SCALE + luts.icoef2[inx] * s as i64 / BLEND_SCALE)
+            as u8
+    }
+}
+
+impl BlendSample for u16 {
+    fn get(data: &[u8], elem: usize) -> Self {
+        u16::from_ne_bytes([data[elem * 2], data[elem * 2 + 1]])
+    }
+
+    fn put(data: &mut [u8], elem: usize, v: Self) {
+        data[elem * 2..elem * 2 + 2].copy_from_slice(&v.to_ne_bytes());
+    }
+
+    fn is_nonzero(self) -> bool {
+        self != 0
+    }
+
+    fn blend(inx: usize, r: Self, s: Self) -> Self {
+        let luts = blend_luts();
+        (luts.icoef1[inx] * r as i64 / BLEND_SCALE + luts.icoef2[inx] * s as i64 / BLEND_SCALE)
+            as u16
+    }
+}
+
+impl BlendSample for f32 {
+    fn get(data: &[u8], elem: usize) -> Self {
+        f32::from_ne_bytes([
+            data[elem * 4],
+            data[elem * 4 + 1],
+            data[elem * 4 + 2],
+            data[elem * 4 + 3],
+        ])
+    }
+
+    fn put(data: &mut [u8], elem: usize, v: Self) {
+        data[elem * 4..elem * 4 + 4].copy_from_slice(&v.to_ne_bytes());
+    }
+
+    fn is_nonzero(self) -> bool {
+        self != 0.0
+    }
+
+    fn blend(inx: usize, r: Self, s: Self) -> Self {
+        let luts = blend_luts();
+        // Float blend in double precision (fblend).
+        (luts.coef1[inx] * r as f64 + luts.coef2[inx] * s as f64) as f32
+    }
+}
+
+/// Whole-pixel zero test (`TEST_ZERO`): every band element must be zero.
+fn pixel_is_zero<S: BlendSample>(data: &[u8], elem: usize, bands: usize) -> bool {
+    (0..bands).all(|b| !S::get(data, elem + b).is_nonzero())
+}
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+/// Per-call merge geometry, mirroring the `Overlapping` struct: all rects
+/// are in output coordinates with the union at (0, 0).
+struct MergeState {
+    rarea: Rect,
+    sarea: Rect,
+    overlap: Rect,
+    oarea: Rect,
+}
+
+fn build_merge_state(
+    ref_: &Raster,
+    sec: &Raster,
+    dx: i64,
+    dy: i64,
+) -> Result<MergeState, MosaicError> {
+    let mut rarea = Rect {
+        left: 0,
+        top: 0,
+        width: ref_.width() as i64,
+        height: ref_.height() as i64,
+    };
+    let mut sarea = Rect {
+        left: -dx,
+        top: -dy,
+        width: sec.width() as i64,
+        height: sec.height() as i64,
+    };
+    let mut overlap = rarea.intersect(&sarea);
+    if overlap.is_empty() {
+        return Err(MosaicError::NoOverlap);
+    }
+    let oarea = rarea.union(&sarea);
+
+    // Translate so the output is at (0, 0).
+    rarea.left -= oarea.left;
+    rarea.top -= oarea.top;
+    sarea.left -= oarea.left;
+    sarea.top -= oarea.top;
+    overlap.left -= oarea.left;
+    overlap.top -= oarea.top;
+    Ok(MergeState {
+        rarea,
+        sarea,
+        overlap,
+        oarea: Rect {
+            left: 0,
+            top: 0,
+            width: oarea.width,
+            height: oarea.height,
+        },
+    })
+}
+
+/// Copy the whole of `src` into `out` with its top-left corner at
+/// `(left, top)` (always in range by construction).
+fn paste(out: &mut Raster, src: &Raster, left: i64, top: i64) {
+    let bpp = src.format().bytes_per_pixel();
+    let src_stride = src.stride();
+    let out_stride = out.stride();
+    let row_bytes = src.width() as usize * bpp;
+    let src_data = src.data();
+    let out_data = out.data_mut();
+    for y in 0..src.height() as usize {
+        let s = y * src_stride;
+        let d = (top as usize + y) * out_stride + left as usize * bpp;
+        out_data[d..d + row_bytes].copy_from_slice(&src_data[s..s + row_bytes]);
+    }
+}
+
+/// `find_first`: position of the first non-zero pixel of `sec`'s span,
+/// scanning band elements left to right; one past the end when all zero.
+/// `find_last`: last non-zero of `ref`'s span, `start - 1` when all zero
+/// (through the same truncating element/band division as the C).
+fn find_first<S: BlendSample>(data: &[u8], base_elem: usize, w: i64, bands: usize) -> i64 {
+    let ne = w * bands as i64;
+    let mut i = 0i64;
+    while i < ne && !S::get(data, base_elem + i as usize).is_nonzero() {
+        i += 1;
+    }
+    i / bands as i64
+}
+
+fn find_last<S: BlendSample>(data: &[u8], base_elem: usize, w: i64, bands: usize) -> i64 {
+    let ne = w * bands as i64;
+    let mut i = ne - 1;
+    while i >= 0 && !S::get(data, base_elem + i as usize).is_nonzero() {
+        i -= 1;
+    }
+    i / bands as i64
+}
+
+/// Render one merged output, all three depths sharing this generic body.
+fn render_merge<S: BlendSample>(
+    out: &mut Raster,
+    ref_: &Raster,
+    sec: &Raster,
+    st: &MergeState,
+    direction: MergeDirection,
+    mwidth: i64,
+) {
+    // Stage 1/2 (vips__merge_gen difficult case): paste ref, then sec over
+    // it; stage 3 rewrites the overlap with the feathered blend.
+    paste(out, ref_, st.rarea.left, st.rarea.top);
+    paste(out, sec, st.sarea.left, st.sarea.top);
+
+    let bands = ref_.format().channels();
+    let ov = st.overlap;
+    let ref_w = ref_.width() as i64;
+    let sec_w = sec.width() as i64;
+    let out_w = out.width() as i64;
+    let ref_data = ref_.data();
+    let sec_data = sec.data();
+    let out_data = out.data_mut();
+
+    let ref_elem =
+        |x: i64, y: i64| (((y - st.rarea.top) * ref_w + (x - st.rarea.left)) as usize) * bands;
+    let sec_elem =
+        |x: i64, y: i64| (((y - st.sarea.top) * sec_w + (x - st.sarea.left)) as usize) * bands;
+    let out_elem = |x: i64, y: i64| ((y * out_w + x) as usize) * bands;
+
+    // first/last per overlap scan-line (lr) or column (tb), in output
+    // coordinates, then clipped to the maximum blend width by shrinking
+    // both ends (make_firstlast).
+    let fl_len = match direction {
+        MergeDirection::Horizontal => ov.height,
+        MergeDirection::Vertical => ov.width,
+    };
+    let mut fl: Vec<(i64, i64)> = Vec::with_capacity(fl_len as usize);
+    for j in 0..fl_len {
+        let (mut first, mut last) = match direction {
+            MergeDirection::Horizontal => {
+                // find_first / find_last translated to output space.
+                let f = ov.left
+                    + find_first::<S>(sec_data, sec_elem(ov.left, ov.top + j), ov.width, bands);
+                let l = ov.left
+                    + find_last::<S>(ref_data, ref_elem(ov.left, ov.top + j), ov.width, bands);
+                (f, l)
+            }
+            MergeDirection::Vertical => {
+                let x = ov.left + j;
+                // find_top / find_bot: scan the column's pixels.
+                let mut i = 0i64;
+                while i < ov.height {
+                    if !pixel_is_zero::<S>(sec_data, sec_elem(x, ov.top + i), bands) {
+                        break;
+                    }
+                    i += 1;
+                }
+                let f = ov.top + i;
+                let mut i = ov.height - 1;
+                while i >= 0 {
+                    if !pixel_is_zero::<S>(ref_data, ref_elem(x, ov.top + i), bands) {
+                        break;
+                    }
+                    i -= 1;
+                }
+                let l = ov.top + i;
+                (f, l)
+            }
+        };
+        if mwidth >= 0 && last - first > mwidth {
+            let shrinkby = (last - first) - mwidth;
+            first += shrinkby / 2;
+            last -= shrinkby / 2;
+        }
+        fl.push((first, last));
+    }
+
+    match direction {
+        MergeDirection::Horizontal => {
+            // lr_blend / iblend: per scan-line ramp between first and last.
+            for j in 0..ov.height {
+                let y = ov.top + j;
+                let (first, last) = fl[j as usize];
+                let left = (first - ov.left).clamp(0, ov.width);
+                let right = (last - ov.left).clamp(left, ov.width);
+                for x in 0..ov.width {
+                    let ox = ov.left + x;
+                    let re = ref_elem(ox, y);
+                    let se = sec_elem(ox, y);
+                    let oe = out_elem(ox, y);
+                    let ref_zero = pixel_is_zero::<S>(ref_data, re, bands);
+                    let sec_zero = pixel_is_zero::<S>(sec_data, se, bands);
+                    let use_ref = if x < left {
+                        !ref_zero
+                    } else if x >= right {
+                        sec_zero
+                    } else if !ref_zero && !sec_zero {
+                        let inx = (((ox - first) << BLEND_SHIFT) / (last - first)) as usize;
+                        for b in 0..bands {
+                            let v =
+                                S::blend(inx, S::get(ref_data, re + b), S::get(sec_data, se + b));
+                            S::put(out_data, oe + b, v);
+                        }
+                        continue;
+                    } else {
+                        !ref_zero
+                    };
+                    let (src, e) = if use_ref {
+                        (ref_data, re)
+                    } else {
+                        (sec_data, se)
+                    };
+                    for b in 0..bands {
+                        S::put(out_data, oe + b, S::get(src, e + b));
+                    }
+                }
+            }
+        }
+        MergeDirection::Vertical => {
+            // tb_blend: per-column ramp between first and last.
+            for j in 0..ov.height {
+                let y = ov.top + j;
+                for x in 0..ov.width {
+                    let ox = ov.left + x;
+                    let (first, last) = fl[x as usize];
+                    let re = ref_elem(ox, y);
+                    let se = sec_elem(ox, y);
+                    let oe = out_elem(ox, y);
+                    let ref_zero = pixel_is_zero::<S>(ref_data, re, bands);
+                    let sec_zero = pixel_is_zero::<S>(sec_data, se, bands);
+                    let use_ref = if y < first {
+                        !ref_zero
+                    } else if y >= last {
+                        sec_zero
+                    } else if !ref_zero && !sec_zero {
+                        let inx = (((y - first) << BLEND_SHIFT) / (last - first)) as usize;
+                        for b in 0..bands {
+                            let v =
+                                S::blend(inx, S::get(ref_data, re + b), S::get(sec_data, se + b));
+                            S::put(out_data, oe + b, v);
+                        }
+                        continue;
+                    } else {
+                        !ref_zero
+                    };
+                    let (src, e) = if use_ref {
+                        (ref_data, re)
+                    } else {
+                        (sec_data, se)
+                    };
+                    for b in 0..bands {
+                        S::put(out_data, oe + b, S::get(src, e + b));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Shared merge implementation; `mwidth` is the maximum blend width
+/// (`-1` = unlimited).
+fn merge_impl(
+    ref_: &Raster,
+    sec: &Raster,
+    direction: MergeDirection,
+    dx: i64,
+    dy: i64,
+    mwidth: i64,
+) -> Result<Raster, MosaicError> {
+    if ref_.format() != sec.format() {
+        return Err(MosaicError::FormatMismatch {
+            reference: ref_.format(),
+            secondary: sec.format(),
+        });
+    }
+
+    // Wrong-side / disjoint displacement: libvips falls back to
+    // vips_insert with expansion (paste both, no blend).
+    let insert_fallback = match direction {
+        MergeDirection::Horizontal => dx > 0 || dx < 1 - ref_.width() as i64,
+        MergeDirection::Vertical => dy > 0 || dy < 1 - ref_.height() as i64,
+    };
+
+    let mut out = if insert_fallback {
+        let rarea = Rect {
+            left: 0,
+            top: 0,
+            width: ref_.width() as i64,
+            height: ref_.height() as i64,
+        };
+        let sarea = Rect {
+            left: -dx,
+            top: -dy,
+            width: sec.width() as i64,
+            height: sec.height() as i64,
+        };
+        let u = rarea.union(&sarea);
+        let mut out = Raster::zeroed(u.width as u32, u.height as u32, ref_.format())?;
+        paste(&mut out, ref_, -u.left, -u.top);
+        paste(&mut out, sec, -dx - u.left, -dy - u.top);
+        out
+    } else {
+        let st = build_merge_state(ref_, sec, dx, dy)?;
+        match direction {
+            MergeDirection::Horizontal => {
+                if st.rarea.right() > st.sarea.right() || st.rarea.left > st.sarea.left {
+                    return Err(MosaicError::TooMuchOverlap);
+                }
+            }
+            MergeDirection::Vertical => {
+                if st.rarea.bottom() > st.sarea.bottom() || st.rarea.top > st.sarea.top {
+                    return Err(MosaicError::TooMuchOverlap);
+                }
+            }
+        }
+        let mut out = Raster::zeroed(st.oarea.width as u32, st.oarea.height as u32, ref_.format())?;
+        match ref_.format().bytes_per_channel() {
+            1 => render_merge::<u8>(&mut out, ref_, sec, &st, direction, mwidth),
+            2 => render_merge::<u16>(&mut out, ref_, sec, &st, direction, mwidth),
+            _ => render_merge::<f32>(&mut out, ref_, sec, &st, direction, mwidth),
+        }
+        out
+    };
+
+    let tree = JoinTree::Join {
+        direction,
+        dx: dx as i32,
+        dy: dy as i32,
+        mblend: mwidth as i32,
+        ref_node: Box::new(tree_of(ref_)?),
+        sec_node: Box::new(tree_of(sec)?),
+    };
+    out.set_field(JOIN_TREE_FIELD, MetadataValue::Blob(tree.serialize()));
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Join-tree metadata (the structured stand-in for #LRJOIN history lines)
+// ---------------------------------------------------------------------------
+
+enum JoinTree {
+    Leaf(Raster),
+    Join {
+        direction: MergeDirection,
+        dx: i32,
+        dy: i32,
+        mblend: i32,
+        ref_node: Box<JoinTree>,
+        sec_node: Box<JoinTree>,
+    },
+}
+
+impl JoinTree {
+    fn serialize(&self) -> Vec<u8> {
+        let mut out = b"VMJ1".to_vec();
+        self.write_node(&mut out);
+        out
+    }
+
+    fn write_node(&self, out: &mut Vec<u8>) {
+        match self {
+            JoinTree::Leaf(r) => {
+                out.push(0);
+                out.extend_from_slice(&r.width().to_le_bytes());
+                out.extend_from_slice(&r.height().to_le_bytes());
+                out.extend_from_slice(&(r.format().channels() as u16).to_le_bytes());
+                out.push(r.format().bytes_per_channel() as u8);
+                out.extend_from_slice(r.data());
+            }
+            JoinTree::Join {
+                direction,
+                dx,
+                dy,
+                mblend,
+                ref_node,
+                sec_node,
+            } => {
+                out.push(1);
+                out.push(match direction {
+                    MergeDirection::Horizontal => 0,
+                    MergeDirection::Vertical => 1,
+                });
+                out.extend_from_slice(&dx.to_le_bytes());
+                out.extend_from_slice(&dy.to_le_bytes());
+                out.extend_from_slice(&mblend.to_le_bytes());
+                ref_node.write_node(out);
+                sec_node.write_node(out);
+            }
+        }
+    }
+
+    fn deserialize(blob: &[u8]) -> Result<JoinTree, MosaicError> {
+        let corrupt = || MosaicError::CorruptMosaicMetadata;
+        let rest = blob.strip_prefix(b"VMJ1".as_slice()).ok_or_else(corrupt)?;
+        let mut cursor = rest;
+        let tree = Self::read_node(&mut cursor)?;
+        if !cursor.is_empty() {
+            return Err(corrupt());
+        }
+        Ok(tree)
+    }
+
+    fn read_node(cursor: &mut &[u8]) -> Result<JoinTree, MosaicError> {
+        let corrupt = || MosaicError::CorruptMosaicMetadata;
+        let take = |cursor: &mut &[u8], n: usize| -> Result<Vec<u8>, MosaicError> {
+            if cursor.len() < n {
+                return Err(MosaicError::CorruptMosaicMetadata);
+            }
+            let (head, tail) = cursor.split_at(n);
+            *cursor = tail;
+            Ok(head.to_vec())
+        };
+        let take_u32 = |cursor: &mut &[u8]| -> Result<u32, MosaicError> {
+            let b = take(cursor, 4)?;
+            Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        };
+        let take_i32 = |cursor: &mut &[u8]| -> Result<i32, MosaicError> {
+            let b = take(cursor, 4)?;
+            Ok(i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        };
+        match take(cursor, 1)?[0] {
+            0 => {
+                let width = take_u32(cursor)?;
+                let height = take_u32(cursor)?;
+                let ch = take(cursor, 2)?;
+                let channels = u16::from_le_bytes([ch[0], ch[1]]) as usize;
+                let bpc = take(cursor, 1)?[0] as usize;
+                let format = PixelFormat::with_channels(channels, bpc).ok_or_else(corrupt)?;
+                let len = (width as usize)
+                    .checked_mul(height as usize)
+                    .and_then(|p| p.checked_mul(format.bytes_per_pixel()))
+                    .ok_or_else(corrupt)?;
+                let data = take(cursor, len)?;
+                let raster = Raster::new(width, height, format, data).map_err(|_| corrupt())?;
+                Ok(JoinTree::Leaf(raster))
+            }
+            1 => {
+                let direction = match take(cursor, 1)?[0] {
+                    0 => MergeDirection::Horizontal,
+                    1 => MergeDirection::Vertical,
+                    _ => return Err(corrupt()),
+                };
+                let dx = take_i32(cursor)?;
+                let dy = take_i32(cursor)?;
+                let mblend = take_i32(cursor)?;
+                let ref_node = Box::new(Self::read_node(cursor)?);
+                let sec_node = Box::new(Self::read_node(cursor)?);
+                Ok(JoinTree::Join {
+                    direction,
+                    dx,
+                    dy,
+                    mblend,
+                    ref_node,
+                    sec_node,
+                })
+            }
+            _ => Err(corrupt()),
+        }
+    }
+}
+
+/// The join tree a raster contributes when used as a merge input: its own
+/// tree when it was itself built by merge/mosaic, otherwise a new leaf.
+fn tree_of(r: &Raster) -> Result<JoinTree, MosaicError> {
+    match r.get_field(JOIN_TREE_FIELD) {
+        Some(MetadataValue::Blob(blob)) => JoinTree::deserialize(&blob),
+        Some(_) => Err(MosaicError::CorruptMosaicMetadata),
+        None => Ok(JoinTree::Leaf(r.clone())),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mosaic: tie-point search (im_lrcalcon.c / chkpair.c / spcor.c)
+// ---------------------------------------------------------------------------
+
+/// A one-band 8-bit search image (the contrast-stretched overlap).
+struct GrayU8 {
+    w: i64,
+    h: i64,
+    data: Vec<u8>,
+}
+
+impl GrayU8 {
+    fn at(&self, x: i64, y: i64) -> u8 {
+        self.data[(y * self.w + x) as usize]
+    }
+}
+
+/// Extract band 0 of `area` and contrast-stretch it to 0..255 exactly as
+/// `vips_scale` does: `clip(0, 255, trunc(f * (v - min) + 0.5))` with
+/// `f = 255 / (max - min)`, or all black when the range is zero.
+fn scale_band0(src: &Raster, area: Rect) -> Result<GrayU8, MosaicError> {
+    let ex = src.extract(
+        area.left as u32,
+        area.top as u32,
+        area.width as u32,
+        area.height as u32,
+    )?;
+    let bands = ex.format().channels();
+    let bpc = ex.format().bytes_per_channel();
+    let data = ex.data();
+    let n = (area.width * area.height) as usize;
+    let sample = |i: usize| -> f64 {
+        let elem = i * bands;
+        match bpc {
+            1 => data[elem] as f64,
+            2 => u16::from_ne_bytes([data[elem * 2], data[elem * 2 + 1]]) as f64,
+            _ => f32::from_ne_bytes([
+                data[elem * 4],
+                data[elem * 4 + 1],
+                data[elem * 4 + 2],
+                data[elem * 4 + 3],
+            ]) as f64,
+        }
+    };
+    let mut mn = f64::INFINITY;
+    let mut mx = f64::NEG_INFINITY;
+    for i in 0..n {
+        let v = sample(i);
+        mn = mn.min(v);
+        mx = mx.max(v);
+    }
+    let mut out = vec![0u8; n];
+    if mx > mn {
+        let f = 255.0 / (mx - mn);
+        let a = -(mn * f) + 0.5;
+        for (i, o) in out.iter_mut().enumerate() {
+            *o = (f * sample(i) + a).clamp(0.0, 255.0) as u8;
+        }
+    }
+    Ok(GrayU8 {
+        w: area.width,
+        h: area.height,
+        data: out,
+    })
+}
+
+/// One tie-point set (`TiePoints`).
+#[derive(Clone, Default)]
+struct TiePoints {
+    xref: Vec<i64>,
+    yref: Vec<i64>,
+    xsec: Vec<i64>,
+    ysec: Vec<i64>,
+    correlation: Vec<f64>,
+    dx: Vec<f64>,
+    dy: Vec<f64>,
+    deviation: Vec<f64>,
+    l_scale: f64,
+    l_angle: f64,
+    l_deltax: f64,
+    l_deltay: f64,
+}
+
+impl TiePoints {
+    fn len(&self) -> usize {
+        self.xref.len()
+    }
+}
+
+/// `all_black`: true when the `winsize` window centred at `(x, y)` holds
+/// only zeros.
+fn all_black(im: &GrayU8, x: i64, y: i64, winsize: i64) -> bool {
+    let h = (winsize - 1) / 2;
+    for j in 0..winsize {
+        for i in 0..winsize {
+            if im.at(x - h + i, y - h + j) != 0 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// `calculate_contrast`: sum of absolute horizontal and vertical
+/// neighbour differences over the window.
+fn window_contrast(im: &GrayU8, x: i64, y: i64, winsize: i64) -> i64 {
+    let h = (winsize - 1) / 2;
+    let mut total = 0i64;
+    for j in 0..winsize - 1 {
+        for i in 0..winsize - 1 {
+            let p = im.at(x - h + i, y - h + j) as i64;
+            let lrd = p - im.at(x - h + i + 1, y - h + j) as i64;
+            let tbd = p - im.at(x - h + i, y - h + j + 1) as i64;
+            total += lrd.abs() + tbd.abs();
+        }
+    }
+    total
+}
+
+/// `vips__find_best_contrast`: the `nbest` highest-contrast window
+/// centres on a `hcorsize` grid over the given area.
+fn find_best_contrast(
+    im: &GrayU8,
+    xpos: i64,
+    ypos: i64,
+    xsize: i64,
+    ysize: i64,
+    nbest: usize,
+    hcorsize: i64,
+) -> Result<Vec<(i64, i64)>, MosaicError> {
+    let windowsize = 2 * hcorsize + 1;
+    let nacross = (xsize - windowsize + hcorsize) / hcorsize;
+    let ndown = (ysize - windowsize + hcorsize) / hcorsize;
+    if nacross <= 0 || ndown <= 0 {
+        return Err(MosaicError::OverlapTooSmall);
+    }
+    let mut candidates: Vec<(i64, i64, i64)> = Vec::new();
+    for y in 0..ndown {
+        for x in 0..nacross {
+            let left = xpos + x * hcorsize;
+            let top = ypos + y * hcorsize;
+            if all_black(im, left, top, windowsize) {
+                continue;
+            }
+            candidates.push((left, top, window_contrast(im, left, top, windowsize)));
+        }
+    }
+    if candidates.len() < nbest {
+        return Err(MosaicError::TooFewPoints {
+            found: candidates.len(),
+            needed: nbest,
+        });
+    }
+    // Stable sort: contrast ties keep scan order (the C qsort's tie order
+    // is unspecified).
+    candidates.sort_by(|l, r| r.2.cmp(&l.2));
+    Ok(candidates[..nbest].iter().map(|c| (c.0, c.1)).collect())
+}
+
+/// `vips__lrcalcon` / `vips__tbcalcon`: high-contrast reference points in
+/// three strips of the overlap.
+fn calcon(im: &GrayU8, direction: MergeDirection) -> Result<Vec<(i64, i64)>, MosaicError> {
+    let border = HAREA;
+    let len = MAXPOINTS / AREAS;
+    let mut points = Vec::with_capacity(MAXPOINTS);
+    match direction {
+        MergeDirection::Horizontal => {
+            let aheight = im.h / AREAS as i64;
+            let (left, width) = (border, im.w - 2 * border - 1);
+            let height = aheight - 2 * border - 1;
+            let mut top = border;
+            let mut i = 0;
+            while top < im.h && i < AREAS {
+                points.extend(find_best_contrast(
+                    im, left, top, width, height, len, HWINDOW,
+                )?);
+                top += aheight;
+                i += 1;
+            }
+        }
+        MergeDirection::Vertical => {
+            let awidth = im.w / AREAS as i64;
+            let (top, height) = (border, im.h - 2 * border - 1);
+            let width = awidth - 2 * border - 1;
+            if width < 0 || height < 0 {
+                return Err(MosaicError::OverlapTooSmall);
+            }
+            let mut left = border;
+            let mut i = 0;
+            while left < im.w && i < AREAS {
+                points.extend(find_best_contrast(
+                    im, left, top, width, height, len, HWINDOW,
+                )?);
+                left += awidth;
+                i += 1;
+            }
+        }
+    }
+    Ok(points)
+}
+
+/// `vips__correl`: search `sec` around `(xsec, ysec)` for the best
+/// normalised spatial correlation with the window around `(xref, yref)`
+/// in `ref`. Returns `(correlation, x, y)`.
+#[allow(clippy::too_many_arguments)]
+fn correl(
+    ref_im: &GrayU8,
+    sec_im: &GrayU8,
+    xref: i64,
+    yref: i64,
+    xsec: i64,
+    ysec: i64,
+    hwindowsize: i64,
+    hsearchsize: i64,
+) -> (f64, i64, i64) {
+    // Window in ref, clipped to the image.
+    let wl = (xref - hwindowsize).max(0);
+    let wt = (yref - hwindowsize).max(0);
+    let wr = (xref + hwindowsize + 1).min(ref_im.w);
+    let wb = (yref + hwindowsize + 1).min(ref_im.h);
+    let (ww, wh) = (wr - wl, wb - wt);
+
+    // Search area in sec, clipped to the image.
+    let sl = (xsec - hsearchsize).max(0);
+    let st = (ysec - hsearchsize).max(0);
+    let sr = (xsec + hsearchsize + 1).min(sec_im.w);
+    let sb = (ysec + hsearchsize + 1).min(sec_im.h);
+    let (sw, sh) = (sr - sl, sb - st);
+
+    // Reference window statistics (spcor pre_generate).
+    let n = (ww * wh) as f64;
+    let mut sum = 0.0;
+    for j in 0..wh {
+        for i in 0..ww {
+            sum += ref_im.at(wl + i, wt + j) as f64;
+        }
+    }
+    let rmean = sum / n;
+    let mut ss = 0.0;
+    for j in 0..wh {
+        for i in 0..ww {
+            let d = ref_im.at(wl + i, wt + j) as f64 - rmean;
+            ss += d * d;
+        }
+    }
+    let c1 = ss.sqrt();
+
+    // Correlation surface over the search area, the window centred at
+    // each position with edge replication (EXTEND_COPY on the extracted
+    // search area).
+    let sec_at = |x: i64, y: i64| sec_im.at(sl + x.clamp(0, sw - 1), st + y.clamp(0, sh - 1));
+    let mut best = f64::NEG_INFINITY;
+    let (mut bx, mut by) = (0i64, 0i64);
+    for py in 0..sh {
+        for px in 0..sw {
+            let (ox, oy) = (px - ww / 2, py - wh / 2);
+            let mut sum1 = 0.0;
+            for j in 0..wh {
+                for i in 0..ww {
+                    sum1 += sec_at(ox + i, oy + j) as f64;
+                }
+            }
+            let imean = sum1 / n;
+            let mut sum2 = 0.0;
+            let mut sum3 = 0.0;
+            for j in 0..wh {
+                for i in 0..ww {
+                    let ip = sec_at(ox + i, oy + j) as f64;
+                    let rp = ref_im.at(wl + i, wt + j) as f64;
+                    let t = ip - imean;
+                    sum2 += t * t;
+                    sum3 += (rp - rmean) * t;
+                }
+            }
+            let c2 = c1 * sum2.sqrt();
+            let cc = if c2 == 0.0 { 0.0 } else { sum3 / c2 };
+            if cc > best {
+                best = cc;
+                bx = px;
+                by = py;
+            }
+        }
+    }
+    (best, bx + sl, by + st)
+}
+
+/// `vips__chkpair`: correlate every reference point into the secondary.
+fn chkpair(ref_im: &GrayU8, sec_im: &GrayU8, refs: &[(i64, i64)]) -> TiePoints {
+    let mut p = TiePoints::default();
+    for &(x, y) in refs {
+        let (correlation, xs, ys) = correl(ref_im, sec_im, x, y, x, y, HWINDOW, HAREA);
+        p.xref.push(x);
+        p.yref.push(y);
+        p.xsec.push(xs);
+        p.ysec.push(ys);
+        p.correlation.push(correlation);
+        p.dx.push((xs - x) as f64);
+        p.dy.push((ys - y) as f64);
+        p.deviation.push(0.0);
+    }
+    p
+}
+
+/// Invert an `n` x `n` matrix (row-major) by Gauss-Jordan elimination with
+/// partial pivoting. `None` when singular.
+fn mat_invert(mut a: Vec<f64>, n: usize) -> Option<Vec<f64>> {
+    let mut inv = vec![0.0; n * n];
+    for d in 0..n {
+        inv[d * n + d] = 1.0;
+    }
+    for col in 0..n {
+        let mut pivot = col;
+        for row in col + 1..n {
+            if a[row * n + col].abs() > a[pivot * n + col].abs() {
+                pivot = row;
+            }
+        }
+        if a[pivot * n + col] == 0.0 {
+            return None;
+        }
+        if pivot != col {
+            for k in 0..n {
+                a.swap(col * n + k, pivot * n + k);
+                inv.swap(col * n + k, pivot * n + k);
+            }
+        }
+        let p = a[col * n + col];
+        for k in 0..n {
+            a[col * n + k] /= p;
+            inv[col * n + k] /= p;
+        }
+        for row in 0..n {
+            if row == col {
+                continue;
+            }
+            let f = a[row * n + col];
+            if f == 0.0 {
+                continue;
+            }
+            for k in 0..n {
+                a[row * n + k] -= f * a[col * n + k];
+                inv[row * n + k] -= f * inv[col * n + k];
+            }
+        }
+    }
+    Some(inv)
+}
+
+/// `vips__clinear`: fit the first-order model and fill dx/dy/deviation.
+/// `false` when the fit matrix is singular (the caller falls back).
+fn clinear(p: &mut TiePoints) -> bool {
+    let elms = p.len() as f64;
+    let (mut sx1, mut sx1x1, mut sy1, mut sy1y1) = (0.0, 0.0, 0.0, 0.0);
+    let (mut sx2x1, mut sx2y1, mut sy2y1, mut sy2x1, mut sx2, mut sy2) =
+        (0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    for i in 0..p.len() {
+        let (xr, yr) = (p.xref[i] as f64, p.yref[i] as f64);
+        let (xs, ys) = (p.xsec[i] as f64, p.ysec[i] as f64);
+        sx1 += xr;
+        sx1x1 += xr * xr;
+        sy1 += yr;
+        sy1y1 += yr * yr;
+        sx2x1 += xs * xr;
+        sx2y1 += xs * yr;
+        sy2y1 += ys * yr;
+        sy2x1 += ys * xr;
+        sx2 += xs;
+        sy2 += ys;
+    }
+    #[rustfmt::skip]
+    let mat = vec![
+        sx1x1 + sy1y1, 0.0,           sx1,  sy1,
+        0.0,           sx1x1 + sy1y1, -sy1, sx1,
+        sx1,           -sy1,          elms, 0.0,
+        sy1,           sx1,           0.0,  elms,
+    ];
+    let g = [sx2x1 + sy2y1, -sx2y1 + sy2x1, sx2, sy2];
+    let Some(inv) = mat_invert(mat, 4) else {
+        return false;
+    };
+    let mut sol = [0.0f64; 4];
+    for (r, s) in sol.iter_mut().enumerate() {
+        // The fit matrix is symmetric, so reading the inverse column-wise
+        // as the C does equals the usual row-wise product.
+        for j in 0..4 {
+            *s += inv[j * 4 + r] * g[j];
+        }
+    }
+    let (scale, angle, xdelta, ydelta) = (sol[0], sol[1], sol[2], sol[3]);
+    for i in 0..p.len() {
+        let (xr, yr) = (p.xref[i] as f64, p.yref[i] as f64);
+        p.dx[i] = p.xsec[i] as f64 - ((scale * xr) - (angle * yr) + xdelta);
+        p.dy[i] = p.ysec[i] as f64 - ((angle * xr) + (scale * yr) + ydelta);
+        p.deviation[i] = (p.dx[i] * p.dx[i] + p.dy[i] * p.dy[i]).sqrt();
+    }
+    p.l_scale = scale;
+    p.l_angle = angle;
+    p.l_deltax = xdelta;
+    p.l_deltay = ydelta;
+    true
+}
+
+/// `vips__initialize`: clinear, or the correlation-weighted average
+/// fallback when the fit matrix is singular.
+fn initialize(p: &mut TiePoints) -> Result<(), MosaicError> {
+    if clinear(p) {
+        return Ok(());
+    }
+    let max_cor = p.correlation.iter().cloned().fold(0.0f64, f64::max) - 0.04;
+    let mut xdelta = 0.0;
+    let mut ydelta = 0.0;
+    let mut j = 0usize;
+    for i in 0..p.len() {
+        if p.correlation[i] >= max_cor {
+            xdelta += (p.xsec[i] - p.xref[i]) as f64;
+            ydelta += (p.ysec[i] - p.yref[i]) as f64;
+            j += 1;
+        }
+    }
+    if j == 0 {
+        return Err(MosaicError::NoTiePoints);
+    }
+    xdelta /= j as f64;
+    ydelta /= j as f64;
+    for i in 0..p.len() {
+        p.dx[i] = (p.xsec[i] - p.xref[i]) as f64 - xdelta;
+        p.dy[i] = (p.ysec[i] - p.yref[i]) as f64 - ydelta;
+        p.deviation[i] = (p.dx[i] * p.dx[i] + p.dy[i] * p.dy[i]).sqrt();
+    }
+    p.l_scale = 1.0;
+    p.l_angle = 0.0;
+    p.l_deltax = xdelta;
+    p.l_deltay = ydelta;
+    Ok(())
+}
+
+/// `copydevpoints`: keep points whose deviation/correlation ratio is
+/// within the adaptive threshold; correlation must exceed 0.01.
+fn copydevpoints(p: &TiePoints) -> TiePoints {
+    let mut min_dev = 9999.0f64;
+    let mut max_dev = 0.0f64;
+    for i in 0..p.len() {
+        if p.correlation[i] > 0.01 {
+            let r = p.deviation[i] / p.correlation[i];
+            min_dev = min_dev.min(r);
+            max_dev = max_dev.max(r);
+        }
+    }
+    let thresh_dev = (min_dev + (max_dev - min_dev) * 0.3).max(1.0);
+    let mut q = TiePoints {
+        l_scale: p.l_scale,
+        l_angle: p.l_angle,
+        l_deltax: p.l_deltax,
+        l_deltay: p.l_deltay,
+        ..TiePoints::default()
+    };
+    for i in 0..p.len() {
+        if p.correlation[i] > 0.01 && p.deviation[i] / p.correlation[i] <= thresh_dev {
+            q.xref.push(p.xref[i]);
+            q.yref.push(p.yref[i]);
+            q.xsec.push(p.xsec[i]);
+            q.ysec.push(p.ysec[i]);
+            q.correlation.push(p.correlation[i]);
+            q.dx.push(p.dx[i]);
+            q.dy.push(p.dy[i]);
+            q.deviation.push(p.deviation[i]);
+        }
+    }
+    q
+}
+
+/// `vips__improve`: repeatedly discard outliers and refit.
+fn improve(points: TiePoints) -> Result<TiePoints, MosaicError> {
+    let mut p = points;
+    loop {
+        let mut q = copydevpoints(&p);
+        if q.len() == p.len() {
+            return Ok(q);
+        }
+        if q.len() < 2 {
+            return Ok(q);
+        }
+        if !clinear(&mut q) {
+            return Err(MosaicError::SingularMatrix);
+        }
+        p = q;
+    }
+}
+
+/// `vips__avgdxdy`: round-half-to-even average of the surviving
+/// displacements.
+fn avgdxdy(p: &TiePoints) -> Result<(i64, i64), MosaicError> {
+    if p.xref.is_empty() {
+        return Err(MosaicError::NoTiePoints);
+    }
+    let mut sumdx = 0i64;
+    let mut sumdy = 0i64;
+    for i in 0..p.len() {
+        sumdx += p.xsec[i] - p.xref[i];
+        sumdy += p.ysec[i] - p.yref[i];
+    }
+    let n = p.len() as f64;
+    Ok((
+        (sumdx as f64 / n).round_ties_even() as i64,
+        (sumdy as f64 / n).round_ties_even() as i64,
+    ))
+}
+
+/// `vips__find_lroverlap` / `vips__find_tboverlap`: refine the tie-point
+/// guess into the merge displacement.
+#[allow(clippy::too_many_arguments)]
+fn find_overlap_offsets(
+    ref_: &Raster,
+    sec: &Raster,
+    direction: MergeDirection,
+    xref: i64,
+    yref: i64,
+    xsec: i64,
+    ysec: i64,
+) -> Result<(i64, i64), MosaicError> {
+    let left = Rect {
+        left: 0,
+        top: 0,
+        width: ref_.width() as i64,
+        height: ref_.height() as i64,
+    };
+    let right = Rect {
+        left: xref - xsec,
+        top: yref - ysec,
+        width: sec.width() as i64,
+        height: sec.height() as i64,
+    };
+    let overlap = left.intersect(&right);
+    if overlap.width < 2 * HAREA + 1 || overlap.height < 2 * HAREA + 1 {
+        return Err(MosaicError::OverlapTooSmall);
+    }
+
+    let ref_ov = scale_band0(ref_, overlap)?;
+    let sec_ov = scale_band0(
+        sec,
+        Rect {
+            left: overlap.left - right.left,
+            top: overlap.top - right.top,
+            width: overlap.width,
+            height: overlap.height,
+        },
+    )?;
+
+    let refs = calcon(&ref_ov, direction)?;
+    let mut points = chkpair(&ref_ov, &sec_ov, &refs);
+    initialize(&mut points)?;
+    let survivors = improve(points)?;
+    let (dx, dy) = avgdxdy(&survivors)?;
+
+    Ok((-right.left + dx, -right.top + dy))
+}
+
+// ---------------------------------------------------------------------------
+// Global balance (global_balance.c)
+// ---------------------------------------------------------------------------
+
+/// A leaf image with its rectangle in final mosaic coordinates.
+struct PlacedLeaf {
+    raster: Raster,
+    rect: Rect,
+}
+
+/// Size of the image a tree node renders to (calc_geometry).
+fn tree_size(node: &JoinTree) -> (i64, i64) {
+    match node {
+        JoinTree::Leaf(r) => (r.width() as i64, r.height() as i64),
+        JoinTree::Join {
+            dx,
+            dy,
+            ref_node,
+            sec_node,
+            ..
+        } => {
+            let (rw, rh) = tree_size(ref_node);
+            let (sw, sh) = tree_size(sec_node);
+            let rarea = Rect {
+                left: 0,
+                top: 0,
+                width: rw,
+                height: rh,
+            };
+            let sarea = Rect {
+                left: -(*dx as i64),
+                top: -(*dy as i64),
+                width: sw,
+                height: sh,
+            };
+            let u = rarea.union(&sarea);
+            (u.width, u.height)
+        }
+    }
+}
+
+/// Collect leaves depth-first (reference before secondary) with their
+/// final-output rectangles.
+fn collect_leaves(node: &JoinTree, ox: i64, oy: i64, out: &mut Vec<PlacedLeaf>) {
+    match node {
+        JoinTree::Leaf(r) => out.push(PlacedLeaf {
+            raster: r.clone(),
+            rect: Rect {
+                left: ox,
+                top: oy,
+                width: r.width() as i64,
+                height: r.height() as i64,
+            },
+        }),
+        JoinTree::Join {
+            dx,
+            dy,
+            ref_node,
+            sec_node,
+            ..
+        } => {
+            let (rw, rh) = tree_size(ref_node);
+            let (sw, sh) = tree_size(sec_node);
+            let rarea = Rect {
+                left: 0,
+                top: 0,
+                width: rw,
+                height: rh,
+            };
+            let sarea = Rect {
+                left: -(*dx as i64),
+                top: -(*dy as i64),
+                width: sw,
+                height: sh,
+            };
+            let u = rarea.union(&sarea);
+            collect_leaves(ref_node, ox - u.left, oy - u.top, out);
+            collect_leaves(
+                sec_node,
+                ox - (*dx as i64) - u.left,
+                oy - (*dy as i64) - u.top,
+                out,
+            );
+        }
+    }
+}
+
+/// Read the flat element `i` of a raster as `f64` (any depth).
+fn elem_f64(r: &Raster, i: usize) -> f64 {
+    let data = r.data();
+    match r.format().bytes_per_channel() {
+        1 => data[i] as f64,
+        2 => u16::from_ne_bytes([data[i * 2], data[i * 2 + 1]]) as f64,
+        _ => f32::from_ne_bytes([
+            data[i * 4],
+            data[i * 4 + 1],
+            data[i * 4 + 2],
+            data[i * 4 + 3],
+        ]) as f64,
+    }
+}
+
+/// One overlap row of the balance system: the masked-mean statistics of
+/// the two leaves over their shared area (find_overlap_stats).
+struct OverlapStat {
+    node: usize,
+    other: usize,
+    nstat: f64,
+    ostat: f64,
+}
+
+fn overlap_stats(a: &PlacedLeaf, b: &PlacedLeaf, overlap: &Rect) -> Option<(f64, f64)> {
+    let bands = a.raster.format().channels();
+    let n_pels = (overlap.width * overlap.height) as f64;
+    let mut nnz = 0u64;
+    let mut sum_n = 0.0f64;
+    let mut sum_o = 0.0f64;
+    for y in overlap.top..overlap.bottom() {
+        for x in overlap.left..overlap.right() {
+            let ae = (((y - a.rect.top) * a.rect.width + (x - a.rect.left)) as usize) * bands;
+            let be = (((y - b.rect.top) * b.rect.width + (x - b.rect.left)) as usize) * bands;
+            for c in 0..bands {
+                let nv = elem_f64(&a.raster, ae + c);
+                let ov = elem_f64(&b.raster, be + c);
+                if nv != 0.0 && ov != 0.0 {
+                    nnz += 1;
+                    sum_n += nv;
+                    sum_o += ov;
+                }
+            }
+        }
+    }
+    // count_nonzero mirrors the C double round-trip through the 0/255
+    // mask average, including its truncation to integer.
+    let avg_mask = 255.0 * nnz as f64 / (n_pels * bands as f64);
+    let count = ((avg_mask * n_pels) / 255.0) as i64;
+    if (count as f64) < TRIVIAL as f64 {
+        return None;
+    }
+    let scale = count as f64 / n_pels;
+    let nstat = (sum_n / (n_pels * bands as f64)) * scale;
+    let ostat = (sum_o / (n_pels * bands as f64)) * scale;
+    Some((nstat, ostat))
+}
+
+/// `find_factors`: least-mean-square balance factors, anchored on leaf 0
+/// and normalised to a mean of 1.0.
+fn find_factors(stats: &[OverlapStat], nim: usize, gamma: f64) -> Result<Vec<f64>, MosaicError> {
+    let novl = stats.len();
+    let cols = nim - 1;
+    if novl == 0 || cols == 0 {
+        return Err(MosaicError::SingularMatrix);
+    }
+    let mut k = vec![0.0f64; novl];
+    let mut m = vec![0.0f64; novl * cols];
+    for (row, s) in stats.iter().enumerate() {
+        let ns = s.nstat.powf(1.0 / gamma);
+        let os = s.ostat.powf(1.0 / gamma);
+        if s.node == 0 {
+            k[row] = ns;
+            m[row * cols + (s.other - 1)] = os;
+        } else {
+            m[row * cols + (s.node - 1)] = -ns;
+            m[row * cols + (s.other - 1)] = os;
+        }
+    }
+    // fac[1..] = (M^T M)^-1 M^T K.
+    let mut mtm = vec![0.0f64; cols * cols];
+    for i in 0..cols {
+        for j in 0..cols {
+            let mut sum = 0.0;
+            for (r, _) in stats.iter().enumerate() {
+                sum += m[r * cols + i] * m[r * cols + j];
+            }
+            mtm[i * cols + j] = sum;
+        }
+    }
+    let inv = mat_invert(mtm, cols).ok_or(MosaicError::SingularMatrix)?;
+    let mut mtk = vec![0.0f64; cols];
+    for (i, v) in mtk.iter_mut().enumerate() {
+        for (r, kv) in k.iter().enumerate() {
+            *v += m[r * cols + i] * kv;
+        }
+    }
+    let mut fac = vec![1.0f64; nim];
+    for i in 0..cols {
+        let mut sum = 0.0;
+        for j in 0..cols {
+            sum += inv[i * cols + j] * mtk[j];
+        }
+        fac[i + 1] = sum;
+    }
+    let avg = fac.iter().sum::<f64>() / nim as f64;
+    for f in &mut fac {
+        *f /= avg;
+    }
+    Ok(fac)
+}
+
+/// `transformf`: scale a leaf by its factor into a float raster. 8/16-bit
+/// depths go through the gamma lookup table
+/// `v -> (v^(1/gamma) * fac)^gamma`; float depths scale linearly; a
+/// factor of exactly 1.0 is a plain float cast.
+fn transform_leaf(leaf: &Raster, fac: f64, gamma: f64) -> Result<Raster, MosaicError> {
+    let bands = leaf.format().channels();
+    let out_format =
+        PixelFormat::with_channels(bands, 4).ok_or(MosaicError::CorruptMosaicMetadata)?;
+    let mut out = Raster::zeroed(leaf.width(), leaf.height(), out_format)?;
+    let n = leaf.width() as usize * leaf.height() as usize * bands;
+    let bpc = leaf.format().bytes_per_channel();
+    let lut: Option<Vec<f32>> = if fac == 1.0 || bpc == 4 {
+        None
+    } else {
+        let entries = if bpc == 1 { 256 } else { 65536 };
+        Some(
+            (0..entries)
+                .map(|v| ((v as f64).powf(1.0 / gamma) * fac).powf(gamma) as f32)
+                .collect(),
+        )
+    };
+    let out_data = out.data_mut();
+    for i in 0..n {
+        let v = elem_f64(leaf, i);
+        let t: f32 = if fac == 1.0 {
+            v as f32
+        } else if let Some(lut) = &lut {
+            lut[v as usize]
+        } else {
+            (v * fac) as f32
+        };
+        out_data[i * 4..i * 4 + 4].copy_from_slice(&t.to_ne_bytes());
+    }
+    Ok(out)
+}
+
+/// `make_mos_image` / `vips__build_mosaic`: re-merge the tree over the
+/// transformed float leaves.
+fn rebuild(
+    node: &JoinTree,
+    facs: &[f64],
+    gamma: f64,
+    next_leaf: &mut usize,
+) -> Result<Raster, MosaicError> {
+    match node {
+        JoinTree::Leaf(r) => {
+            let fac = facs[*next_leaf];
+            *next_leaf += 1;
+            transform_leaf(r, fac, gamma)
+        }
+        JoinTree::Join {
+            direction,
+            dx,
+            dy,
+            mblend,
+            ref_node,
+            sec_node,
+        } => {
+            let im1 = rebuild(ref_node, facs, gamma, next_leaf)?;
+            let im2 = rebuild(sec_node, facs, gamma, next_leaf)?;
+            merge_impl(
+                &im1,
+                &im2,
+                *direction,
+                *dx as i64,
+                *dy as i64,
+                *mblend as i64,
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+impl Raster {
+    /// Merge, the fallible form of [`Raster::merge`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MosaicError::FormatMismatch`] when the images differ in
+    /// pixel format, [`MosaicError::NoOverlap`] when the displaced images
+    /// share no pixels, and [`MosaicError::TooMuchOverlap`] when `self`
+    /// extends past `other` on the trailing edge.
+    pub fn try_merge(
+        &self,
+        other: &Raster,
+        direction: MergeDirection,
+        dx: i32,
+        dy: i32,
+    ) -> Result<Raster, MosaicError> {
+        merge_impl(self, other, direction, dx as i64, dy as i64, DEFAULT_MBLEND)
+    }
+
+    /// Merge two overlapping images with a feathered seam (libvips
+    /// `vips_merge` with the default `mblend` of 10).
+    ///
+    /// `self` is the reference image at `(0, 0)` (left for
+    /// [`MergeDirection::Horizontal`], top for
+    /// [`MergeDirection::Vertical`]); `other` is displaced to
+    /// `(-dx, -dy)`, so a left-right join with a 10-pixel overlap is
+    /// `dx = 10 - self.width()`. The output covers the union of the two
+    /// placed images; zero pixels are transparent in the seam. The result
+    /// carries the metadata [`Raster::global_balance`] needs.
+    ///
+    /// # Panics
+    ///
+    /// Panics on mismatched formats or impossible geometry; use
+    /// [`Raster::try_merge`] to handle those as errors.
+    pub fn merge(&self, other: &Raster, direction: MergeDirection, dx: i32, dy: i32) -> Raster {
+        expect_mosaic("merge", self.try_merge(other, direction, dx, dy))
+    }
+
+    /// Mosaic, the fallible form of [`Raster::mosaic`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MosaicError::OverlapTooSmall`] when the tie-point
+    /// estimate leaves less overlap than the search geometry needs,
+    /// [`MosaicError::TooFewPoints`] when a search strip has too few
+    /// usable high-contrast windows, [`MosaicError::NoTiePoints`] /
+    /// [`MosaicError::SingularMatrix`] when the fit fails, plus every
+    /// [`Raster::try_merge`] error for the final join.
+    pub fn try_mosaic(
+        &self,
+        other: &Raster,
+        direction: MergeDirection,
+        ref_x: i32,
+        ref_y: i32,
+        sec_x: i32,
+        sec_y: i32,
+    ) -> Result<Raster, MosaicError> {
+        if self.format() != other.format() {
+            return Err(MosaicError::FormatMismatch {
+                reference: self.format(),
+                secondary: other.format(),
+            });
+        }
+        let (dx0, dy0) = find_overlap_offsets(
+            self,
+            other,
+            direction,
+            ref_x as i64,
+            ref_y as i64,
+            sec_x as i64,
+            sec_y as i64,
+        )?;
+        merge_impl(self, other, direction, dx0, dy0, DEFAULT_MBLEND)
+    }
+
+    /// Join two images given an approximate tie-point (libvips
+    /// `vips_mosaic` with the default `bandno` 0, `hwindow` 5, `harea`
+    /// 15, `mblend` 10).
+    ///
+    /// `other` is positioned so that its pixel `(sec_x, sec_y)` lands on
+    /// `(ref_x, ref_y)` in `self`; the exact displacement is then refined
+    /// by correlating sixty high-contrast points of the estimated overlap
+    /// and the images are joined with [`Raster::merge`] semantics.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the overlap is too small to search, too few
+    /// high-contrast tie-point candidates exist, or the fit fails; use
+    /// [`Raster::try_mosaic`] to handle those as errors.
+    pub fn mosaic(
+        &self,
+        other: &Raster,
+        direction: MergeDirection,
+        ref_x: i32,
+        ref_y: i32,
+        sec_x: i32,
+        sec_y: i32,
+    ) -> Raster {
+        expect_mosaic(
+            "mosaic",
+            self.try_mosaic(other, direction, ref_x, ref_y, sec_x, sec_y),
+        )
+    }
+
+    /// Global balance, the fallible form of [`Raster::global_balance`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MosaicError::NoMosaicMetadata`] when the raster was not
+    /// built by [`Raster::merge`] / [`Raster::mosaic`],
+    /// [`MosaicError::CorruptMosaicMetadata`] when the join metadata does
+    /// not deserialize, and [`MosaicError::SingularMatrix`] when the
+    /// factor system cannot be solved (for example when every overlap is
+    /// smaller than the 20x20 significance threshold).
+    pub fn try_global_balance(&self) -> Result<Raster, MosaicError> {
+        let blob = match self.get_field(JOIN_TREE_FIELD) {
+            Some(MetadataValue::Blob(blob)) => blob,
+            Some(_) => return Err(MosaicError::CorruptMosaicMetadata),
+            None => return Err(MosaicError::NoMosaicMetadata),
+        };
+        let tree = JoinTree::deserialize(&blob)?;
+
+        let mut leaves = Vec::new();
+        collect_leaves(&tree, 0, 0, &mut leaves);
+        let nim = leaves.len();
+
+        // Every leaf pair with a significant overlap contributes one
+        // equation (test_overlap).
+        let mut stats = Vec::new();
+        for i in 0..nim {
+            for j in i + 1..nim {
+                let overlap = leaves[i].rect.intersect(&leaves[j].rect);
+                if overlap.is_empty() || overlap.width * overlap.height < TRIVIAL {
+                    continue;
+                }
+                if let Some((nstat, ostat)) = overlap_stats(&leaves[i], &leaves[j], &overlap) {
+                    stats.push(OverlapStat {
+                        node: i,
+                        other: j,
+                        nstat,
+                        ostat,
+                    });
+                }
+            }
+        }
+
+        let facs = find_factors(&stats, nim, BALANCE_GAMMA)?;
+        let mut next_leaf = 0usize;
+        rebuild(&tree, &facs, BALANCE_GAMMA, &mut next_leaf)
+    }
+
+    /// Remove brightness differences across an assembled mosaic (libvips
+    /// `vips_globalbalance` with the default gamma of 1.6 and float
+    /// output).
+    ///
+    /// The input must have been built by [`Raster::merge`] /
+    /// [`Raster::mosaic`], whose outputs carry the join metadata this
+    /// operation rebuilds from. Each source image is scaled by a
+    /// least-mean-square balance factor computed from the leaf overlap
+    /// statistics, and the mosaic is reassembled in float with the same
+    /// geometry as the input.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the raster carries no mosaic metadata or the factor
+    /// system cannot be solved; use [`Raster::try_global_balance`] to
+    /// handle those as errors.
+    pub fn global_balance(&self) -> Raster {
+        expect_mosaic("global_balance", self.try_global_balance())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uniform(w: u32, h: u32, v: u8) -> Raster {
+        Raster::new(w, h, PixelFormat::Gray8, vec![v; (w * h) as usize]).unwrap()
+    }
+
+    /// Deterministic high-contrast texture: a hash of the scene
+    /// coordinates mapped into 30..=225 so no pixel is transparent.
+    fn textured(w: u32, h: u32, ox: u32, oy: u32) -> Raster {
+        let mut data = Vec::with_capacity((w * h) as usize);
+        for y in 0..h {
+            for x in 0..w {
+                let mut v = (x + ox).wrapping_mul(0x9E37_79B9) ^ (y + oy).wrapping_mul(0x85EB_CA6B);
+                v ^= v >> 13;
+                v = v.wrapping_mul(0xC2B2_AE35);
+                v ^= v >> 16;
+                data.push(30 + (v % 196) as u8);
+            }
+        }
+        Raster::new(w, h, PixelFormat::Gray8, data).unwrap()
+    }
+
+    /**
+     * Compile-position pin for the exact ported-test call surface of the
+     * mosaicing batch (ported_mosaicing.rs): merge and mosaic with the
+     * MergeDirection enum and i32 offsets, and global_balance.
+     * Works by invoking every call site shape the ported tests use.
+     */
+    #[test]
+    fn ported_call_surface_compiles() {
+        let left = textured(80, 60, 0, 0);
+        let right = textured(80, 60, 70, 0);
+        let dx = 10 - left.width() as i32;
+        let join: Raster = left.merge(&right, MergeDirection::Horizontal, dx, 0);
+        assert_eq!(join.width(), left.width() + right.width() - 10);
+        assert_eq!(join.height(), left.height().max(right.height()));
+        let balanced: Raster = join.global_balance();
+        assert_eq!(balanced.format().channels(), 1);
+        let _ = |a: &Raster, b: &Raster| -> Raster {
+            a.mosaic(
+                b,
+                MergeDirection::Horizontal,
+                a.width() as i32 - 30,
+                0,
+                30,
+                0,
+            )
+        };
+    }
+
+    /**
+     * Tests left-right merge geometry, the ported test_lrmerge contract:
+     * a 10-pixel overlap yields width w1 + w2 - 10 and height
+     * max(h1, h2), and the ref-only / sec-only regions carry their source
+     * pixels unchanged.
+     * Works on two textured images of different heights.
+     */
+    #[test]
+    fn lrmerge_geometry_and_content() {
+        let left = textured(60, 50, 0, 0);
+        let right = textured(60, 40, 50, 0);
+        let dx = 10 - left.width() as i32;
+        let join = left.merge(&right, MergeDirection::Horizontal, dx, 0);
+        assert_eq!(join.width(), 110);
+        assert_eq!(join.height(), 50);
+        assert_eq!(join.format(), PixelFormat::Gray8);
+        // Far left: pure ref; far right: pure sec.
+        assert_eq!(join.getpoint(0, 0), left.getpoint(0, 0));
+        assert_eq!(join.getpoint(20, 30), left.getpoint(20, 30));
+        assert_eq!(join.getpoint(109, 10), right.getpoint(59, 10));
+        // Below sec's extent in sec-only columns: black.
+        assert_eq!(join.getpoint(109, 45)[0], 0.0);
+    }
+
+    /**
+     * Tests top-bottom merge geometry, the ported test_tbmerge contract:
+     * height h1 + h2 - overlap, width max(w1, w2).
+     * Works on two textured images of different widths.
+     */
+    #[test]
+    fn tbmerge_geometry() {
+        let top = textured(50, 60, 0, 0);
+        let bottom = textured(45, 60, 0, 50);
+        let dy = 10 - top.height() as i32;
+        let join = top.merge(&bottom, MergeDirection::Vertical, 0, dy);
+        assert_eq!(join.width(), 50);
+        assert_eq!(join.height(), 110);
+        assert_eq!(join.getpoint(10, 0), top.getpoint(10, 0));
+        assert_eq!(join.getpoint(10, 109), bottom.getpoint(10, 59));
+    }
+
+    /**
+     * Tests the raised-cosine seam on uniform images: the blend band is
+     * the centred mblend-wide strip of the overlap, pure ref left of it,
+     * pure sec right of it, and inside it each column matches the exact
+     * integer-lut blend the C computes.
+     * Works by merging uniform 100 and 200 images with a 30-pixel overlap
+     * and recomputing every overlap column with the same formulas.
+     */
+    #[test]
+    fn lrmerge_blend_band_exact() {
+        let left = uniform(60, 20, 100);
+        let right = uniform(60, 20, 200);
+        let dx = 30 - left.width() as i32; // 30-pixel overlap at x 30..60
+        let join = left.merge(&right, MergeDirection::Horizontal, dx, 0);
+        assert_eq!(join.width(), 90);
+        // first = 30, last = 59; wider than mblend 10, so the band
+        // shrinks by (29 - 10) / 2 = 9 on each side: [39, 50).
+        let (first, last) = (39i64, 50i64);
+        for x in 30..60i64 {
+            let expected = if x < first {
+                100.0
+            } else if x >= last {
+                200.0
+            } else {
+                let inx = ((x - first) << BLEND_SHIFT) / (last - first);
+                let luts = blend_luts();
+                (luts.icoef1[inx as usize] * 100 / BLEND_SCALE
+                    + luts.icoef2[inx as usize] * 200 / BLEND_SCALE) as f64
+            };
+            assert_eq!(
+                join.getpoint(x as u32, 10)[0],
+                expected,
+                "overlap column {x}"
+            );
+        }
+    }
+
+    /**
+     * Tests zero-pixel transparency in the seam: where sec is zero inside
+     * the overlap the ref pixel shows through unblended, and vice versa.
+     * Works by zeroing one sec row inside the overlap and checking that
+     * row keeps the ref value across the whole overlap.
+     */
+    #[test]
+    fn lrmerge_zero_is_transparent() {
+        let left = uniform(40, 10, 100);
+        let mut right = uniform(40, 10, 200);
+        // Zero out sec's row 3 over the whole image.
+        for x in 0..40 {
+            right.put_pixel(x, 3, &[0]);
+        }
+        let dx = 20 - left.width() as i32;
+        let join = left.merge(&right, MergeDirection::Horizontal, dx, 0);
+        for x in 20..40u32 {
+            assert_eq!(join.getpoint(x, 3)[0], 100.0, "ref shows through at {x}");
+        }
+        // A normal row still reaches pure sec on the right of the band.
+        assert_eq!(join.getpoint(39, 5)[0], 200.0);
+    }
+
+    /**
+     * Tests the insert fallback: a positive dx cannot be feathered, so
+     * the images are pasted into the union unblended, exactly like the
+     * vips_insert path.
+     * Works with dx = 5 (sec placed left of ref) and checks both source
+     * regions and the output size.
+     */
+    #[test]
+    fn merge_insert_fallback() {
+        let left = uniform(20, 10, 100);
+        let right = uniform(15, 10, 200);
+        let join = left.merge(&right, MergeDirection::Horizontal, 5, 0);
+        // sec at (-5, 0), ref at (0, 0): union spans -5..20.
+        assert_eq!(join.width(), 25);
+        assert_eq!(join.height(), 10);
+        assert_eq!(join.getpoint(0, 0)[0], 200.0, "sec-only far left");
+        assert_eq!(join.getpoint(24, 0)[0], 100.0, "ref-only far right");
+        // Overlap region: sec pasted over ref.
+        assert_eq!(join.getpoint(7, 0)[0], 200.0);
+    }
+
+    /**
+     * Tests merge error cases: mismatched formats, disjoint placements
+     * (vertical gap), and too much overlap (ref extends past sec).
+     * Works by asserting each try_merge error variant.
+     */
+    #[test]
+    fn merge_errors() {
+        let a = uniform(20, 10, 10);
+        let rgb = Raster::zeroed(20, 10, PixelFormat::Rgb8).unwrap();
+        assert!(matches!(
+            a.try_merge(&rgb, MergeDirection::Horizontal, -10, 0),
+            Err(MosaicError::FormatMismatch { .. })
+        ));
+        // In-range dx but a vertical displacement pushing sec fully
+        // below ref: no overlap.
+        assert!(matches!(
+            a.try_merge(&a, MergeDirection::Horizontal, -10, -20),
+            Err(MosaicError::NoOverlap)
+        ));
+        // sec narrower than ref at the same origin: ref's right edge
+        // passes sec's.
+        let narrow = uniform(10, 10, 10);
+        assert!(matches!(
+            a.try_merge(&narrow, MergeDirection::Horizontal, 0, 0),
+            Err(MosaicError::TooMuchOverlap)
+        ));
+    }
+
+    /**
+     * Tests float merging: FloatF32 rasters blend through the
+     * double-precision coefficient path and keep the float format, which
+     * the global-balance rebuild relies on.
+     * Works by merging two uniform float images and checking a blend
+     * column against the double lut.
+     */
+    #[test]
+    fn merge_float_path() {
+        let n = std::num::NonZeroU16::new(1).unwrap();
+        let fmt = PixelFormat::FloatF32(n);
+        let mut a = Raster::zeroed(30, 5, fmt).unwrap();
+        let mut b = Raster::zeroed(30, 5, fmt).unwrap();
+        for v in a.data_mut().chunks_exact_mut(4) {
+            v.copy_from_slice(&100.0f32.to_ne_bytes());
+        }
+        for v in b.data_mut().chunks_exact_mut(4) {
+            v.copy_from_slice(&200.0f32.to_ne_bytes());
+        }
+        let dx = 10 - a.width() as i32;
+        let join = a.merge(&b, MergeDirection::Horizontal, dx, 0);
+        assert_eq!(join.format(), fmt);
+        assert_eq!(join.width(), 50);
+        // Overlap 20..30, band [24, 30... shrink (9 - 10)? width 10 - 1 =
+        // 9 <= 10: no shrink; first 20, last 29.
+        let luts = blend_luts();
+        let x = 24i64;
+        let inx = ((x - 20) << BLEND_SHIFT) / 9;
+        let expected = (luts.coef1[inx as usize] * 100.0 + luts.coef2[inx as usize] * 200.0) as f32;
+        assert_eq!(join.getpoint(x as u32, 2)[0], expected as f64);
+    }
+
+    /**
+     * Tests the full mosaic search pipeline recovers a known true offset:
+     * two crops of one textured scene are mosaiced with a tie-point guess
+     * off by (+3, -2), and the correlation search must find the exact
+     * placement, giving the geometry of the true overlap.
+     * Works by comparing output dimensions and a sec-only pixel against
+     * the scene.
+     */
+    #[test]
+    fn lrmosaic_recovers_true_offset() {
+        // Scene 300x240; ref = left 160 columns, sec = 200 columns
+        // starting at (100, 3).
+        let ref_ = textured(160, 240, 0, 0);
+        let sec = textured(200, 234, 100, 3);
+        // Truth: sec pixel (30, 117) == scene (130, 120) == ref (130, 120).
+        // Guess passes (27, 119) instead: 3 columns left, 2 rows down.
+        let join = ref_.mosaic(&sec, MergeDirection::Horizontal, 130, 120, 27, 119);
+        assert_eq!(join.width(), 300, "true sec placement at x=100");
+        assert_eq!(join.height(), 240, "sec fits inside ref rows 3..237");
+        // A pixel right of the overlap comes straight from sec at the
+        // true offset.
+        assert_eq!(join.getpoint(299, 100), sec.getpoint(199, 97));
+    }
+
+    /**
+     * Tests the vertical mosaic search: same scene-crop construction
+     * top-bottom with a guess off by (-2, +4).
+     * Works by checking the output dimensions equal the true union.
+     */
+    #[test]
+    fn tbmosaic_recovers_true_offset() {
+        let ref_ = textured(240, 160, 0, 0);
+        let sec = textured(234, 200, 3, 100);
+        // Truth: sec pixel (117, 30) == scene (120, 130) == ref (120, 130).
+        let join = ref_.mosaic(&sec, MergeDirection::Vertical, 120, 130, 119, 26);
+        assert_eq!(join.width(), 240);
+        assert_eq!(join.height(), 300);
+    }
+
+    /**
+     * Tests mosaic search failure modes: an overlap estimate smaller than
+     * the 31-pixel search square is OverlapTooSmall, and an overlap
+     * without contrast (uniform images) has no usable tie-points.
+     * Works by asserting the try_mosaic error variants.
+     */
+    #[test]
+    fn mosaic_errors() {
+        let a = textured(100, 100, 0, 0);
+        let b = textured(100, 100, 90, 0);
+        // Guess placing sec with only a 10-column overlap.
+        assert!(matches!(
+            a.try_mosaic(&b, MergeDirection::Horizontal, 95, 50, 5, 50),
+            Err(MosaicError::OverlapTooSmall)
+        ));
+        // A uniform overlap has no high-contrast windows at all: every
+        // candidate is skipped as all-black after contrast stretching.
+        let ua = uniform(200, 200, 100);
+        let ub = uniform(200, 200, 100);
+        assert!(matches!(
+            ua.try_mosaic(&ub, MergeDirection::Horizontal, 150, 100, 50, 100),
+            Err(MosaicError::TooFewPoints { .. })
+        ));
+    }
+
+    /**
+     * Tests global balance on a two-image mosaic of uniform brightness
+     * 100 and 150: the factor system equalises the two sides, so after
+     * balancing the ref-only and sec-only regions agree, at the value the
+     * closed-form factors predict, and the output is float with the
+     * mosaic's geometry.
+     * Works by recomputing the expected factors analytically (single
+     * overlap row: f2 = (100/150)^(1/gamma), normalised to mean 1) and
+     * comparing balanced pixels.
+     */
+    #[test]
+    fn global_balance_two_image_mosaic() {
+        let left = uniform(60, 40, 100);
+        let right = uniform(60, 40, 150);
+        let dx = 10 - left.width() as i32;
+        let join = left.merge(&right, MergeDirection::Horizontal, dx, 0);
+        assert_eq!(join.width(), 110);
+
+        let balanced = join.global_balance();
+        assert_eq!(balanced.width(), 110);
+        assert_eq!(balanced.height(), 40);
+        assert_eq!(balanced.format().channels(), 1);
+        assert!(balanced.format().is_float(), "output must be float");
+
+        let gamma = BALANCE_GAMMA;
+        let f2 = (100.0f64).powf(1.0 / gamma) / (150.0f64).powf(1.0 / gamma);
+        let avg = (1.0 + f2) / 2.0;
+        let expected_ref = 100.0 * (1.0 / avg).powf(gamma);
+        let expected_sec = 150.0 * (f2 / avg).powf(gamma);
+
+        let got_ref = balanced.getpoint(5, 20)[0];
+        let got_sec = balanced.getpoint(105, 20)[0];
+        assert!(
+            (got_ref - expected_ref).abs() < 1e-3,
+            "ref side {got_ref} vs {expected_ref}"
+        );
+        assert!(
+            (got_sec - expected_sec).abs() < 1e-3,
+            "sec side {got_sec} vs {expected_sec}"
+        );
+        assert!(
+            (got_ref - got_sec).abs() < 1e-3,
+            "balancing equalises the two uniform sides"
+        );
+    }
+
+    /**
+     * Tests that global balance requires mosaic metadata: a plain raster
+     * is NoMosaicMetadata, and a corrupted blob is CorruptMosaicMetadata.
+     * Works by asserting the try_global_balance error variants.
+     */
+    #[test]
+    fn global_balance_metadata_errors() {
+        let plain = uniform(10, 10, 50);
+        assert!(matches!(
+            plain.try_global_balance(),
+            Err(MosaicError::NoMosaicMetadata)
+        ));
+        let mut bad = uniform(10, 10, 50);
+        bad.set_field(JOIN_TREE_FIELD, MetadataValue::Blob(vec![1, 2, 3]));
+        assert!(matches!(
+            bad.try_global_balance(),
+            Err(MosaicError::CorruptMosaicMetadata)
+        ));
+    }
+
+    /**
+     * Tests the join-tree metadata round trip: a merge of a merge
+     * serialises a three-leaf tree that deserialises back to the same
+     * geometry, sizes, and pixel data.
+     * Works by building a small two-join mosaic and walking the decoded
+     * tree.
+     */
+    #[test]
+    fn join_tree_round_trip() {
+        let a = textured(40, 30, 0, 0);
+        let b = textured(40, 30, 25, 0);
+        let c = textured(55, 30, 0, 22);
+        let ab = a.merge(&b, MergeDirection::Horizontal, 15 - 40, 0);
+        let abc = ab.merge(&c, MergeDirection::Vertical, 0, 8 - 30);
+        let blob = match abc.get_field(JOIN_TREE_FIELD) {
+            Some(MetadataValue::Blob(blob)) => blob,
+            other => panic!("expected join-tree blob, got {other:?}"),
+        };
+        let tree = JoinTree::deserialize(&blob).unwrap();
+        let JoinTree::Join {
+            direction: MergeDirection::Vertical,
+            dy: -22,
+            ref_node,
+            sec_node,
+            ..
+        } = tree
+        else {
+            panic!("root must be the vertical join at dy -22");
+        };
+        let JoinTree::Leaf(leaf_c) = *sec_node else {
+            panic!("secondary of the root is leaf c");
+        };
+        assert_eq!(leaf_c.data(), c.data());
+        assert_eq!(tree_size(&ref_node), (65, 30));
+        let JoinTree::Join {
+            direction: MergeDirection::Horizontal,
+            dx: -25,
+            ..
+        } = *ref_node
+        else {
+            panic!("reference of the root is the horizontal join at dx -25");
+        };
+    }
+
+    /**
+     * Tests leaf placement in final coordinates: for a horizontal join
+     * then a vertical join, collect_leaves reproduces the same rects the
+     * merge geometry used, which global balance's overlap statistics
+     * depend on.
+     * Works by comparing against hand-computed placements.
+     */
+    #[test]
+    fn collect_leaves_placement() {
+        let a = textured(40, 30, 0, 0);
+        let b = textured(40, 30, 25, 0);
+        let ab = a.merge(&b, MergeDirection::Horizontal, 15 - 40, 0);
+        assert_eq!((ab.width(), ab.height()), (65, 30));
+        let blob = match ab.get_field(JOIN_TREE_FIELD) {
+            Some(MetadataValue::Blob(blob)) => blob,
+            _ => unreachable!(),
+        };
+        let tree = JoinTree::deserialize(&blob).unwrap();
+        let mut leaves = Vec::new();
+        collect_leaves(&tree, 0, 0, &mut leaves);
+        assert_eq!(leaves.len(), 2);
+        assert_eq!(
+            leaves[0].rect,
+            Rect {
+                left: 0,
+                top: 0,
+                width: 40,
+                height: 30
+            }
+        );
+        assert_eq!(
+            leaves[1].rect,
+            Rect {
+                left: 25,
+                top: 0,
+                width: 40,
+                height: 30
+            }
+        );
+    }
+
+    /**
+     * Tests the blend luts against the closed form: coef1 is the raised
+     * cosine from 1 to 0, coef2 its complement, and the integer tables
+     * are the truncated scaled values, with the endpoints exact.
+     * Works by spot-checking the ends and middle of the tables.
+     */
+    #[test]
+    fn blend_luts_shape() {
+        let luts = blend_luts();
+        assert_eq!(luts.coef1[0], 1.0);
+        assert_eq!(luts.icoef1[0], BLEND_SCALE);
+        assert_eq!(luts.icoef2[0], 0);
+        assert!(luts.coef1[BLEND_SIZE - 1].abs() < 1e-12);
+        assert_eq!(luts.icoef1[BLEND_SIZE - 1], 0);
+        let mid = luts.coef1[BLEND_SIZE / 2] + luts.coef2[BLEND_SIZE / 2];
+        assert!((mid - 1.0).abs() < 1e-12);
+    }
+
+    /**
+     * Tests round-half-to-even displacement averaging (im_avgdxdy uses
+     * rint): an average of 0.5 rounds to 0 and 1.5 rounds to 2.
+     * Works by feeding two-point sets with those averages.
+     */
+    #[test]
+    fn avgdxdy_rounds_ties_to_even() {
+        let p = TiePoints {
+            xref: vec![0, 0],
+            yref: vec![0, 0],
+            xsec: vec![0, 1], // average 0.5 -> 0
+            ysec: vec![1, 2], // average 1.5 -> 2
+            correlation: vec![1.0, 1.0],
+            dx: vec![0.0; 2],
+            dy: vec![0.0; 2],
+            deviation: vec![0.0; 2],
+            ..TiePoints::default()
+        };
+        assert_eq!(avgdxdy(&p).unwrap(), (0, 2));
+    }
+
+    /**
+     * Tests the clinear fit on a pure translation: every point displaced
+     * by (3, -2) fits scale 1, angle 0, delta (3, -2) with zero
+     * deviations, so improve keeps all points.
+     * Works by fitting four spread points and checking the model.
+     */
+    #[test]
+    fn clinear_pure_translation() {
+        let mut p = TiePoints::default();
+        for (x, y) in [(10i64, 10i64), (40, 12), (12, 45), (44, 41)] {
+            p.xref.push(x);
+            p.yref.push(y);
+            p.xsec.push(x + 3);
+            p.ysec.push(y - 2);
+            p.correlation.push(1.0);
+            p.dx.push(0.0);
+            p.dy.push(0.0);
+            p.deviation.push(0.0);
+        }
+        assert!(clinear(&mut p));
+        assert!((p.l_scale - 1.0).abs() < 1e-9);
+        assert!(p.l_angle.abs() < 1e-9);
+        assert!((p.l_deltax - 3.0).abs() < 1e-9);
+        assert!((p.l_deltay + 2.0).abs() < 1e-9);
+        assert!(p.deviation.iter().all(|&d| d < 1e-9));
+        let kept = improve(p).unwrap();
+        assert_eq!(kept.len(), 4);
+    }
+
+    /**
+     * Tests improve discards an outlier: three consistent displacements
+     * and one wild one leave the consistent trio after refitting.
+     * Works by checking the survivor count and the averaged offset.
+     */
+    #[test]
+    fn improve_discards_outlier() {
+        let mut p = TiePoints::default();
+        for (x, y) in [(10i64, 10i64), (60, 12), (12, 65)] {
+            p.xref.push(x);
+            p.yref.push(y);
+            p.xsec.push(x + 5);
+            p.ysec.push(y + 1);
+            p.correlation.push(0.95);
+            p.dx.push(0.0);
+            p.dy.push(0.0);
+            p.deviation.push(0.0);
+        }
+        // The outlier.
+        p.xref.push(62);
+        p.yref.push(60);
+        p.xsec.push(62 + 14);
+        p.ysec.push(60 - 9);
+        p.correlation.push(0.2);
+        p.dx.push(0.0);
+        p.dy.push(0.0);
+        p.deviation.push(0.0);
+        initialize(&mut p).unwrap();
+        let kept = improve(p).unwrap();
+        assert_eq!(kept.len(), 3, "outlier dropped");
+        assert_eq!(avgdxdy(&kept).unwrap(), (5, 1));
+    }
+
+    /**
+     * Tests the correlation search finds an exact translated match: a
+     * textured reference window is located in a secondary image shifted
+     * by (4, -3), with correlation 1 at the true position.
+     * Works by running correl directly on two shifted views of one
+     * texture.
+     */
+    #[test]
+    fn correl_finds_shift() {
+        let scene = textured(80, 80, 0, 0);
+        let view = |ox: i64, oy: i64| GrayU8 {
+            w: 50,
+            h: 50,
+            data: {
+                let mut d = Vec::with_capacity(2500);
+                for y in 0..50i64 {
+                    for x in 0..50i64 {
+                        d.push(scene.data()[((y + oy) * 80 + (x + ox)) as usize]);
+                    }
+                }
+                d
+            },
+        };
+        let ref_im = view(10, 10);
+        let sec_im = view(14, 7); // sec(x, y) == ref(x + 4, y - 3)... i.e.
+        // ref feature at (x, y) appears in sec at (x - 4, y + 3).
+        let (cc, xs, ys) = correl(&ref_im, &sec_im, 25, 25, 25, 25, HWINDOW, HAREA);
+        assert_eq!((xs, ys), (21, 28));
+        assert!((cc - 1.0).abs() < 1e-9, "perfect match correlates at 1");
+    }
+
+    /**
+     * Tests scale_band0 matches the vips_scale contract: the band minimum
+     * maps to 0, the maximum to 255, and a zero-range image scales to all
+     * black.
+     * Works on a two-pixel ramp and a uniform image.
+     */
+    #[test]
+    fn scale_band0_contract() {
+        let r = Raster::new(2, 1, PixelFormat::Gray8, vec![10, 210]).unwrap();
+        let s = scale_band0(
+            &r,
+            Rect {
+                left: 0,
+                top: 0,
+                width: 2,
+                height: 1,
+            },
+        )
+        .unwrap();
+        assert_eq!(s.data, vec![0, 255]);
+        let u = uniform(3, 1, 77);
+        let s = scale_band0(
+            &u,
+            Rect {
+                left: 0,
+                top: 0,
+                width: 3,
+                height: 1,
+            },
+        )
+        .unwrap();
+        assert_eq!(s.data, vec![0, 0, 0], "zero range scales to black");
+    }
+}

--- a/tests/morphology_ported_surface.rs
+++ b/tests/morphology_ported_surface.rs
@@ -1,0 +1,112 @@
+//! Pins the morphology call surface required by the libviprs-tests ported
+//! suite (libviprs-tests issue #55, `tests/ported_morphology.rs`).
+//!
+//! Integration tests compile as an external crate, exactly the position
+//! the ported tests are in, so this file proves the surface they call
+//! compiles and behaves: method names, argument types (including the
+//! `&[&[u8]]` structuring-element shape and the `Direction` enum), and
+//! return types. Behaviour depth is covered by the unit tests in
+//! `src/morphology.rs`; this file is the API contract.
+//!
+//! Every ported morphology test builds its image synthetically (as the
+//! libvips originals do), so the bodies here are kept literal, including
+//! the `test_labelregions` segment-count assertion: libvips assigns
+//! region serials from 1 and reports `regions + 1` as the segment count,
+//! so one circle on black is labels 1 and 2 with a count of 3.
+
+use libviprs::{Direction, PixelFormat, Raster};
+
+/// The ported suite's `black_image` helper.
+fn black_image(w: u32, h: u32) -> Raster {
+    Raster::zeroed(w, h, PixelFormat::Gray8).unwrap()
+}
+
+/// The ported `test_countlines` body.
+#[test]
+fn ported_countlines_call_site() {
+    let mut im = black_image(100, 100);
+
+    // Draw a horizontal line: ink=255 from (0,50) to (100,50)
+    im.draw_line(&[255], 0, 50, 100, 50);
+
+    let n_lines = im.countlines(Direction::Horizontal);
+    assert_eq!(n_lines, 1.0);
+}
+
+/// The ported `test_labelregions` body.
+#[test]
+fn ported_labelregions_call_site() {
+    let mut im = black_image(100, 100);
+    im.draw_circle_filled(&[255], 50, 50, 25);
+
+    let (mask, segments) = im.label_regions();
+    assert_eq!(segments, 3);
+
+    let max_label = mask.data().iter().copied().max().unwrap();
+    assert_eq!(max_label, 2);
+}
+
+/// The ported `test_erode` body.
+#[test]
+fn ported_erode_call_site() {
+    let mut im = black_image(100, 100);
+    im.draw_circle_filled(&[255], 50, 50, 25);
+
+    let kernel: &[&[u8]] = &[&[128, 255, 128], &[255, 255, 255], &[128, 255, 128]];
+    let im2 = im.erode(kernel);
+
+    assert_eq!(im.width(), im2.width());
+    assert_eq!(im.height(), im2.height());
+    assert_eq!(im.format(), im2.format());
+
+    let avg_before: f64 = im.data().iter().map(|&b| b as f64).sum::<f64>() / im.data().len() as f64;
+    let avg_after: f64 =
+        im2.data().iter().map(|&b| b as f64).sum::<f64>() / im2.data().len() as f64;
+    assert!(
+        avg_before > avg_after,
+        "Erosion should reduce the average pixel value: before={avg_before}, after={avg_after}"
+    );
+}
+
+/// The ported `test_dilate` body.
+#[test]
+fn ported_dilate_call_site() {
+    let mut im = black_image(100, 100);
+    im.draw_circle_filled(&[255], 50, 50, 25);
+
+    let kernel: &[&[u8]] = &[&[128, 255, 128], &[255, 255, 255], &[128, 255, 128]];
+    let im2 = im.dilate(kernel);
+
+    assert_eq!(im.width(), im2.width());
+    assert_eq!(im.height(), im2.height());
+    assert_eq!(im.format(), im2.format());
+
+    let avg_before: f64 = im.data().iter().map(|&b| b as f64).sum::<f64>() / im.data().len() as f64;
+    let avg_after: f64 =
+        im2.data().iter().map(|&b| b as f64).sum::<f64>() / im2.data().len() as f64;
+    assert!(
+        avg_after > avg_before,
+        "Dilation should increase the average pixel value: before={avg_before}, after={avg_after}"
+    );
+}
+
+/// The ported `test_rank` body.
+#[test]
+fn ported_rank_call_site() {
+    let mut im = black_image(100, 100);
+    im.draw_circle_filled(&[255], 50, 50, 25);
+
+    let im2 = im.rank(3, 3, 8);
+
+    assert_eq!(im.width(), im2.width());
+    assert_eq!(im.height(), im2.height());
+    assert_eq!(im.format(), im2.format());
+
+    let avg_before: f64 = im.data().iter().map(|&b| b as f64).sum::<f64>() / im.data().len() as f64;
+    let avg_after: f64 =
+        im2.data().iter().map(|&b| b as f64).sum::<f64>() / im2.data().len() as f64;
+    assert!(
+        avg_after > avg_before,
+        "Max rank filter should increase average: before={avg_before}, after={avg_after}"
+    );
+}

--- a/tests/mosaicing_ported_surface.rs
+++ b/tests/mosaicing_ported_surface.rs
@@ -1,0 +1,178 @@
+//! Pins the mosaicing call surface required by the libviprs-tests ported
+//! suite (libviprs-tests issue #55, `tests/ported_mosaicing.rs`).
+//!
+//! Integration tests compile as an external crate, exactly the position
+//! the ported tests are in, so this file proves the surface they call
+//! compiles and behaves: method names, argument types (the
+//! `MergeDirection` enum and `i32` offsets/tie-points), and return types.
+//! Behaviour depth is covered by the unit tests in `src/mosaicing.rs`;
+//! this file is the API contract.
+//!
+//! The ported tests decode the libvips `cd*.jpg` mosaic fixtures; the
+//! setups here reproduce that character with synthetic one-band crops of
+//! a shared deterministic textured scene, so the tie-point search has
+//! real structure to lock onto, and the merge / mosaic / global-balance
+//! expressions are kept literal. The exact fixture dimensions the ported
+//! tests assert (1014x379 and friends) are covered by the ported suite
+//! itself once its reference images are fetched; here the same
+//! assertions run against the synthetic scene's known true geometry.
+
+use libviprs::{MergeDirection, PixelFormat, Raster};
+
+/// A crop of the shared textured scene, standing in for one `cd*.jpg`
+/// mosaic fixture (one band, no zero pixels, high local contrast).
+fn scene_crop(w: u32, h: u32, ox: u32, oy: u32) -> Raster {
+    let mut data = Vec::with_capacity((w * h) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let mut v = (x + ox).wrapping_mul(0x9E37_79B9) ^ (y + oy).wrapping_mul(0x85EB_CA6B);
+            v ^= v >> 13;
+            v = v.wrapping_mul(0xC2B2_AE35);
+            v ^= v >> 16;
+            data.push(30 + (v % 196) as u8);
+        }
+    }
+    Raster::new(w, h, PixelFormat::Gray8, data).unwrap()
+}
+
+/// The ported `test_lrmerge` body, on synthetic fixtures.
+#[test]
+fn ported_lrmerge_call_site() {
+    let left = scene_crop(240, 180, 0, 0);
+    let right = scene_crop(240, 170, 230, 6);
+
+    let dx = 10 - left.width() as i32;
+    let join = left.merge(&right, MergeDirection::Horizontal, dx, 0);
+
+    assert_eq!(join.width(), left.width() + right.width() - 10);
+    assert_eq!(join.height(), left.height().max(right.height()));
+    assert_eq!(join.format().channels(), 1);
+}
+
+/// The ported `test_tbmerge` body, on synthetic fixtures.
+#[test]
+fn ported_tbmerge_call_site() {
+    let top = scene_crop(180, 240, 0, 0);
+    let bottom = scene_crop(170, 240, 6, 230);
+
+    let dy = 10 - top.height() as i32;
+    let join = top.merge(&bottom, MergeDirection::Vertical, 0, dy);
+
+    assert_eq!(join.width(), top.width().max(bottom.width()));
+    assert_eq!(join.height(), top.height() + bottom.height() - 10);
+    assert_eq!(join.format().channels(), 1);
+}
+
+/// The ported `test_lrmosaic` body: the tie-point call shape, with the
+/// dimension assertions against the synthetic scene's known true geometry
+/// (`right` really sits at scene (240, 4), so the joined image spans
+/// 540x240).
+#[test]
+fn ported_lrmosaic_call_site() {
+    let left = scene_crop(300, 240, 0, 0);
+    let right = scene_crop(300, 234, 240, 4);
+
+    // Tie-point: scene (270, 120) is left (270, 120) and right (30, 116).
+    let ref_x = left.width() as i32 - 30;
+    let join = left.mosaic(&right, MergeDirection::Horizontal, ref_x, 120, 30, 116);
+
+    assert_eq!(join.width(), 540);
+    assert_eq!(join.height(), 240);
+}
+
+/// The ported `test_tbmosaic` body, transposed geometry.
+#[test]
+fn ported_tbmosaic_call_site() {
+    let top = scene_crop(240, 300, 0, 0);
+    let bottom = scene_crop(234, 300, 4, 240);
+
+    // Tie-point: scene (120, 270) is top (120, 270) and bottom (116, 30).
+    let ref_y = top.height() as i32 - 30;
+    let join = top.mosaic(&bottom, MergeDirection::Vertical, 120, ref_y, 116, 30);
+
+    assert_eq!(join.width(), 240);
+    assert_eq!(join.height(), 540);
+}
+
+/// The ported `test_mosaic` loop shape: horizontal pairs joined
+/// vertically through the same iterative `Option` fold, on a 2x2 grid of
+/// crops of one shared scene.
+#[test]
+fn ported_mosaic_call_site() {
+    // Two horizontal pairs: the top row at scene y 0, the bottom row at
+    // scene y 190, each pair overlapping 60 columns around scene x 270.
+    let files = [
+        scene_crop(300, 240, 0, 0),
+        scene_crop(300, 234, 240, 4),
+        scene_crop(300, 240, 2, 190),
+        scene_crop(300, 230, 242, 194),
+    ];
+    // Tie-point marks per pair, like MOSAIC_MARKS: scene (270, 120) for
+    // the first pair, scene (272, 310) for the second.
+    let marks = [(270, 120), (30, 116), (270, 120), (30, 116)];
+    // Vertical marks, like MOSAIC_VERTICAL_MARKS: scene (150, 210) seen
+    // by the finished strips (strip 2 sits at (2, 190) under strip 1).
+    let vertical_marks = [(148, 20), (150, 210)];
+
+    let mut mosaiced: Option<Raster> = None;
+
+    for i in (0..files.len()).step_by(2) {
+        let im = &files[i];
+        let sec_im = &files[i + 1];
+
+        let (ref_x, ref_y) = marks[i];
+        let (sec_x, sec_y) = marks[i + 1];
+
+        let horizontal_part = im.mosaic(
+            sec_im,
+            MergeDirection::Horizontal,
+            ref_x,
+            ref_y,
+            sec_x,
+            sec_y,
+        );
+
+        mosaiced = Some(match mosaiced {
+            None => horizontal_part,
+            Some(prev) => {
+                let vi = i - 2;
+                let (vref_x, vref_y) = vertical_marks[vi + 1];
+                let (vsec_x, vsec_y) = vertical_marks[vi];
+                prev.mosaic(
+                    &horizontal_part,
+                    MergeDirection::Vertical,
+                    vref_x,
+                    vref_y,
+                    vsec_x,
+                    vsec_y,
+                )
+            }
+        });
+    }
+
+    let result = mosaiced.unwrap();
+    // True geometry: both 540-wide strips, the second offset (2, 190).
+    assert_eq!(result.width(), 542);
+    assert_eq!(result.height(), 430);
+    // Mosaic images are grayscale
+    assert_eq!(result.format().channels(), 1);
+}
+
+/// The ported `test_globalbalance` body: balance the mosaic built by the
+/// mosaic surface and keep its geometry, one band, float format.
+#[test]
+fn ported_globalbalance_call_site() {
+    let left = scene_crop(300, 240, 0, 0);
+    let right = scene_crop(300, 234, 240, 4);
+
+    let ref_x = left.width() as i32 - 30;
+    let mosaiced = left.mosaic(&right, MergeDirection::Horizontal, ref_x, 120, 30, 116);
+
+    let balanced = mosaiced.global_balance();
+
+    assert_eq!(balanced.width(), 540);
+    assert_eq!(balanced.height(), 240);
+    assert_eq!(balanced.format().channels(), 1);
+    // Global balance produces float output.
+    assert!(balanced.format().is_float());
+}


### PR DESCRIPTION
## Summary

Next pure-Rust batch of the libvips op surface for the ported integration suite (libviprs/libviprs-tests#55): the MORPHOLOGY and MOSAICING families, each in a dedicated new module, plus the two external-crate call-surface pin files.

## src/morphology.rs

| Method | libvips equivalent |
|---|---|
| `Raster::erode(&self, kernel: &[&[u8]]) -> Raster` | `vips_morph` (erode) |
| `Raster::dilate(&self, kernel: &[&[u8]]) -> Raster` | `vips_morph` (dilate) |
| `Raster::rank(&self, width: u32, height: u32, index: u32) -> Raster` | `vips_rank` |
| `Raster::countlines(&self, direction: Direction) -> f64` | `vips_countlines` |
| `Raster::label_regions(&self) -> (Raster, u32)` | `vips_labelregions` |

Plus `pub enum Direction { Horizontal, Vertical }`, `MorphologyError`, and `try_*` fallible forms per the batch convention.

- erode/dilate: 0/128/255 structuring elements (255 must-match, 0 must-not, 128 don't-care), bitwise AND/OR accumulation exactly as `vips_erode_gen` / `vips_dilate_gen`, mask origin `(w/2, h/2)`, EXTEND_COPY edges, bandwise, typed errors for bad elements and non-8-bit depths.
- rank: index-th sorted value in the window, unsigned 8/16-bit, replicated edges.
- countlines: 128 threshold, rising transitions averaged over width/height, mono only.
- label_regions: row-major 4-connected flood labelling of equal-valued regions with serials starting at 1; the segment count is the final serial (regions + 1), which is the actual `vips_labelregions` contract behind the ported `segments == 3` assertion for one circle on black. Mask is Gray16 (no int-32 `PixelFormat`); stored labels saturate at 65535 while the returned count stays exact.

## src/mosaicing.rs

| Method | libvips equivalent |
|---|---|
| `Raster::merge(&self, other, direction: MergeDirection, dx: i32, dy: i32) -> Raster` | `vips_merge` (mblend 10) |
| `Raster::mosaic(&self, other, direction, ref_x, ref_y, sec_x, sec_y) -> Raster` | `vips_mosaic` (defaults) |
| `Raster::global_balance(&self) -> Raster` | `vips_globalbalance` (gamma 1.6, float) |

Plus `pub enum MergeDirection { Horizontal, Vertical }`, `MosaicError`, and `try_*` forms.

- merge: lrmerge/tbmerge union geometry, per-line first/last from the non-zero spans, raised-cosine feather clipped to mblend by shrinking both ends, integer-lut blend with truncating division (8/16-bit) and double-precision blend (float), zero-pixel transparency, `vips_insert` expansion fallback for wrong-side displacements, no-overlap / too-much-overlap typed errors.
- mosaic: the full default tie-point search ported from `lrmosaic.c` / `im_lrcalcon.c` / `chkpair.c` / `spcor.c`: band-0 `vips_scale` stretch, three-strip 20-point best-contrast selection on a 5px grid, normalised spatial correlation over a +-15px search square with edge replication, `im_clinear` first-order fit, `im_improve` outlier rejection, `im_avgdxdy` round-half-to-even averaging, then merge at the refined offset.
- global_balance: least-mean-square per-leaf factors (gamma 1.6) from masked overlap statistics, normalised to mean 1, leaves scaled by `(v^(1/g)*fac)^g` and re-merged in float. The join tree libvips reconstructs by parsing `#LRJOIN` history lines travels here as a structured `mosaic-join-tree` metadata blob attached by merge/mosaic, since in-memory rasters have no filenames to re-open.

Documented deviations: inputs must share a `PixelFormat` (libvips casts to a common format), contrast/correlation ties break deterministically (stable scan order) where C `qsort` / threaded `vips_max` are unspecified, and `mblend` is fixed at the default 10 on the public surface.

## Verification

- Verified against the real libvips v8.18.4 reference fixtures: all 11 `ported_morphology.rs` / `ported_mosaicing.rs` cells pass against this branch, including the exact mosaic dimensions (`test_lrmosaic` 1014x379, `test_tbmosaic` 542x688, `test_mosaic` 1005x1295) and the float `test_globalbalance` output. No ported assertion needed changing; the `label_regions` segments == 3 pin is faithful libvips behaviour. (Wiring note for the tests repo: the two files need `Direction` / `MergeDirection` added to their `use libviprs::{...}` lines when the cell is enabled.)
- 45 new unit tests in the two modules (exact blend-band pixels against the integer luts, offset recovery of known true placements by the search pipeline, closed-form two-image balance factors, join-tree round trip, typed-error coverage) plus `tests/morphology_ported_surface.rs` and `tests/mosaicing_ported_surface.rs` pinning the exact ported call shapes from the external-crate position.
- `make fmt`, `make clippy` (default + pdfium, -D warnings), `make test` (874 lib tests + all integration suites), and `make doc` all green locally.