### PR TITLE
arithmetic: correct two approximation values in comments

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -2859,7 +2859,7 @@ mod tests {
         let v = float_samples(&q)[0];
         assert!((v - 128.0 / 255.0).abs() < 1e-6, "128/255 ~ 0.502, got {v}");
         let a = float_samples(&q.atanh())[0];
-        let expected = (128.0f64 / 255.0).atanh(); // ~0.55245
+        let expected = (128.0f64 / 255.0).atanh(); // ~0.551924
         assert!(a.is_finite(), "atanh(0.502) is finite, got {a}");
         assert!((a - expected).abs() < 1e-6, "expected {expected}, got {a}");
     }
@@ -3617,7 +3617,7 @@ mod tests {
     /// f32::MAX (~89.4): real libvips `vips_math` on uchar input also
     /// outputs float (f32) and yields inf there, so inf IS the correct
     /// op result for large fixture values (libviprs-tests issue #77:
-    /// sinh(226) ~ 3.7e97 >> f32::MAX ~ 3.4e38). Small probes stay
+    /// sinh(226) ~ 7.07e97 >> f32::MAX ~ 3.4e38). Small probes stay
     /// finite and exact.
     #[test]
     fn sinh_cosh_f32_overflow_matches_libvips() {

--- a/tests/arithmetic_ported_surface.rs
+++ b/tests/arithmetic_ported_surface.rs
@@ -575,7 +575,7 @@ fn ported_surface_math_trig() {
 /// divide / linear float promotion), so the `div_const(255.0)` setup
 /// keeps 128/255 as ~0.502 and the expected values read the
 /// post-division image. The float contract is what makes the literal
-/// `test_atanh` body pass: atanh(0.502) ~ 0.5525 is finite, where the
+/// `test_atanh` body pass: atanh(0.502) ~ 0.5519 is finite, where the
 /// old integer round-to-1 contract degenerated it to atanh(1) = inf.
 #[test]
 fn ported_surface_math_inverse_trig() {


### PR DESCRIPTION
Follow-up to #303 (libviprs/libviprs-tests#77): the assertions compute their expected values so tests are unaffected, but two prose approximations were off. atanh(128/255) is ~0.551924 (I wrote ~0.5525), and sinh(226) is ~7.07e97 (I wrote ~3.7e97). Comment-only change.
