### PR TITLE
feat(core): libvips freqfilt and matrix ops in new freqfilt/matrix modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,12 @@ pdfium-render = { version = "0.9", features = [
 	"sync",
 ], git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/integration" }
 proptest = "1"
+# Pure-Rust FFT (MIT OR Apache-2.0) used by the frequency-domain filter
+# operations in `src/freqfilt.rs` (`fwfft`, `invfft`, `freqmult`, `spectrum`,
+# `phasecor`). Chosen over an FFTW binding to keep the crate pure Rust; its
+# mixed-radix planner (with Bluestein fallback) handles every image size, not
+# just powers of two, matching what libvips gets from FFTW.
+rustfft = "6"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.11.0"
@@ -131,6 +137,7 @@ image = { workspace = true }
 lopdf = { workspace = true }
 moxcms = { workspace = true }
 pdfium-render = { workspace = true, optional = true }
+rustfft = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/src/freqfilt.rs
+++ b/src/freqfilt.rs
@@ -1,0 +1,971 @@
+//! Frequency-domain filter operations ported from libvips `freqfilt`.
+//!
+//! This module carries the FFT family: the forward and inverse discrete
+//! Fourier transforms plus the three compound operations libvips builds
+//! on them. Every operation is a faithful port of the corresponding
+//! libvips C source (`libvips/freqfilt/*.c` plus the `cross_phase` macro
+//! in `libvips/arithmetic/complex.c`), swapping FFTW for the pure-Rust
+//! `rustfft` planner.
+//!
+//! | libviprs | libvips | notes |
+//! |---|---|---|
+//! | [`Raster::fwfft`] | `vips_fwfft` | forward transform, scaled `1/(w*h)` |
+//! | [`Raster::invfft`] | `vips_invfft` | inverse transform, unscaled, complex output |
+//! | [`Raster::invfft_real`] | `vips_invfft` with `real: TRUE` | inverse transform, real output |
+//! | [`Raster::freqmult`] | `vips_freqmult` | multiply in frequency space |
+//! | [`Raster::spectrum`] | `vips_spectrum` | displayable log-scaled power spectrum |
+//! | [`Raster::phasecor`] | `vips_phasecor` | phase correlation of two images |
+//!
+//! # Conventions
+//!
+//! * **Complex images.** libvips has native complex band formats;
+//!   libviprs does not. Following the convention established by
+//!   [`crate::arithmetic`]'s complex family, a complex image here is a
+//!   float raster with an even band count holding `(re, im)` pairs. To
+//!   distinguish a Fourier-domain image from an ordinary even-band float
+//!   image (libvips branches on `vips_band_format_iscomplex`), the
+//!   compound operations treat an input as already-complex only when it
+//!   has an even band count *and* is stamped
+//!   [`Interpretation::Fourier`], which is exactly what [`Raster::fwfft`]
+//!   produces. Any other input takes the real path, mirroring the
+//!   band-splitting `vips__fftproc` driver: each band is transformed as
+//!   an independent real (or, for `invfft`, zero-imaginary) signal.
+//! * **Normalisation.** `fwfft` divides by `w*h` (libvips `fwfft.c`
+//!   divides every output sample by `VIPS_IMAGE_N_PELS`); `invfft` is
+//!   unnormalised (libvips `invfft.c` runs FFTW backward with no scale).
+//!   `invfft(fwfft(x))` therefore round-trips to `x`.
+//! * **Layout.** `fwfft` output is in FFT layout with the DC component at
+//!   the origin `(0, 0)`; libvips does not re-centre it. [`Raster::spectrum`]
+//!   is the displayable form: it applies the log-scale map and then
+//!   [`Raster::wrap`] to move DC to the centre.
+//! * **`invfft_real`.** libvips `rinvfft1` feeds only the left
+//!   `w/2 + 1` columns to FFTW's complex-to-real transform, which
+//!   reconstructs the rest by Hermitian symmetry. This port does the
+//!   same: the right half of the input spectrum is ignored and rebuilt
+//!   as the conjugate mirror of the left half, so results match libvips
+//!   even for spectra that are not exactly Hermitian.
+//! * **Precision.** Transforms run in `f64` and results are stored in
+//!   [`PixelFormat::FloatF32`] rasters (libvips stores `dpcomplex` /
+//!   `double`; libviprs carries float rasters as `f32`, the same
+//!   depth trade documented by [`crate::create`] for its generators).
+//! * **Sizes.** `rustfft`'s mixed-radix planner (Bluestein for large
+//!   primes) handles any width and height, matching FFTW; images do not
+//!   need power-of-two dimensions.
+
+use rustfft::FftPlanner;
+use rustfft::num_complex::Complex;
+
+use thiserror::Error;
+
+use crate::conversion::{ConversionError, Interpretation};
+use crate::pixel::PixelFormat;
+use crate::raster::{Raster, RasterError};
+
+/// The `vips_scale` log-mode exponent (its libvips default), shared
+/// with [`Raster::scaleimage`].
+const SCALE_LOG_EXP: f64 = 0.25;
+
+/// Typed errors for the frequency-domain operations in
+/// [`crate::freqfilt`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum FreqfiltError {
+    /// Two rasters that must share pixel dimensions do not.
+    #[error("{op}: dimension mismatch: {expected_w}x{expected_h} vs {got_w}x{got_h}")]
+    DimensionMismatch {
+        /// The operation that failed.
+        op: &'static str,
+        /// Width of the first image.
+        expected_w: u32,
+        /// Height of the first image.
+        expected_h: u32,
+        /// Width of the second image.
+        got_w: u32,
+        /// Height of the second image.
+        got_h: u32,
+    },
+    /// The mask or second image's band count is incompatible: it must
+    /// match the image's complex pair count, or be a single band (a
+    /// single pair for a complex mask) to broadcast.
+    #[error("{op}: band count mismatch: image has {image_pairs} complex pair(s), got {got}")]
+    BandMismatch {
+        /// The operation that failed.
+        op: &'static str,
+        /// Complex pair count of the transformed image.
+        image_pairs: usize,
+        /// Band (or pair) count of the incompatible input.
+        got: usize,
+    },
+    /// The output band count would exceed the [`PixelFormat`] limit of
+    /// `u16::MAX` bands.
+    #[error("{op}: output band count {bands} exceeds the format limit")]
+    TooManyBands {
+        /// The operation that failed.
+        op: &'static str,
+        /// The band count that does not fit.
+        bands: usize,
+    },
+    /// An underlying raster allocation failed.
+    #[error(transparent)]
+    Raster(#[from] RasterError),
+    /// A conversion step (`cast` in `freqmult`, `wrap` in `spectrum`)
+    /// failed.
+    #[error(transparent)]
+    Conversion(#[from] ConversionError),
+}
+
+/// Panic with the standard message shape for the panicking wrappers.
+#[track_caller]
+fn expect_freq<T>(op: &str, r: Result<T, FreqfiltError>) -> T {
+    match r {
+        Ok(v) => v,
+        Err(e) => panic!("{op}: {e}"),
+    }
+}
+
+/// Whether this raster is a Fourier-domain complex image: an even band
+/// count of `(re, im)` pairs stamped [`Interpretation::Fourier`]. This is
+/// the libviprs analogue of libvips' `vips_band_format_iscomplex` branch
+/// (see the module docs).
+fn is_fourier_complex(r: &Raster) -> bool {
+    r.format().channels() % 2 == 0 && r.interpretation() == Interpretation::Fourier
+}
+
+/// Read every sample as `f64` in raster order (row-major, bands
+/// interleaved), whatever the depth.
+fn samples_f64(r: &Raster) -> Vec<f64> {
+    let fmt = r.format();
+    let bpc = fmt.bytes_per_channel();
+    let data = r.data();
+    let n = r.width() as usize * r.height() as usize * fmt.channels();
+    (0..n)
+        .map(|i| match bpc {
+            1 => f64::from(data[i]),
+            2 => f64::from(u16::from_ne_bytes([data[i * 2], data[i * 2 + 1]])),
+            _ => f64::from(f32::from_ne_bytes([
+                data[i * 4],
+                data[i * 4 + 1],
+                data[i * 4 + 2],
+                data[i * 4 + 3],
+            ])),
+        })
+        .collect()
+}
+
+/// The canonical float format for `bands` bands, or `TooManyBands`.
+fn float_format(op: &'static str, bands: usize) -> Result<PixelFormat, FreqfiltError> {
+    PixelFormat::with_channels(bands, 4).ok_or(FreqfiltError::TooManyBands { op, bands })
+}
+
+/// Build a float raster from `f64` samples in raster order.
+fn float_raster(
+    width: u32,
+    height: u32,
+    format: PixelFormat,
+    samples: &[f64],
+) -> Result<Raster, FreqfiltError> {
+    let mut data = Vec::with_capacity(samples.len() * 4);
+    for &v in samples {
+        data.extend_from_slice(&(v as f32).to_ne_bytes());
+    }
+    Ok(Raster::new(width, height, format, data)?)
+}
+
+/// In-place 2D DFT over `buf` (row-major, `h` rows of `w`): row
+/// transforms then column transforms, both unnormalised, forward
+/// (`e^-i`) or inverse (`e^+i`) like FFTW's `FFTW_FORWARD` /
+/// `FFTW_BACKWARD`. Callers apply the libvips `fwfft` `1/(w*h)` scale
+/// themselves.
+fn fft_2d(buf: &mut [Complex<f64>], w: usize, h: usize, inverse: bool) {
+    let mut planner = FftPlanner::new();
+    let row_fft = if inverse {
+        planner.plan_fft_inverse(w)
+    } else {
+        planner.plan_fft_forward(w)
+    };
+    // `process` splits the buffer into `h` chunks of length `w` and
+    // transforms each: all rows in one call.
+    row_fft.process(buf);
+
+    let col_fft = if inverse {
+        planner.plan_fft_inverse(h)
+    } else {
+        planner.plan_fft_forward(h)
+    };
+    let mut col = vec![Complex::new(0.0, 0.0); h];
+    for x in 0..w {
+        for (y, c) in col.iter_mut().enumerate() {
+            *c = buf[y * w + x];
+        }
+        col_fft.process(&mut col);
+        for (y, c) in col.iter().enumerate() {
+            buf[y * w + x] = *c;
+        }
+    }
+}
+
+/// The complex pairs of one Fourier-domain band pair `p` of `r`, or one
+/// real band `p` (imaginary parts zero) when `complex_input` is false.
+fn load_plane(samples: &[f64], bands: usize, p: usize, complex_input: bool) -> Vec<Complex<f64>> {
+    let pixels = samples.len() / bands;
+    (0..pixels)
+        .map(|i| {
+            if complex_input {
+                Complex::new(samples[i * bands + 2 * p], samples[i * bands + 2 * p + 1])
+            } else {
+                Complex::new(samples[i * bands + p], 0.0)
+            }
+        })
+        .collect()
+}
+
+/// Rebuild the full spectrum FFTW's complex-to-real path implies: keep
+/// the left `w/2 + 1` columns and replace the right half with the
+/// conjugate mirror `F[y][x] = conj(F[(h - y) % h][w - x])`, exactly the
+/// half-complex slice libvips `rinvfft1` feeds to `fftw_plan_dft_c2r_2d`.
+fn hermitian_from_left_half(buf: &mut [Complex<f64>], w: usize, h: usize) {
+    let half_w = w / 2 + 1;
+    for y in 0..h {
+        for x in half_w..w {
+            let src_y = (h - y) % h;
+            let src_x = w - x;
+            buf[y * w + x] = buf[src_y * w + src_x].conj();
+        }
+    }
+}
+
+impl Raster {
+    // -----------------------------------------------------------------
+    // Forward transform
+    // -----------------------------------------------------------------
+
+    /// Fallible form of [`Raster::fwfft`].
+    ///
+    /// # Errors
+    ///
+    /// [`FreqfiltError::TooManyBands`] if doubling the band count
+    /// overflows the format limit, or [`FreqfiltError::Raster`] on
+    /// allocation failure.
+    pub fn try_fwfft(&self) -> Result<Raster, FreqfiltError> {
+        let (w, h) = (self.width() as usize, self.height() as usize);
+        let bands = self.format().channels();
+        let samples = samples_f64(self);
+        let scale = 1.0 / (w as f64 * h as f64);
+
+        let complex_input = is_fourier_complex(self);
+        let (planes, out_bands) = if complex_input {
+            (bands / 2, bands)
+        } else {
+            (bands, bands * 2)
+        };
+        let format = float_format("fwfft", out_bands)?;
+
+        let mut out = vec![0.0f64; w * h * out_bands];
+        for p in 0..planes {
+            let mut buf = load_plane(&samples, bands, p, complex_input);
+            fft_2d(&mut buf, w, h, false);
+            for (i, c) in buf.iter().enumerate() {
+                out[i * out_bands + 2 * p] = c.re * scale;
+                out[i * out_bands + 2 * p + 1] = c.im * scale;
+            }
+        }
+
+        let mut raster = float_raster(self.width(), self.height(), format, &out)?;
+        raster.meta = self.meta;
+        raster.meta.interpretation = Some(Interpretation::Fourier);
+        Ok(raster)
+    }
+
+    /// Transform to Fourier space (libvips `vips_fwfft`): an
+    /// unnormalised forward 2D DFT scaled by `1/(w*h)`, with the DC
+    /// component at the origin. Each real band becomes a `(re, im)`
+    /// float pair (libvips band-splits through `vips__fftproc`); a
+    /// Fourier-domain complex input (see the module docs) is transformed
+    /// pair-wise instead. The output is stamped
+    /// [`Interpretation::Fourier`]. Panicking form of
+    /// [`Raster::try_fwfft`], matching the ported-test call surface.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`FreqfiltError`]; see [`Raster::try_fwfft`].
+    #[track_caller]
+    pub fn fwfft(&self) -> Raster {
+        expect_freq("fwfft", self.try_fwfft())
+    }
+
+    // -----------------------------------------------------------------
+    // Inverse transform
+    // -----------------------------------------------------------------
+
+    /// Fallible form of [`Raster::invfft`].
+    ///
+    /// # Errors
+    ///
+    /// [`FreqfiltError::TooManyBands`] if doubling a real input's band
+    /// count overflows the format limit, or [`FreqfiltError::Raster`] on
+    /// allocation failure.
+    pub fn try_invfft(&self) -> Result<Raster, FreqfiltError> {
+        let (w, h) = (self.width() as usize, self.height() as usize);
+        let bands = self.format().channels();
+        let samples = samples_f64(self);
+
+        // libvips `cinvfft1` casts any input to complex first: a real
+        // band becomes a zero-imaginary pair, mirroring `vips_cast` to
+        // `dpcomplex`.
+        let complex_input = is_fourier_complex(self);
+        let (planes, out_bands) = if complex_input {
+            (bands / 2, bands)
+        } else {
+            (bands, bands * 2)
+        };
+        let format = float_format("invfft", out_bands)?;
+
+        let mut out = vec![0.0f64; w * h * out_bands];
+        for p in 0..planes {
+            let mut buf = load_plane(&samples, bands, p, complex_input);
+            fft_2d(&mut buf, w, h, true);
+            for (i, c) in buf.iter().enumerate() {
+                out[i * out_bands + 2 * p] = c.re;
+                out[i * out_bands + 2 * p + 1] = c.im;
+            }
+        }
+
+        let mut raster = float_raster(self.width(), self.height(), format, &out)?;
+        raster.meta = self.meta;
+        // Back in the spatial domain: drop the Fourier stamp (libvips
+        // `invfft.c` retags the output B_W).
+        raster.meta.interpretation = None;
+        Ok(raster)
+    }
+
+    /// Transform from Fourier space (libvips `vips_invfft` with the
+    /// default `real: FALSE`): an unnormalised inverse 2D DFT, so
+    /// `invfft(fwfft(x))` round-trips. The output is complex, one
+    /// `(re, im)` float pair per input pair; a non-Fourier input is cast
+    /// to complex first (each band gains a zero imaginary half), like
+    /// libvips. Panicking form of [`Raster::try_invfft`].
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`FreqfiltError`]; see [`Raster::try_invfft`].
+    #[track_caller]
+    pub fn invfft(&self) -> Raster {
+        expect_freq("invfft", self.try_invfft())
+    }
+
+    /// Fallible form of [`Raster::invfft_real`].
+    ///
+    /// # Errors
+    ///
+    /// [`FreqfiltError::Raster`] on allocation failure.
+    pub fn try_invfft_real(&self) -> Result<Raster, FreqfiltError> {
+        let (w, h) = (self.width() as usize, self.height() as usize);
+        let bands = self.format().channels();
+        let samples = samples_f64(self);
+
+        let complex_input = is_fourier_complex(self);
+        let planes = if complex_input { bands / 2 } else { bands };
+        let format = float_format("invfft", planes)?;
+
+        let mut out = vec![0.0f64; w * h * planes];
+        for p in 0..planes {
+            let mut buf = load_plane(&samples, bands, p, complex_input);
+            // libvips `rinvfft1` hands FFTW only the left half of the
+            // spectrum; mirror that before the full inverse transform.
+            hermitian_from_left_half(&mut buf, w, h);
+            fft_2d(&mut buf, w, h, true);
+            for (i, c) in buf.iter().enumerate() {
+                out[i * planes + p] = c.re;
+            }
+        }
+
+        let mut raster = float_raster(self.width(), self.height(), format, &out)?;
+        raster.meta = self.meta;
+        raster.meta.interpretation = None;
+        Ok(raster)
+    }
+
+    /// Transform from Fourier space to a real image (libvips
+    /// `vips_invfft` with `real: TRUE`): an unnormalised inverse 2D DFT
+    /// keeping the real component, one float band per input pair. Like
+    /// libvips' complex-to-real FFTW path, only the left `w/2 + 1`
+    /// columns of the spectrum are read; the rest is reconstructed by
+    /// Hermitian symmetry. Panicking form of [`Raster::try_invfft_real`].
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`FreqfiltError`]; see [`Raster::try_invfft_real`].
+    #[track_caller]
+    pub fn invfft_real(&self) -> Raster {
+        expect_freq("invfft_real", self.try_invfft_real())
+    }
+
+    // -----------------------------------------------------------------
+    // Compound operations
+    // -----------------------------------------------------------------
+
+    /// Fallible form of [`Raster::freqmult`].
+    ///
+    /// # Errors
+    ///
+    /// [`FreqfiltError::DimensionMismatch`] if `mask` is not the same
+    /// size as the image, [`FreqfiltError::BandMismatch`] if the mask's
+    /// band count neither matches the image's complex pair count nor is
+    /// broadcastable from one band, or [`FreqfiltError::Raster`] /
+    /// [`FreqfiltError::Conversion`] on allocation or cast failure.
+    pub fn try_freqmult(&self, mask: &Raster) -> Result<Raster, FreqfiltError> {
+        if self.width() != mask.width() || self.height() != mask.height() {
+            return Err(FreqfiltError::DimensionMismatch {
+                op: "freqmult",
+                expected_w: self.width(),
+                expected_h: self.height(),
+                got_w: mask.width(),
+                got_h: mask.height(),
+            });
+        }
+
+        // libvips `freqmult.c`: a complex input skips the forward
+        // transform; a real input is transformed, multiplied, inverted,
+        // and cast back to its original format.
+        if is_fourier_complex(self) {
+            let product = fourier_multiply("freqmult", self, mask)?;
+            product.try_invfft_real()
+        } else {
+            let fourier = self.try_fwfft()?;
+            let product = fourier_multiply("freqmult", &fourier, mask)?;
+            let real = product.try_invfft_real()?;
+            Ok(real.try_cast(
+                PixelFormat::with_channels(
+                    self.format().channels(),
+                    self.format().bytes_per_channel(),
+                )
+                .expect("input format is valid, so its channel/depth pair is too"),
+            )?)
+        }
+    }
+
+    /// Multiply the image by `mask` in Fourier space (libvips
+    /// `vips_freqmult`): transform forward if not already
+    /// Fourier-domain, multiply by the mask (a real mask, such as the
+    /// [`Raster::mask_ideal`] family, scales both halves of each pair; a
+    /// Fourier-domain complex mask multiplies pair-wise), transform back
+    /// keeping the real component, and cast a real input back to its
+    /// original format. Panicking form of [`Raster::try_freqmult`],
+    /// matching the ported-test call surface.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`FreqfiltError`]; see [`Raster::try_freqmult`].
+    #[track_caller]
+    pub fn freqmult(&self, mask: &Raster) -> Raster {
+        expect_freq("freqmult", self.try_freqmult(mask))
+    }
+
+    /// Fallible form of [`Raster::spectrum`].
+    ///
+    /// # Errors
+    ///
+    /// [`FreqfiltError::TooManyBands`], [`FreqfiltError::Raster`], or
+    /// [`FreqfiltError::Conversion`]; see [`Raster::try_fwfft`].
+    pub fn try_spectrum(&self) -> Result<Raster, FreqfiltError> {
+        // libvips `spectrum.c`: fwfft unless complex, then
+        // abs -> scale log -> wrap.
+        let fourier = if is_fourier_complex(self) {
+            self.clone()
+        } else {
+            self.try_fwfft()?
+        };
+
+        let (w, h) = (fourier.width() as usize, fourier.height() as usize);
+        let bands = fourier.format().channels();
+        let pairs = bands / 2;
+        let samples = samples_f64(&fourier);
+
+        // Complex magnitude, one band per pair (`vips_abs` on a complex
+        // image).
+        let mut mag = vec![0.0f64; w * h * pairs];
+        for i in 0..w * h {
+            for p in 0..pairs {
+                let re = samples[i * bands + 2 * p];
+                let im = samples[i * bands + 2 * p + 1];
+                mag[i * pairs + p] = re.hypot(im);
+            }
+        }
+
+        // `vips_scale` in log mode: the same curve as
+        // [`Raster::scaleimage`] with `log = Some(true)`
+        // (`255 / log10(1 + max^0.25) * log10(1 + v^0.25)`), applied
+        // here directly because the magnitudes are float and the
+        // integer-raster `scaleimage` path does not accept float input.
+        // Rounding matches the arithmetic module's uchar write: round to
+        // nearest, clamp, NaN to zero.
+        let mx = mag.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let denom = (1.0 + mx.powf(SCALE_LOG_EXP)).log10();
+        let f = if denom > 0.0 { 255.0 / denom } else { 0.0 };
+        let format = PixelFormat::with_channels(pairs, 1).ok_or(FreqfiltError::TooManyBands {
+            op: "spectrum",
+            bands: pairs,
+        })?;
+        let data: Vec<u8> = mag
+            .iter()
+            .map(|&v| {
+                let scaled = f * (1.0 + v.powf(SCALE_LOG_EXP)).log10();
+                if scaled.is_nan() {
+                    0
+                } else {
+                    scaled.round().clamp(0.0, 255.0) as u8
+                }
+            })
+            .collect();
+        let scaled = Raster::new(fourier.width(), fourier.height(), format, data)?;
+
+        // `vips_wrap` moves DC to the centre.
+        Ok(scaled.try_wrap()?)
+    }
+
+    /// Make a displayable power spectrum (libvips `vips_spectrum`): the
+    /// image is transformed to Fourier space if it is not already, the
+    /// complex magnitude is log-scaled to 8-bit through
+    /// [`Raster::scaleimage`], and the quadrants are swapped with
+    /// [`Raster::wrap`] so the DC component sits at the centre.
+    /// Panicking form of [`Raster::try_spectrum`].
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`FreqfiltError`]; see [`Raster::try_spectrum`].
+    #[track_caller]
+    pub fn spectrum(&self) -> Raster {
+        expect_freq("spectrum", self.try_spectrum())
+    }
+
+    /// Fallible form of [`Raster::phasecor`].
+    ///
+    /// # Errors
+    ///
+    /// [`FreqfiltError::DimensionMismatch`] if the images differ in
+    /// size, [`FreqfiltError::BandMismatch`] if their complex pair
+    /// counts differ, or [`FreqfiltError::TooManyBands`] /
+    /// [`FreqfiltError::Raster`] from the transforms.
+    pub fn try_phasecor(&self, other: &Raster) -> Result<Raster, FreqfiltError> {
+        if self.width() != other.width() || self.height() != other.height() {
+            return Err(FreqfiltError::DimensionMismatch {
+                op: "phasecor",
+                expected_w: self.width(),
+                expected_h: self.height(),
+                got_w: other.width(),
+                got_h: other.height(),
+            });
+        }
+
+        // libvips `phasecor.c`: fwfft either input unless complex.
+        let a = if is_fourier_complex(self) {
+            self.clone()
+        } else {
+            self.try_fwfft()?
+        };
+        let b = if is_fourier_complex(other) {
+            other.clone()
+        } else {
+            other.try_fwfft()?
+        };
+
+        let bands = a.format().channels();
+        let pairs = bands / 2;
+        if b.format().channels() / 2 != pairs {
+            return Err(FreqfiltError::BandMismatch {
+                op: "phasecor",
+                image_pairs: pairs,
+                got: b.format().channels() / 2,
+            });
+        }
+
+        let (w, h) = (a.width(), a.height());
+        let sa = samples_f64(&a);
+        let sb = samples_f64(&b);
+
+        // `vips_cross_phase`, ported exactly from the CROSS macro in
+        // libvips `arithmetic/complex.c`.
+        let mut cross = vec![0.0f64; sa.len()];
+        for i in 0..sa.len() / 2 {
+            let (re, im) = cross_phase(sa[2 * i], sa[2 * i + 1], sb[2 * i], sb[2 * i + 1]);
+            cross[2 * i] = re;
+            cross[2 * i + 1] = im;
+        }
+        let mut cross = float_raster(w, h, float_format("phasecor", bands)?, &cross)?;
+        cross.meta.interpretation = Some(Interpretation::Fourier);
+
+        cross.try_invfft_real()
+    }
+
+    /// Phase correlation of two images (libvips `vips_phasecor`): both
+    /// are transformed to Fourier space if not already, the phase of
+    /// their cross power spectrum is taken, and the result is
+    /// transformed back keeping the real component. The peak of the
+    /// output sits at the translation relating the two images.
+    /// Panicking form of [`Raster::try_phasecor`].
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`FreqfiltError`]; see [`Raster::try_phasecor`].
+    #[track_caller]
+    pub fn phasecor(&self, other: &Raster) -> Raster {
+        expect_freq("phasecor", self.try_phasecor(other))
+    }
+}
+
+/// Multiply a Fourier-domain complex image by a mask, pair-wise
+/// (libvips reaches this through `vips_multiply`, which handles the
+/// complex/real and band-broadcast cases). A real mask scales both
+/// halves of every pair; a Fourier-domain complex mask (even bands plus
+/// the Fourier stamp) multiplies complex-wise. A one-band (or one-pair)
+/// mask broadcasts across pairs.
+fn fourier_multiply(
+    op: &'static str,
+    fourier: &Raster,
+    mask: &Raster,
+) -> Result<Raster, FreqfiltError> {
+    let (w, h) = (fourier.width() as usize, fourier.height() as usize);
+    let bands = fourier.format().channels();
+    let pairs = bands / 2;
+    let samples = samples_f64(fourier);
+    let mask_samples = samples_f64(mask);
+    let mask_bands = mask.format().channels();
+    let mask_complex = is_fourier_complex(mask);
+    let mask_planes = if mask_complex {
+        mask_bands / 2
+    } else {
+        mask_bands
+    };
+    if mask_planes != pairs && mask_planes != 1 {
+        return Err(FreqfiltError::BandMismatch {
+            op,
+            image_pairs: pairs,
+            got: mask_planes,
+        });
+    }
+
+    let mut out = vec![0.0f64; samples.len()];
+    for i in 0..w * h {
+        for p in 0..pairs {
+            let mp = if mask_planes == 1 { 0 } else { p };
+            let re = samples[i * bands + 2 * p];
+            let im = samples[i * bands + 2 * p + 1];
+            let (ore, oim) = if mask_complex {
+                let mre = mask_samples[i * mask_bands + 2 * mp];
+                let mim = mask_samples[i * mask_bands + 2 * mp + 1];
+                (re * mre - im * mim, re * mim + im * mre)
+            } else {
+                let m = mask_samples[i * mask_bands + mp];
+                (re * m, im * m)
+            };
+            out[i * bands + 2 * p] = ore;
+            out[i * bands + 2 * p + 1] = oim;
+        }
+    }
+
+    let format = float_format(op, bands)?;
+    let mut raster = float_raster(fourier.width(), fourier.height(), format, &out)?;
+    raster.meta = fourier.meta;
+    raster.meta.interpretation = Some(Interpretation::Fourier);
+    Ok(raster)
+}
+
+/// One sample of `vips_cross_phase`: the phase of the cross power
+/// spectrum of `(x1, y1)` and `(x2, y2)`, normalised to unit modulus.
+/// Ported branch-for-branch from the CROSS macro in libvips
+/// `arithmetic/complex.c`, including its zero cases (either input zero,
+/// or both imaginary halves zero, give `(0, 0)`).
+fn cross_phase(x1: f64, y1: f64, x2: f64, y2: f64) -> (f64, f64) {
+    if (x1 == 0.0 && y1 == 0.0) || (x2 == 0.0 && y2 == 0.0) || (y1 == 0.0 && y2 == 0.0) {
+        (0.0, 0.0)
+    } else if y1.abs() > y2.abs() {
+        let a = y2 / y1;
+        let b = y1 + y2 * a;
+        let re = (x1 + x2 * a) / b;
+        let im = (x2 - x1 * a) / b;
+        let modulus = re.hypot(im);
+        (re / modulus, im / modulus)
+    } else {
+        let a = y1 / y2;
+        let b = y2 + y1 * a;
+        let re = (x1 * a + x2) / b;
+        let im = (x2 * a - x1) / b;
+        let modulus = re.hypot(im);
+        (re / modulus, im / modulus)
+    }
+}
+
+/// A deterministic single-band float test image with no symmetry, so
+/// spectra exercise every bin.
+#[cfg(test)]
+fn test_image(width: u32, height: u32) -> Raster {
+    let n = width as usize * height as usize;
+    let samples: Vec<f64> = (0..n)
+        .map(|i| (i as f64 * 0.7).sin() * 100.0 + (i as f64 * 0.13).cos() * 40.0)
+        .collect();
+    float_raster(
+        width,
+        height,
+        PixelFormat::with_channels(1, 4).expect("one float band"),
+        &samples,
+    )
+    .expect("test image allocates")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// fwfft of a constant image puts all energy in the DC bin at the
+    /// origin (libvips does not re-centre), scaled by `1/(w*h)` so the
+    /// DC value equals the constant.
+    #[test]
+    fn fwfft_constant_is_dc_only() {
+        let im = Raster::new(8, 4, PixelFormat::Gray8, vec![200u8; 8 * 4]).expect("raster");
+        let f = im.fwfft();
+        assert_eq!(f.width(), 8);
+        assert_eq!(f.height(), 4);
+        assert_eq!(f.format().channels(), 2);
+        assert_eq!(f.interpretation(), Interpretation::Fourier);
+        let dc = f.getpoint(0, 0);
+        assert!((dc[0] - 200.0).abs() < 1e-3, "DC re = {}", dc[0]);
+        assert!(dc[1].abs() < 1e-3, "DC im = {}", dc[1]);
+        for y in 0..4 {
+            for x in 0..8 {
+                if x == 0 && y == 0 {
+                    continue;
+                }
+                let p = f.getpoint(x, y);
+                assert!(
+                    p[0].abs() < 1e-3 && p[1].abs() < 1e-3,
+                    "bin ({x},{y}) = {p:?}"
+                );
+            }
+        }
+    }
+
+    /// The ported `test_fwfft_small_image` body: a 2x1 black image
+    /// transforms without panicking.
+    #[test]
+    fn fwfft_small_image() {
+        let im = Raster::black(2, 1);
+        let fft = im.fwfft();
+        assert_eq!(fft.width(), 2);
+        assert_eq!(fft.height(), 1);
+        assert_eq!(fft.format().channels(), 2);
+    }
+
+    /// invfft(fwfft(x)) round-trips a non-power-of-two image: the real
+    /// half matches the input and the imaginary half is zero. The real
+    /// output variant matches too.
+    #[test]
+    fn fwfft_invfft_round_trip() {
+        let im = test_image(5, 3);
+        let expected = samples_f64(&im);
+
+        let complex = im.fwfft().invfft();
+        assert_eq!(complex.format().channels(), 2);
+        let got = samples_f64(&complex);
+        for (i, &e) in expected.iter().enumerate() {
+            assert!(
+                (got[2 * i] - e).abs() < 1e-3,
+                "re[{i}]: {} vs {e}",
+                got[2 * i]
+            );
+            assert!(got[2 * i + 1].abs() < 1e-3, "im[{i}]: {}", got[2 * i + 1]);
+        }
+
+        let real = im.fwfft().invfft_real();
+        assert_eq!(real.format().channels(), 1);
+        let got = samples_f64(&real);
+        for (i, &e) in expected.iter().enumerate() {
+            assert!((got[i] - e).abs() < 1e-3, "[{i}]: {} vs {e}", got[i]);
+        }
+    }
+
+    /// fwfft of an n-band image transforms each band independently
+    /// (libvips `vips__fftproc`): the pairs equal the per-band
+    /// transforms.
+    #[test]
+    fn fwfft_multiband_matches_per_band() {
+        // A 2-band float image assembled from two different planes.
+        let a = test_image(4, 4);
+        let b = Raster::new(4, 4, PixelFormat::Gray8, (0..16u8).map(|v| v * 3).collect())
+            .expect("raster");
+        let sa = samples_f64(&a);
+        let sb = samples_f64(&b);
+        let joined: Vec<f64> = (0..16).flat_map(|i| [sa[i], sb[i]]).collect();
+        let im = float_raster(
+            4,
+            4,
+            PixelFormat::with_channels(2, 4).expect("two float bands"),
+            &joined,
+        )
+        .expect("raster");
+
+        let f = im.fwfft();
+        assert_eq!(f.format().channels(), 4);
+        let fa = samples_f64(&a.fwfft());
+        let fb = samples_f64(&b.fwfft());
+        let fj = samples_f64(&f);
+        for i in 0..16 {
+            assert!((fj[4 * i] - fa[2 * i]).abs() < 1e-6);
+            assert!((fj[4 * i + 1] - fa[2 * i + 1]).abs() < 1e-6);
+            assert!((fj[4 * i + 2] - fb[2 * i]).abs() < 1e-6);
+            assert!((fj[4 * i + 3] - fb[2 * i + 1]).abs() < 1e-6);
+        }
+    }
+
+    /// fwfft of a Fourier-domain image takes the complex path: for a
+    /// delta at `x = 1` in a 4x1 image, `fwfft(fwfft(x))` is the
+    /// index-reversed input scaled by `1/(w*h)`, i.e. a `0.25` delta at
+    /// `x = 3`.
+    #[test]
+    fn fwfft_complex_input_double_transform() {
+        let im = float_raster(
+            4,
+            1,
+            PixelFormat::with_channels(1, 4).expect("one float band"),
+            &[0.0, 1.0, 0.0, 0.0],
+        )
+        .expect("raster");
+        let ff = im.fwfft().fwfft();
+        assert_eq!(ff.format().channels(), 2);
+        let got = samples_f64(&ff);
+        let expected = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.25, 0.0];
+        for (i, &e) in expected.iter().enumerate() {
+            assert!((got[i] - e).abs() < 1e-9, "[{i}]: {} vs {e}", got[i]);
+        }
+    }
+
+    /// freqmult by an all-ones mask is the identity, and the output is
+    /// cast back to the input format (libvips `freqmult.c` casts to
+    /// `in->BandFmt`).
+    #[test]
+    fn freqmult_ones_mask_is_identity() {
+        let data: Vec<u8> = (0..24u8).map(|v| v.wrapping_mul(11)).collect();
+        let im = Raster::new(6, 4, PixelFormat::Gray8, data.clone()).expect("raster");
+        let mask = float_raster(
+            6,
+            4,
+            PixelFormat::with_channels(1, 4).expect("one float band"),
+            &[1.0; 24],
+        )
+        .expect("mask");
+        let out = im.freqmult(&mask);
+        assert_eq!(out.format(), PixelFormat::Gray8);
+        assert_eq!(out.data(), im.data());
+    }
+
+    /// freqmult validates geometry and mask bands with typed errors.
+    #[test]
+    fn freqmult_typed_errors() {
+        let im = test_image(4, 4);
+        let small = test_image(2, 2);
+        assert!(matches!(
+            im.try_freqmult(&small),
+            Err(FreqfiltError::DimensionMismatch { op: "freqmult", .. })
+        ));
+
+        let mask3 = float_raster(
+            4,
+            4,
+            PixelFormat::with_channels(3, 4).expect("three float bands"),
+            &[1.0; 48],
+        )
+        .expect("mask");
+        assert!(matches!(
+            im.try_freqmult(&mask3),
+            Err(FreqfiltError::BandMismatch { op: "freqmult", .. })
+        ));
+    }
+
+    /// spectrum is 8-bit, and for a constant image the only non-zero
+    /// bin is DC, re-centred by wrap: the maximum sits at
+    /// `(w/2, h/2)` with value 255.
+    #[test]
+    fn spectrum_constant_peaks_at_centre() {
+        let im = Raster::new(16, 16, PixelFormat::Gray8, vec![37u8; 256]).expect("raster");
+        let s = im.spectrum();
+        assert_eq!(s.format(), PixelFormat::Gray8);
+        let (value, x, y) = s.maxpos();
+        assert_eq!((x, y), (8, 8));
+        assert!((value - 255.0).abs() < f64::EPSILON);
+    }
+
+    /// phasecor of an image with a toroidally shifted copy peaks at the
+    /// shift: with `B(x, y) = A((x+3) % w, (y+2) % h)`, the peak of
+    /// `phasecor(A, B)` is at `(3, 2)` (verified against the libvips
+    /// CROSS macro semantics numerically).
+    #[test]
+    fn phasecor_peaks_at_shift() {
+        let (w, h) = (8u32, 8u32);
+        let a = test_image(w, h);
+        let sa = samples_f64(&a);
+        let (dx, dy) = (3u32, 2u32);
+        let shifted: Vec<f64> = (0..h)
+            .flat_map(|y| {
+                let sa = &sa;
+                (0..w).map(move |x| {
+                    let sx = (x + dx) % w;
+                    let sy = (y + dy) % h;
+                    sa[(sy * w + sx) as usize]
+                })
+            })
+            .collect();
+        let b = float_raster(
+            w,
+            h,
+            PixelFormat::with_channels(1, 4).expect("one float band"),
+            &shifted,
+        )
+        .expect("raster");
+
+        let c = a.phasecor(&b);
+        assert_eq!(c.format().channels(), 1);
+        let (_, x, y) = c.maxpos();
+        assert_eq!((x, y), (dx, dy));
+    }
+
+    /// phasecor validates geometry with a typed error.
+    #[test]
+    fn phasecor_dimension_mismatch() {
+        let a = test_image(4, 4);
+        let b = test_image(5, 4);
+        assert!(matches!(
+            a.try_phasecor(&b),
+            Err(FreqfiltError::DimensionMismatch { op: "phasecor", .. })
+        ));
+    }
+
+    /// The cross-phase zero cases from the libvips CROSS macro: either
+    /// input zero, or both imaginary halves zero, give `(0, 0)`; a unit
+    /// rotation comes back normalised.
+    #[test]
+    fn cross_phase_matches_libvips_macro() {
+        assert_eq!(cross_phase(0.0, 0.0, 1.0, 2.0), (0.0, 0.0));
+        assert_eq!(cross_phase(1.0, 2.0, 0.0, 0.0), (0.0, 0.0));
+        assert_eq!(cross_phase(3.0, 0.0, 4.0, 0.0), (0.0, 0.0));
+        // Same phase in both inputs: the cross phase is purely real.
+        let (re, im) = cross_phase(1.0, 1.0, 2.0, 2.0);
+        assert!((re - 1.0).abs() < 1e-12);
+        assert!(im.abs() < 1e-12);
+        // Unit modulus in the general case.
+        let (re, im) = cross_phase(0.3, -1.7, 2.2, 0.9);
+        assert!((re.hypot(im) - 1.0).abs() < 1e-12);
+    }
+
+    /// invfft on a real (non-Fourier) input casts to complex first,
+    /// like libvips: each band gains a zero imaginary half before the
+    /// unnormalised inverse transform.
+    #[test]
+    fn invfft_real_input_casts_to_complex() {
+        let im = test_image(4, 3);
+        let out = im.invfft();
+        assert_eq!(out.format().channels(), 2);
+        // The DC bin of an unnormalised inverse transform is the sum.
+        let sum: f64 = samples_f64(&im).iter().sum();
+        let dc = out.getpoint(0, 0);
+        assert!((dc[0] - sum).abs() < 0.35, "{} vs {sum}", dc[0]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub mod engine;
 pub mod engine_builder;
 pub mod extensions;
 pub mod extract;
+pub mod freqfilt;
 pub mod geo;
 pub mod histogram;
 pub mod imageio;
@@ -71,6 +72,7 @@ pub(crate) mod level_walk;
 mod loom_tests;
 pub mod manifest;
 pub(crate) mod mapreduce_hot_cache;
+pub mod matrix;
 pub mod morphology;
 pub mod mosaicing;
 pub mod observe;
@@ -118,6 +120,7 @@ pub use engine::{
 };
 pub use engine_builder::{EngineBuilder, EngineKind, EngineSource, IntoEngineSource};
 pub use extract::{CompassDirection, Extend, ExtractError, SmartcropInteresting};
+pub use freqfilt::FreqfiltError;
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};
 pub use histogram::HistogramError;
 // The imageio free functions are re-exported at the root (not just behind
@@ -131,6 +134,7 @@ pub use manifest::{
     ChecksumAlgo, Checksums, GenerationSettings, LevelMetadata, Manifest, ManifestBuilder,
     ManifestError, ManifestV1, SourceMetadata, SparsePolicy,
 };
+pub use matrix::MatrixError;
 pub use morphology::{Direction, MorphologyError};
 pub use mosaicing::{MergeDirection, MosaicError};
 pub use observe::{

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,0 +1,768 @@
+//! Matrix-image and LUT-inversion operations ported from libvips.
+//!
+//! A matrix image is a small one-band image holding dense numeric data,
+//! produced by [`Raster::from_matrix`] and stamped
+//! [`Interpretation::Matrix`]. This module carries the two operations
+//! the ported suite calls on them:
+//!
+//! | libviprs | libvips | notes |
+//! |---|---|---|
+//! | [`Raster::matrixinvert`] | `vips_matrixinvert` | dense inverse of a square matrix image |
+//! | [`Raster::invertlut`] | `vips_invertlut` | inverse LUT from measured `(x, f(x))` rows |
+//!
+//! [`Raster::buildlut`] (the forward companion of `invertlut`) already
+//! lives in [`crate::create`] with the other generators;
+//! `vips_matrixmultiply` is not called by the ported suite and stays
+//! unimplemented.
+//!
+//! # Semantics
+//!
+//! * **`matrixinvert`** is a faithful port of libvips
+//!   `mosaicing/matrixinvert.c`: matrices below 4x4 invert through the
+//!   direct cofactor formulas, larger ones through the Numerical
+//!   Recipes PLU decomposition with implicit (scaled) partial pivoting,
+//!   solving one unit vector per column. A zero row, or a pivot smaller
+//!   than `2 * DBL_MIN`, is a typed [`MatrixError::Singular`] error,
+//!   matching the C thresholds exactly.
+//! * **`invertlut`** is a faithful port of libvips `create/invertlut.c`:
+//!   rows of the input matrix are measured points, column 0 the input
+//!   level and each further column one band's measured response, all in
+//!   `0..=1`. Rows are sorted by column 0; each output band linearly
+//!   interpolates between the bracketing measured rows, extrapolating
+//!   the head to `(0, 0)` and the tail to `(1, 1)`. The output is a
+//!   `size` x 1 image (default 256) with one band per measured column,
+//!   stamped [`Interpretation::Histogram`].
+//! * **Precision.** Both operations compute in `f64` and store results
+//!   in [`PixelFormat::FloatF32`] rasters (libvips stores `double`;
+//!   libviprs carries float data as `f32`, the same trade documented by
+//!   [`crate::create`] for `from_matrix` itself).
+
+use std::num::NonZeroU16;
+
+use thiserror::Error;
+
+use crate::conversion::Interpretation;
+use crate::pixel::PixelFormat;
+use crate::raster::{Raster, RasterError};
+
+/// The `vips_check_matrix` size limit: matrix images wider or taller
+/// than this are rejected.
+const MAX_MATRIX_SIZE: u32 = 100_000;
+
+/// libvips `matrixinvert.c` TOO_SMALL: twice the smallest normalised
+/// double. Pivots below this magnitude count as singular.
+const TOO_SMALL: f64 = 2.0 * f64::MIN_POSITIVE;
+
+/// Typed errors for the matrix operations in [`crate::matrix`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum MatrixError {
+    /// The input is not a matrix image: matrices are one-band.
+    #[error("{op} requires a one-band matrix image, got {bands} bands")]
+    NotOneBand {
+        /// The operation that failed.
+        op: &'static str,
+        /// The offending band count.
+        bands: usize,
+    },
+    /// The input exceeds the libvips `vips_check_matrix` size limit.
+    #[error("{op}: matrix is too large: {width}x{height} (limit {MAX_MATRIX_SIZE})")]
+    TooLarge {
+        /// The operation that failed.
+        op: &'static str,
+        /// Matrix width.
+        width: u32,
+        /// Matrix height.
+        height: u32,
+    },
+    /// `matrixinvert` was given a non-square matrix.
+    #[error("matrixinvert: non-square matrix ({width}x{height})")]
+    NotSquare {
+        /// Matrix width.
+        width: u32,
+        /// Matrix height.
+        height: u32,
+    },
+    /// The matrix is singular or near-singular: a row of zeros, or a
+    /// pivot below the libvips `TOO_SMALL` threshold.
+    #[error("matrixinvert: singular or near-singular matrix")]
+    Singular,
+    /// `invertlut` needs an input column plus at least one measured
+    /// column.
+    #[error("invertlut: bad input matrix: need at least two columns, got {columns}")]
+    TooFewColumns {
+        /// The offending column count.
+        columns: u32,
+    },
+    /// An `invertlut` matrix element is outside `0..=1` (NaN included;
+    /// libvips checks the same range).
+    #[error("invertlut: element ({column}, {row}) is {value}, outside range [0,1]")]
+    OutOfRange {
+        /// Zero-based column of the offending element.
+        column: u32,
+        /// Zero-based row of the offending element.
+        row: u32,
+        /// The offending value.
+        value: f64,
+    },
+    /// The requested `invertlut` LUT size is outside the libvips range
+    /// `1..=65536`.
+    #[error("invertlut: bad size {size} (expected 1..=65536)")]
+    BadSize {
+        /// The offending size.
+        size: u32,
+    },
+    /// An underlying raster allocation failed.
+    #[error(transparent)]
+    Raster(#[from] RasterError),
+}
+
+/// Panic with the standard message shape for the panicking wrappers.
+#[track_caller]
+fn expect_matrix<T>(op: &str, r: Result<T, MatrixError>) -> T {
+    match r {
+        Ok(v) => v,
+        Err(e) => panic!("{op}: {e}"),
+    }
+}
+
+/// The `vips_check_matrix` gate: one band, within the size limit.
+/// Returns the matrix as rows of `f64`.
+fn check_matrix(op: &'static str, r: &Raster) -> Result<Vec<Vec<f64>>, MatrixError> {
+    let bands = r.format().channels();
+    if bands != 1 {
+        return Err(MatrixError::NotOneBand { op, bands });
+    }
+    if r.width() > MAX_MATRIX_SIZE || r.height() > MAX_MATRIX_SIZE {
+        return Err(MatrixError::TooLarge {
+            op,
+            width: r.width(),
+            height: r.height(),
+        });
+    }
+    Ok((0..r.height())
+        .map(|y| (0..r.width()).map(|x| r.getpoint(x, y)[0]).collect())
+        .collect())
+}
+
+/// Build the one-band float matrix image for `rows`, stamped with
+/// `interpretation`.
+fn matrix_raster(
+    rows: &[Vec<f64>],
+    width: u32,
+    height: u32,
+    bands: u16,
+    interpretation: Interpretation,
+) -> Result<Raster, MatrixError> {
+    let mut data = Vec::with_capacity(width as usize * height as usize * bands as usize * 4);
+    for row in rows {
+        for &v in row {
+            data.extend_from_slice(&(v as f32).to_ne_bytes());
+        }
+    }
+    let format = PixelFormat::FloatF32(NonZeroU16::new(bands).expect("bands is non-zero"));
+    let mut out = Raster::new(width, height, format, data)?;
+    out.meta.interpretation = Some(interpretation);
+    Ok(out)
+}
+
+/// The direct cofactor inverses for 1x1, 2x2, and 3x3 matrices, ported
+/// from `vips_matrixinvert_direct`.
+fn invert_direct(m: &[Vec<f64>]) -> Result<Vec<Vec<f64>>, MatrixError> {
+    match m.len() {
+        1 => {
+            let det = m[0][0];
+            if det.abs() < TOO_SMALL {
+                return Err(MatrixError::Singular);
+            }
+            Ok(vec![vec![1.0 / det]])
+        }
+        2 => {
+            let det = m[0][0] * m[1][1] - m[0][1] * m[1][0];
+            if det.abs() < TOO_SMALL {
+                return Err(MatrixError::Singular);
+            }
+            let t = 1.0 / det;
+            Ok(vec![
+                vec![t * m[1][1], -t * m[0][1]],
+                vec![-t * m[1][0], t * m[0][0]],
+            ])
+        }
+        _ => {
+            let det = m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+                - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+                + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+            if det.abs() < TOO_SMALL {
+                return Err(MatrixError::Singular);
+            }
+            let t = 1.0 / det;
+            Ok(vec![
+                vec![
+                    t * (m[1][1] * m[2][2] - m[1][2] * m[2][1]),
+                    t * (m[0][2] * m[2][1] - m[0][1] * m[2][2]),
+                    t * (m[0][1] * m[1][2] - m[0][2] * m[1][1]),
+                ],
+                vec![
+                    t * (m[1][2] * m[2][0] - m[1][0] * m[2][2]),
+                    t * (m[0][0] * m[2][2] - m[0][2] * m[2][0]),
+                    t * (m[0][2] * m[1][0] - m[0][0] * m[1][2]),
+                ],
+                vec![
+                    t * (m[1][0] * m[2][1] - m[1][1] * m[2][0]),
+                    t * (m[0][1] * m[2][0] - m[0][0] * m[2][1]),
+                    t * (m[0][0] * m[1][1] - m[0][1] * m[1][0]),
+                ],
+            ])
+        }
+    }
+}
+
+/// The PLU decomposition from `lu_decomp` (Numerical Recipes `ludcmp`
+/// with implicit pivot scaling): returns the packed LU matrix and the
+/// row permutation, or `Singular`.
+fn lu_decomp(m: &[Vec<f64>]) -> Result<(Vec<Vec<f64>>, Vec<usize>), MatrixError> {
+    let n = m.len();
+    let mut lu: Vec<Vec<f64>> = m.to_vec();
+    let mut perm = vec![0usize; n];
+
+    // Scaling factors: the largest magnitude in each row.
+    let mut row_scale = vec![0.0f64; n];
+    for (i, row) in lu.iter().enumerate() {
+        for &v in row {
+            row_scale[i] = row_scale[i].max(v.abs());
+        }
+        if row_scale[i] == 0.0 {
+            return Err(MatrixError::Singular);
+        }
+        row_scale[i] = 1.0 / row_scale[i];
+    }
+
+    for j in 0..n {
+        // Upper half, except the diagonal.
+        for i in 0..j {
+            for k in 0..i {
+                lu[i][j] -= lu[i][k] * lu[k][j];
+            }
+        }
+
+        // Diagonal and lower half, tracking the best scaled pivot.
+        let mut max = -1.0f64;
+        let mut i_of_max = 0usize;
+        for i in j..n {
+            for k in 0..j {
+                lu[i][j] -= lu[i][k] * lu[k][j];
+            }
+            let abs_val = row_scale[i] * lu[i][j].abs();
+            if abs_val > max {
+                max = abs_val;
+                i_of_max = i;
+            }
+        }
+
+        if lu[i_of_max][j].abs() < TOO_SMALL {
+            return Err(MatrixError::Singular);
+        }
+
+        if i_of_max != j {
+            lu.swap(j, i_of_max);
+            row_scale[i_of_max] = row_scale[j];
+        }
+        perm[j] = i_of_max;
+
+        for i in j + 1..n {
+            lu[i][j] /= lu[j][j];
+        }
+    }
+
+    Ok((lu, perm))
+}
+
+/// Solve `A x = vec` in place given the PLU decomposition, ported from
+/// `lu_solve`.
+fn lu_solve(lu: &[Vec<f64>], perm: &[usize], vec: &mut [f64]) {
+    let n = lu.len();
+    for i in 0..n {
+        let i_perm = perm[i];
+        if i_perm != i {
+            vec.swap(i, i_perm);
+        }
+        for j in 0..i {
+            vec[i] -= lu[i][j] * vec[j];
+        }
+    }
+    for i in (0..n).rev() {
+        for j in i + 1..n {
+            vec[i] -= lu[i][j] * vec[j];
+        }
+        vec[i] /= lu[i][i];
+    }
+}
+
+impl Raster {
+    // -----------------------------------------------------------------
+    // matrixinvert
+    // -----------------------------------------------------------------
+
+    /// Fallible form of [`Raster::matrixinvert`].
+    ///
+    /// # Errors
+    ///
+    /// [`MatrixError::NotOneBand`] / [`MatrixError::TooLarge`] for an
+    /// input `vips_check_matrix` would reject, [`MatrixError::NotSquare`]
+    /// for a non-square matrix, [`MatrixError::Singular`] for a singular
+    /// or near-singular one, or [`MatrixError::Raster`] on allocation
+    /// failure.
+    pub fn try_matrixinvert(&self) -> Result<Raster, MatrixError> {
+        let m = check_matrix("matrixinvert", self)?;
+        if self.width() != self.height() {
+            return Err(MatrixError::NotSquare {
+                width: self.width(),
+                height: self.height(),
+            });
+        }
+        let n = m.len();
+
+        // libvips: direct path below 4x4, PLU above.
+        let inv = if n < 4 {
+            invert_direct(&m)?
+        } else {
+            let (lu, perm) = lu_decomp(&m)?;
+            let mut inv = vec![vec![0.0f64; n]; n];
+            let mut vec_buf = vec![0.0f64; n];
+            for j in 0..n {
+                vec_buf.fill(0.0);
+                vec_buf[j] = 1.0;
+                lu_solve(&lu, &perm, &mut vec_buf);
+                for i in 0..n {
+                    inv[i][j] = vec_buf[i];
+                }
+            }
+            inv
+        };
+
+        matrix_raster(&inv, self.width(), self.height(), 1, Interpretation::Matrix)
+    }
+
+    /// Invert a square matrix image (libvips `vips_matrixinvert`):
+    /// direct cofactor formulas below 4x4, PLU decomposition with
+    /// scaled partial pivoting above. The output is a matrix image the
+    /// same size as the input, stamped [`Interpretation::Matrix`].
+    /// Panicking form of [`Raster::try_matrixinvert`], matching the
+    /// ported-test call surface.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`MatrixError`]; see [`Raster::try_matrixinvert`].
+    #[track_caller]
+    pub fn matrixinvert(&self) -> Raster {
+        expect_matrix("matrixinvert", self.try_matrixinvert())
+    }
+
+    // -----------------------------------------------------------------
+    // invertlut
+    // -----------------------------------------------------------------
+
+    /// Fallible form of [`Raster::invertlut`].
+    ///
+    /// # Errors
+    ///
+    /// See [`Raster::try_invertlut_size`]; the size is the libvips
+    /// default of 256.
+    pub fn try_invertlut(&self) -> Result<Raster, MatrixError> {
+        self.try_invertlut_size(256)
+    }
+
+    /// Build an inverse look-up table (libvips `vips_invertlut` with the
+    /// default `size: 256`): see [`Raster::try_invertlut_size`].
+    /// Panicking form, matching the ported-test call surface.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`MatrixError`]; see [`Raster::try_invertlut_size`].
+    #[track_caller]
+    pub fn invertlut(&self) -> Raster {
+        expect_matrix("invertlut", self.try_invertlut())
+    }
+
+    /// Fallible form of [`Raster::invertlut_size`].
+    ///
+    /// # Errors
+    ///
+    /// [`MatrixError::NotOneBand`] / [`MatrixError::TooLarge`] for an
+    /// input `vips_check_matrix` would reject,
+    /// [`MatrixError::TooFewColumns`] without a measured column,
+    /// [`MatrixError::OutOfRange`] for an element outside `0..=1`,
+    /// [`MatrixError::BadSize`] for a size outside `1..=65536`, or
+    /// [`MatrixError::Raster`] on allocation failure.
+    pub fn try_invertlut_size(&self, size: u32) -> Result<Raster, MatrixError> {
+        let mut data = check_matrix("invertlut", self)?;
+        let width = self.width();
+        let height = data.len();
+        if width < 2 {
+            return Err(MatrixError::TooFewColumns { columns: width });
+        }
+        if !(1..=65536).contains(&size) {
+            return Err(MatrixError::BadSize { size });
+        }
+        let size = size as usize;
+
+        // Range-check every element like `vips_invertlut_build_init`.
+        // The `!(0.0..=1.0).contains(...)` shape also rejects NaN, which
+        // the C comparison chain lets through into undefined territory.
+        for (y, row) in data.iter().enumerate() {
+            for (x, &v) in row.iter().enumerate() {
+                if !(0.0..=1.0).contains(&v) {
+                    return Err(MatrixError::OutOfRange {
+                        column: x as u32,
+                        row: y as u32,
+                        value: v,
+                    });
+                }
+            }
+        }
+
+        // Sort rows by the input column, like the C qsort on column 0.
+        data.sort_by(|a, b| a[0].partial_cmp(&b[0]).expect("range check rejects NaN"));
+
+        let bands = width as usize - 1;
+        let mut buf = vec![0.0f64; size * bands];
+
+        // `vips_invertlut_build_create`, band by band.
+        for b in 0..bands {
+            // The first and last LUT positions with known real values.
+            // C truncates the double to int.
+            let first = (data[0][b + 1] * (size - 1) as f64) as usize;
+            let last = (data[height - 1][b + 1] * (size - 1) as f64) as usize;
+
+            // Extrapolate the head towards (0, 0) ...
+            for k in 0..first {
+                // Divide inside the loop, like the C source, so
+                // first == 0 never divides by zero.
+                let fac = data[0][0] / first as f64;
+                buf[b + k * bands] = k as f64 * fac;
+            }
+
+            // ... and the tail towards (1, 1).
+            for k in last..size {
+                let fac = (1.0 - data[height - 1][0]) / ((size - 1) - last) as f64;
+                buf[b + k * bands] = data[height - 1][0] + (k - last) as f64 * fac;
+            }
+
+            // Interpolate the measured section (inclusive of `last`,
+            // overwriting the tail's first slot, like the C loop).
+            for k in first..=last {
+                let ki = k as f64 / (size - 1) as f64;
+
+                // Search down for the lowest row strictly below ki;
+                // default to row 0 when there is none.
+                let j = (0..height)
+                    .rev()
+                    .find(|&j| data[j][b + 1] < ki)
+                    .unwrap_or(0);
+
+                if height > 1 {
+                    let irange = data[j + 1][b + 1] - data[j][b + 1];
+                    let orange = data[j + 1][0] - data[j][0];
+                    buf[b + k * bands] = data[j][0] + orange * ((ki - data[j][b + 1]) / irange);
+                } else {
+                    buf[b + k * bands] = data[j][0];
+                }
+            }
+        }
+
+        let rows: Vec<Vec<f64>> = vec![buf];
+        let bands_u16 = u16::try_from(bands).map_err(|_| MatrixError::TooLarge {
+            op: "invertlut",
+            width,
+            height: self.height(),
+        })?;
+        matrix_raster(&rows, size as u32, 1, bands_u16, Interpretation::Histogram)
+    }
+
+    /// Build an inverse look-up table with an explicit output size
+    /// (libvips `vips_invertlut` with `size` set). Given a matrix image
+    /// of measured points, column 0 the input level and each further
+    /// column one band's measured response (all in `0..=1`), produce a
+    /// `size` x 1 float image with one band per measured column mapping
+    /// each target level back to the input that produces it: linear
+    /// interpolation between the bracketing rows, extrapolated to
+    /// `(0, 0)` and `(1, 1)` at the ends. Handy for linearising
+    /// printers. The output is stamped [`Interpretation::Histogram`].
+    /// Panicking form of [`Raster::try_invertlut_size`].
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`MatrixError`]; see [`Raster::try_invertlut_size`].
+    #[track_caller]
+    pub fn invertlut_size(&self, size: u32) -> Raster {
+        expect_matrix("invertlut", self.try_invertlut_size(size))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Read a matrix image back as rows of `f64`.
+    fn rows(r: &Raster) -> Vec<Vec<f64>> {
+        (0..r.height())
+            .map(|y| (0..r.width()).map(|x| r.getpoint(x, y)[0]).collect())
+            .collect()
+    }
+
+    /// A 2x2 inverse matches the analytic cofactor inverse (the libvips
+    /// direct path).
+    #[test]
+    fn matrixinvert_2x2_analytic() {
+        let m = Raster::from_matrix(&[vec![1.0, 2.0], vec![3.0, 4.0]]);
+        let inv = m.matrixinvert();
+        assert_eq!(inv.width(), 2);
+        assert_eq!(inv.height(), 2);
+        assert_eq!(inv.interpretation(), Interpretation::Matrix);
+        let got = rows(&inv);
+        let expected = [[-2.0, 1.0], [1.5, -0.5]];
+        for i in 0..2 {
+            for j in 0..2 {
+                assert!((got[i][j] - expected[i][j]).abs() < 1e-6, "({i},{j})");
+            }
+        }
+    }
+
+    /// A 3x3 inverse matches the analytic inverse (the libvips direct
+    /// path).
+    #[test]
+    fn matrixinvert_3x3_analytic() {
+        let m = Raster::from_matrix(&[
+            vec![1.0, 0.0, 1.0],
+            vec![0.0, 2.0, 0.0],
+            vec![0.0, 0.0, 4.0],
+        ]);
+        let inv = m.matrixinvert();
+        let got = rows(&inv);
+        let expected = [[1.0, 0.0, -0.25], [0.0, 0.5, 0.0], [0.0, 0.0, 0.25]];
+        for i in 0..3 {
+            for j in 0..3 {
+                assert!((got[i][j] - expected[i][j]).abs() < 1e-6, "({i},{j})");
+            }
+        }
+    }
+
+    /// The ported 4x4 matrix (the libvips PLU path) matches its full
+    /// analytic inverse, not just the two entries the ported cell
+    /// checks.
+    #[test]
+    fn matrixinvert_4x4_ported_matrix() {
+        let m = Raster::from_matrix(&[
+            vec![4.0, 0.0, 0.0, 0.0],
+            vec![0.0, 0.0, 2.0, 0.0],
+            vec![0.0, 1.0, 2.0, 0.0],
+            vec![1.0, 0.0, 0.0, 1.0],
+        ]);
+        let inv = m.matrixinvert();
+        assert_eq!(inv.width(), 4);
+        assert_eq!(inv.height(), 4);
+        let got = rows(&inv);
+        let expected = [
+            [0.25, 0.0, 0.0, 0.0],
+            [0.0, -1.0, 1.0, 0.0],
+            [0.0, 0.5, 0.0, 0.0],
+            [-0.25, 0.0, 0.0, 1.0],
+        ];
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!(
+                    (got[i][j] - expected[i][j]).abs() < 1e-6,
+                    "({i},{j}): {} vs {}",
+                    got[i][j],
+                    expected[i][j]
+                );
+            }
+        }
+    }
+
+    /// Inverting twice returns the original matrix (PLU path).
+    #[test]
+    fn matrixinvert_round_trip() {
+        let original = [
+            vec![2.0, 1.0, 0.5, 0.0],
+            vec![1.0, 3.0, 0.0, 1.0],
+            vec![0.0, 1.0, 4.0, 2.0],
+            vec![1.0, 0.0, 2.0, 5.0],
+        ];
+        let m = Raster::from_matrix(&original);
+        let back = m.matrixinvert().matrixinvert();
+        let got = rows(&back);
+        for i in 0..4 {
+            for j in 0..4 {
+                assert!((got[i][j] - original[i][j]).abs() < 1e-4, "({i},{j})");
+            }
+        }
+    }
+
+    /// Singular matrices are a typed error on both paths, matching the
+    /// libvips TOO_SMALL threshold.
+    #[test]
+    fn matrixinvert_singular() {
+        // Direct path (2x2, linearly dependent rows).
+        let m = Raster::from_matrix(&[vec![1.0, 2.0], vec![2.0, 4.0]]);
+        assert!(matches!(m.try_matrixinvert(), Err(MatrixError::Singular)));
+
+        // PLU path (4x4 with a zero row).
+        let m = Raster::from_matrix(&[
+            vec![1.0, 0.0, 0.0, 0.0],
+            vec![0.0, 0.0, 0.0, 0.0],
+            vec![0.0, 0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 0.0, 1.0],
+        ]);
+        assert!(matches!(m.try_matrixinvert(), Err(MatrixError::Singular)));
+
+        // PLU path, singular without a zero row (rank 3).
+        let m = Raster::from_matrix(&[
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![2.0, 4.0, 6.0, 8.0],
+            vec![0.0, 1.0, 0.0, 1.0],
+            vec![1.0, 0.0, 1.0, 0.0],
+        ]);
+        assert!(matches!(m.try_matrixinvert(), Err(MatrixError::Singular)));
+    }
+
+    /// Shape errors are typed: non-square and multi-band inputs.
+    #[test]
+    fn matrixinvert_shape_errors() {
+        let m = Raster::from_matrix(&[vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
+        assert!(matches!(
+            m.try_matrixinvert(),
+            Err(MatrixError::NotSquare {
+                width: 3,
+                height: 2
+            })
+        ));
+
+        let rgb = Raster::black_bands(2, 2, 3);
+        assert!(matches!(
+            rgb.try_matrixinvert(),
+            Err(MatrixError::NotOneBand {
+                op: "matrixinvert",
+                bands: 3
+            })
+        ));
+    }
+
+    /// The ported `test_invertlut` table, checked against hand-computed
+    /// values from the libvips algorithm: zero at 0, one at 255, and
+    /// the measured levels mapped back to their inputs.
+    #[test]
+    fn invertlut_ported_table() {
+        let lut = Raster::from_matrix(&[
+            vec![0.1, 0.2, 0.3, 0.1],
+            vec![0.2, 0.4, 0.4, 0.2],
+            vec![0.7, 0.5, 0.6, 0.3],
+        ]);
+        let im = lut.invertlut();
+
+        assert_eq!(im.width(), 256);
+        assert_eq!(im.height(), 1);
+        assert_eq!(im.format().channels(), 3);
+        assert_eq!(im.interpretation(), Interpretation::Histogram);
+
+        // Head extrapolation: everything starts at 0.
+        for &v in &im.getpoint(0, 0) {
+            assert!(v.abs() < 0.001);
+        }
+        // Tail extrapolation: everything ends at 1.
+        for &v in &im.getpoint(255, 0) {
+            assert!((v - 1.0).abs() < 0.001);
+        }
+        // Measured points map back to their inputs: band 0 measured 0.2
+        // at input 0.1, so LUT[trunc(0.2 * 255)][0] = 0.1. Bands 1 and 2
+        // likewise.
+        let p = im.getpoint(51, 0);
+        assert!((p[0] - 0.1).abs() < 0.001, "band 0 at 51: {}", p[0]);
+        let p = im.getpoint(76, 0);
+        assert!((p[1] - 0.1).abs() < 0.01, "band 1 at 76: {}", p[1]);
+        let p = im.getpoint(25, 0);
+        assert!((p[2] - 0.1).abs() < 0.01, "band 2 at 25: {}", p[2]);
+
+        // An interior interpolated value, hand-computed: band 0 at
+        // k = 90, ki = 90/255, bracketed by rows (0.1, 0.2) and
+        // (0.2, 0.4): 0.1 + 0.1 * (90/255 - 0.2) / 0.2.
+        let ki = 90.0 / 255.0;
+        let expected = 0.1 + 0.1 * ((ki - 0.2) / 0.2);
+        let p = im.getpoint(90, 0);
+        assert!((p[0] - expected).abs() < 1e-4, "{} vs {expected}", p[0]);
+    }
+
+    /// A one-row table: the measured section collapses to the row's
+    /// input value and both extrapolations still anchor at (0,0) and
+    /// (1,1).
+    #[test]
+    fn invertlut_single_row() {
+        let lut = Raster::from_matrix(&[vec![0.5, 0.5]]);
+        let im = lut.invertlut();
+        assert_eq!(im.width(), 256);
+        let p = im.getpoint(0, 0);
+        assert!(p[0].abs() < 1e-6);
+        // trunc(0.5 * 255) = 127: the single measured point.
+        let p = im.getpoint(127, 0);
+        assert!((p[0] - 0.5).abs() < 1e-6);
+        let p = im.getpoint(255, 0);
+        assert!((p[0] - 1.0).abs() < 1e-6);
+    }
+
+    /// An explicit size produces that many entries.
+    #[test]
+    fn invertlut_explicit_size() {
+        let lut = Raster::from_matrix(&[vec![0.2, 0.5], vec![0.7, 0.9]]);
+        let im = lut.invertlut_size(1024);
+        assert_eq!(im.width(), 1024);
+        assert_eq!(im.height(), 1);
+        let p = im.getpoint(1023, 0);
+        assert!((p[0] - 1.0).abs() < 1e-6);
+    }
+
+    /// invertlut input validation is typed: range, shape, band count,
+    /// and size errors.
+    #[test]
+    fn invertlut_typed_errors() {
+        let out_of_range = Raster::from_matrix(&[vec![0.1, 1.5], vec![0.2, 0.4]]);
+        assert!(matches!(
+            out_of_range.try_invertlut(),
+            Err(MatrixError::OutOfRange {
+                column: 1,
+                row: 0,
+                ..
+            })
+        ));
+
+        let nan = Raster::from_matrix(&[vec![0.1, f64::NAN], vec![0.2, 0.4]]);
+        assert!(matches!(
+            nan.try_invertlut(),
+            Err(MatrixError::OutOfRange { .. })
+        ));
+
+        let narrow = Raster::from_matrix(&[vec![0.1], vec![0.2]]);
+        assert!(matches!(
+            narrow.try_invertlut(),
+            Err(MatrixError::TooFewColumns { columns: 1 })
+        ));
+
+        let rgb = Raster::black_bands(4, 2, 3);
+        assert!(matches!(
+            rgb.try_invertlut(),
+            Err(MatrixError::NotOneBand {
+                op: "invertlut",
+                bands: 3
+            })
+        ));
+
+        let lut = Raster::from_matrix(&[vec![0.2, 0.5], vec![0.7, 0.9]]);
+        assert!(matches!(
+            lut.try_invertlut_size(0),
+            Err(MatrixError::BadSize { size: 0 })
+        ));
+        assert!(matches!(
+            lut.try_invertlut_size(65537),
+            Err(MatrixError::BadSize { size: 65537 })
+        ));
+    }
+}

--- a/tests/create_ported_surface.rs
+++ b/tests/create_ported_surface.rs
@@ -9,14 +9,15 @@
 //! `src/create.rs`; this file is the API contract, with each ported test
 //! body reproduced literally.
 //!
-//! Not pinned here, because they belong to later batches, are the
-//! ported cell's `fwfft` (`test_fwfft_small_image`), `invertlut`
-//! (`test_invertlut`), `matrixinvert` (`test_matrixinvert`), and
-//! `Kernel::gaussmat` / `Kernel::logmat` (`test_gaussmat` /
-//! `test_logmat`) call sites. The `from_matrix` setup those tests share
-//! is in this batch and is pinned below. The `test_grey` and
-//! `test_identity` bodies are already pinned in
-//! `tests/conversion_ported_surface.rs`.
+//! Not pinned here, because they live in other batches, are the
+//! ported cell's `fwfft` (`test_fwfft_small_image`, pinned in
+//! `tests/freqfilt_ported_surface.rs`), `invertlut` / `matrixinvert`
+//! (`test_invertlut` / `test_matrixinvert`, pinned in
+//! `tests/matrix_ported_surface.rs`), and `Kernel::gaussmat` /
+//! `Kernel::logmat` (`test_gaussmat` / `test_logmat`, a later batch)
+//! call sites. The `from_matrix` setup those tests share is pinned
+//! below. The `test_grey` and `test_identity` bodies are already
+//! pinned in `tests/conversion_ported_surface.rs`.
 //!
 //! One ported assertion is corrected here (see
 //! `ported_mask_butterworth`): the ported cell passes `nodc: true` in

--- a/tests/freqfilt_ported_surface.rs
+++ b/tests/freqfilt_ported_surface.rs
@@ -1,0 +1,57 @@
+//! Pins the frequency-filter call surface required by the libviprs-tests
+//! ported suite (libviprs-tests issue #55, `tests/ported_create.rs`).
+//!
+//! Integration tests compile as an external crate, exactly the position
+//! the ported tests are in, so this file proves the surface they call
+//! compiles and behaves. The ported suite's only frequency-domain call
+//! site today is `fwfft` (`test_fwfft_small_image` in
+//! `ported_create.rs`); its body is reproduced literally below.
+//! Behaviour depth for the rest of the family (`invfft`, `invfft_real`,
+//! `freqmult`, `spectrum`, `phasecor`) is covered by the unit tests in
+//! `src/freqfilt.rs`; the smoke checks here pin their signatures from
+//! the external-caller position.
+
+use libviprs::{FreqfiltError, PixelFormat, Raster};
+
+/// The ported `test_fwfft_small_image` body.
+#[test]
+fn ported_fwfft_small_image() {
+    let im = Raster::black(2, 1);
+    let _fft = im.fwfft(); // Should not panic
+}
+
+/// The rest of the freqfilt family compiles and runs from the external
+/// position: panicking forms and `try_` twins.
+#[test]
+fn freqfilt_family_surface() {
+    let im = Raster::black(8, 8);
+
+    let fourier: Raster = im.fwfft();
+    let _complex: Raster = fourier.invfft();
+    let real: Raster = fourier.invfft_real();
+    assert_eq!(real.format().channels(), 1);
+
+    let mask = Raster::mask_ideal(8, 8, 0.5, false);
+    let _filtered: Raster = im.freqmult(&mask);
+    let _display: Raster = im.spectrum();
+    let _corr: Raster = im.phasecor(&im);
+
+    let _: Result<Raster, FreqfiltError> = im.try_fwfft();
+    let _: Result<Raster, FreqfiltError> = fourier.try_invfft();
+    let _: Result<Raster, FreqfiltError> = fourier.try_invfft_real();
+    let _: Result<Raster, FreqfiltError> = im.try_freqmult(&mask);
+    let _: Result<Raster, FreqfiltError> = im.try_spectrum();
+    let _: Result<Raster, FreqfiltError> = im.try_phasecor(&im);
+}
+
+/// fwfft output is a complex (re, im) float raster: two bands for a
+/// one-band input, in the interleaved convention the arithmetic
+/// module's complex family uses.
+#[test]
+fn fwfft_output_is_complex_pairs() {
+    let im = Raster::black(4, 4);
+    let f = im.fwfft();
+    assert_eq!(f.format().channels(), 2);
+    assert!(f.format().is_float());
+    assert_eq!(f.format(), PixelFormat::with_channels(2, 4).unwrap());
+}

--- a/tests/matrix_ported_surface.rs
+++ b/tests/matrix_ported_surface.rs
@@ -1,0 +1,76 @@
+//! Pins the matrix/LUT call surface required by the libviprs-tests
+//! ported suite (libviprs-tests issue #55, `tests/ported_create.rs`).
+//!
+//! Integration tests compile as an external crate, exactly the position
+//! the ported tests are in, so this file proves the surface they call
+//! compiles and behaves: `invertlut` (`test_invertlut`) and
+//! `matrixinvert` (`test_matrixinvert`), each ported test body
+//! reproduced literally. Behaviour depth is covered by the unit tests
+//! in `src/matrix.rs`. The `from_matrix` setup both bodies share, and
+//! the `buildlut` companion, are pinned in
+//! `tests/create_ported_surface.rs` with the rest of the create batch.
+
+use libviprs::{MatrixError, Raster};
+
+/// The ported `test_invertlut` body.
+#[test]
+fn ported_invertlut() {
+    let lut = Raster::from_matrix(&[
+        vec![0.1, 0.2, 0.3, 0.1],
+        vec![0.2, 0.4, 0.4, 0.2],
+        vec![0.7, 0.5, 0.6, 0.3],
+    ]);
+    let im = lut.invertlut();
+
+    assert_eq!(im.width(), 256);
+    assert_eq!(im.height(), 1);
+    assert_eq!(im.format().channels(), 3);
+
+    let p = im.getpoint(0, 0);
+    for &v in &p {
+        assert!(v.abs() < 0.001);
+    }
+    let p = im.getpoint(255, 0);
+    for &v in &p {
+        assert!((v - 1.0).abs() < 0.001);
+    }
+
+    let p = im.getpoint((0.2 * 255.0) as u32, 0);
+    assert!((p[0] - 0.1).abs() < 0.1);
+}
+
+/// The ported `test_matrixinvert` body.
+#[test]
+fn ported_matrixinvert() {
+    let mat = Raster::from_matrix(&[
+        vec![4.0, 0.0, 0.0, 0.0],
+        vec![0.0, 0.0, 2.0, 0.0],
+        vec![0.0, 1.0, 2.0, 0.0],
+        vec![1.0, 0.0, 0.0, 1.0],
+    ]);
+    let inv = mat.matrixinvert();
+
+    assert_eq!(inv.width(), 4);
+    assert_eq!(inv.height(), 4);
+
+    let p = inv.getpoint(0, 0);
+    assert!((p[0] - 0.25).abs() < 0.001);
+    let p = inv.getpoint(3, 3);
+    assert!((p[0] - 1.0).abs() < 0.001);
+}
+
+/// The `try_` twins and the sized `invertlut` variant compile from the
+/// external position, and singular input is a typed error rather than
+/// a panic.
+#[test]
+fn matrix_family_surface() {
+    let mat = Raster::from_matrix(&[vec![1.0, 2.0], vec![2.0, 4.0]]);
+    let r: Result<Raster, MatrixError> = mat.try_matrixinvert();
+    assert!(matches!(r, Err(MatrixError::Singular)));
+
+    let lut = Raster::from_matrix(&[vec![0.2, 0.5], vec![0.7, 0.9]]);
+    let _: Result<Raster, MatrixError> = lut.try_invertlut();
+    let _: Result<Raster, MatrixError> = lut.try_invertlut_size(512);
+    let sized: Raster = lut.invertlut_size(512);
+    assert_eq!(sized.width(), 512);
+}


### PR DESCRIPTION
Final pure-Rust op batch for libviprs-tests#55: the frequency-filter family and the matrix/LUT operations, in two new modules file-disjoint from every existing op module.

## What lands

**src/freqfilt.rs** (new module)
- `Raster::fwfft` / `try_fwfft`: forward 2D DFT, scaled 1/(w*h), DC at the origin, output stamped `Interpretation::Fourier` (ports `freqfilt/fwfft.c` including the band-splitting `vips__fftproc` driver)
- `Raster::invfft` / `try_invfft`: unnormalised inverse, complex output (ports `cinvfft1`)
- `Raster::invfft_real` / `try_invfft_real`: unnormalised inverse keeping the real component, with the FFTW c2r left-half Hermitian reconstruction (ports `rinvfft1`)
- `Raster::freqmult` / `try_freqmult`: multiply in frequency space, cast back to the input format (ports `freqmult.c`)
- `Raster::spectrum` / `try_spectrum`: displayable log-scaled power spectrum, wrap re-centres DC (ports `spectrum.c`)
- `Raster::phasecor` / `try_phasecor`: phase correlation, with the CROSS macro from `arithmetic/complex.c` ported branch-for-branch
- `FreqfiltError` (`#[non_exhaustive]`), re-exported from lib.rs

**src/matrix.rs** (new module)
- `Raster::matrixinvert` / `try_matrixinvert`: direct cofactor path below 4x4, Numerical Recipes PLU with scaled partial pivoting above, the exact `2 * DBL_MIN` singularity threshold (ports `mosaicing/matrixinvert.c`)
- `Raster::invertlut` / `try_invertlut` plus `invertlut_size` / `try_invertlut_size`: inverse LUT from measured rows, sorted by column 0, head/tail extrapolation to (0,0)/(1,1), inclusive interpolation loop (ports `create/invertlut.c` current master)
- `MatrixError` (`#[non_exhaustive]`), re-exported from lib.rs
- `buildlut` already lives in create.rs and is not redefined; `matrixmultiply` is not called by the ported suite and stays unimplemented

**FFT core**: `rustfft` (pure Rust, MIT OR Apache-2.0) as a workspace dependency; mixed-radix planning handles non-power-of-two sizes.

**Complex convention**: `(re, im)` interleaved float pairs per the arithmetic module, tagged `Interpretation::Fourier` to stand in for libvips' complex band formats; the compound ops use that tag where libvips branches on `vips_band_format_iscomplex`.

## Tests

- 22 new unit tests: constant-image DC bin, fwfft/invfft round trips at non-power-of-two sizes, per-band and complex-input transform paths, freqmult identity plus typed errors, spectrum peak at the centre, phasecor shift recovery (peak at the applied (3,2) shift), analytic 2x2/3x3/4x4 inverses, inverse round trip, singular detection on both paths, invertlut hand-computed tables and typed errors
- New compile-position pins `tests/freqfilt_ported_surface.rs` and `tests/matrix_ported_surface.rs` reproduce the ported `test_fwfft_small_image`, `test_invertlut`, and `test_matrixinvert` bodies literally; the stale later-batch note in `tests/create_ported_surface.rs` now points at them

## Verification

- make fmt, make clippy (default and pdfium, -D warnings), make test, and the doc gate (broken intra-doc links denied) all green locally, re-run after rebasing onto the composite-float merge (#267)
- Ported cell run against this branch (tests repo with the `SdfParams` import fixed and the two later-batch `Kernel` tests removed): 27/28 pass; `test_fwfft_small_image`, `test_invertlut`, `test_matrixinvert`, and `test_buildlut` all pass. The single red is the already-proven `test_mask_butterworth` mis-port documented in `tests/create_ported_surface.rs` (the cell sets `nodc: true` in the uchar+optical variant yet expects the DC 255 that libvips only produces with nodc off); it stays red in the tests repo for the enablement round. Note `tests/ported_create.rs` on tests main does not compile under `--features ported_tests` today: it uses `Kernel` (a later core batch) and `SdfParams` without importing them.