### PR TITLE
engine: bound default in-flight tiles to the worker count (libviprs-tests #79)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -170,7 +170,18 @@ pub enum BlankTileStrategy {
 pub struct EngineConfig {
     /// Number of worker threads for tile extraction. 0 = single-threaded (current thread).
     pub concurrency: usize,
-    /// Maximum tiles buffered between producer and sink. Controls backpressure.
+    /// Extra tiles the producer/sink channel may buffer *beyond* the ones the
+    /// workers are actively handing off. Controls backpressure and bounds the
+    /// number of tiles held in flight.
+    ///
+    /// The default is `0`: a rendezvous channel where a worker blocks until the
+    /// sink consumer takes its tile, so the peak in-flight tile count stays at
+    /// roughly the worker count (`concurrency`, plus the one being handed off).
+    /// This keeps memory bounded by the parallelism the caller asked for rather
+    /// than by an unrelated constant, so a run never admits far more tiles than
+    /// it can consume (libviprs-tests issue #79). Raise it to let producers run
+    /// ahead of a bursty or high-latency sink, at the cost of higher peak
+    /// memory and a higher `queue_pressure_peak`.
     pub buffer_size: usize,
     /// Background color (RGB) used to pad edge tiles to the full tile size.
     /// Defaults to white (255, 255, 255).
@@ -224,7 +235,7 @@ impl Default for EngineConfig {
     fn default() -> Self {
         Self {
             concurrency: 0,
-            buffer_size: 64,
+            buffer_size: 0,
             background_rgb: [255, 255, 255],
             blank_tile_strategy: BlankTileStrategy::Emit,
             failure_policy: FailurePolicy::default(),
@@ -253,7 +264,10 @@ impl EngineConfig {
     ///
     /// A smaller buffer limits memory usage but may cause producers to block
     /// more frequently. A larger buffer smooths out sink latency at the cost
-    /// of higher peak memory.
+    /// of higher peak memory. The default (`0`) is a rendezvous channel that
+    /// holds no extra tiles, so the peak in-flight count tracks the worker
+    /// count; pass a positive `n` to let producers run up to `n` tiles ahead
+    /// of the sink.
     ///
     /// **See also:** [interactive example](https://libviprs.org/cli/#flag-buffer-size).
     pub fn with_buffer_size(mut self, n: usize) -> Self {
@@ -3928,12 +3942,68 @@ mod tests {
             result.queue_pressure_peak
         );
         // Sanity: occupancy can never exceed what the channel plus in-flight
-        // senders can hold.
+        // senders can hold. The gauge is bumped just before each `send`, so at
+        // the peak every one of the `concurrency` producers may have counted a
+        // tile that is not yet resident in the buffer, on top of a full buffer.
+        // The bounded channel also lets one item sit mid-handoff (sent but not
+        // yet received) beyond its declared capacity, so the true ceiling is
+        // `buffer_size + concurrency + 1`; asserting the tighter
+        // `buffer_size + concurrency` made this a ~3%-flaky test (it fired at
+        // `+ 1` under an unlucky producer/consumer interleaving).
         assert!(
-            result.queue_pressure_peak <= (buffer_size + concurrency) as u32,
+            result.queue_pressure_peak <= (buffer_size + concurrency + 1) as u32,
             "queue_pressure_peak {} exceeds the maximum possible occupancy {}",
             result.queue_pressure_peak,
-            buffer_size + concurrency
+            buffer_size + concurrency + 1
         );
+    }
+
+    /// libviprs-tests issue #79 (queue over-admission): with the *default*
+    /// config a parallel run must not let far more tiles than the worker count
+    /// sit in flight. Before the fix the default channel buffered up to 64
+    /// tiles, so a `concurrency(4)` run peaked at 30-56 in flight regardless of
+    /// how few workers the caller asked for. The default is now a rendezvous
+    /// channel, so a worker blocks until the sink takes its tile and the peak
+    /// tracks the worker count (plus the one being handed off).
+    ///
+    /// This is the core reproduction of
+    /// `phase3_tracing::queue_pressure_peak_bounded_by_concurrency`.
+    #[test]
+    fn queue_pressure_peak_bounded_by_concurrency_default_config() {
+        let src = gradient_raster(1024, 1024);
+        let plan = PyramidPlanner::new(1024, 1024, 128, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+
+        let concurrency = 4usize;
+        // Default config -> default (rendezvous) buffer. The only knob the
+        // caller sets is the worker count, mirroring the phase3 test.
+        let config = EngineConfig::default().with_concurrency(concurrency);
+
+        // Run repeatedly: the peak is scheduling-sensitive, so a single pass
+        // could pass by luck. Every pass must honour the bound.
+        for pass in 0..16 {
+            let sink = MemorySink::new();
+            let result =
+                generate_pyramid_observed(&src, &plan, &sink, &config, &NoopObserver).unwrap();
+
+            // Matches the phase3 contract: peak <= concurrency + a small fudge
+            // for the tile being handed off to the sink.
+            let fudge = 2u32;
+            assert!(
+                result.queue_pressure_peak <= concurrency as u32 + fudge,
+                "pass {pass}: queue_pressure_peak {} exceeds concurrency {concurrency} + fudge {fudge}",
+                result.queue_pressure_peak,
+            );
+            assert!(
+                result.queue_pressure_peak > 0,
+                "pass {pass}: queue_pressure_peak should be > 0 after a real run",
+            );
+            assert_eq!(
+                result.tiles_produced,
+                plan.total_tile_count(),
+                "pass {pass}: every tile must still be produced under the tighter buffer",
+            );
+        }
     }
 }


### PR DESCRIPTION
## What

Fixes the scheduler over-admission that kept the enforced mirror from going
end-to-end green: `phase3_tracing::queue_pressure_peak_bounded_by_concurrency`
(libviprs-tests #79, epic #270 P0 cluster).

The parallel tile-emission path sized its producer/sink channel from a fixed
`buffer_size` default of 64, unrelated to the worker count. A `concurrency(4)`
run therefore let producers race up to ~60 tiles ahead of the single consumer,
so `queue_pressure_peak` peaked at 30-56 in flight (the test asserts
`<= concurrency + 2` and observed 43-44).

I default `EngineConfig::buffer_size` to `0`, a rendezvous channel: a worker
blocks until the sink takes its tile, so the peak in-flight count tracks the
worker count plus the one being handed off. This matches the phase3 test's own
model ("+1 for the tile currently being handed off to the sink") and bounds
memory by the parallelism the caller asked for rather than by an unrelated
constant. Every explicit-buffer path still opts in with `with_buffer_size(n)`,
so the issue #115 occupancy test (which sets `buffer_size = 16`) is unchanged.

I also corrected the issue #115 sanity ceiling, which was off by one: the gauge
is bumped just before each send and the bounded channel holds one item
mid-handoff, so the true maximum is `buffer_size + concurrency + 1`, not
`+ concurrency`. The tighter bound made that test ~3% flaky; the `peak >
concurrency` contract is untouched.

Adds a core reproduction `queue_pressure_peak_bounded_by_concurrency_default_config`
that runs the phase3 scenario 16 times and holds the bound on every pass.

## Scope note on the rest of the #270 P0 cluster

At current `main` the other three named #79 tests already pass and I verified
this directly against this branch:

- `phase3_resume::resume_mode_refuses_if_plan_hash_differs` (M11 / #276): green,
  10/10 in the full `phase3_resume` file.
- `phase3_validation_stress::restart_during_level_generation_resume_completes_output`
  (M2 / #272): green, byte-identical to the clean reference, stressed 12x.
- `phase3_validation_stress::restart_during_tile_encode_resume_completes_output`
  (M2 / M10 / #272, #275): green, stressed 12x.

The dedupe-purity and manifest-reconstruction contracts (M2 #272, M10 #275) are
exercised by `verify_mode_on_output_of_full_pipeline` and
`verify_mode_on_dedupe_blanks_with_default_emit_strategy`, both green here, so
dedupe placement is already a pure function of content + coordinates and the
manifest + dedupe index already reconstruct on resume. No change to the resume,
sink, manifest, or dedupe paths was needed or made.

## Validation

- Core mirror: `make fmt`, `make clippy` (default + pdfium, `-D warnings`), and
  `make test` (1229 passed / 0 failed) all green, including the new test.
- Acceptance against libviprs-tests phase3 cells (dep temporarily pointed at
  this branch, then restored): the four target tests green; full
  `phase3_resume` (10/10), `phase3_tracing` default features (7/7), and
  `phase3_validation_stress` (10/10) green.

## Cross-links

Closes gap in libviprs-tests #79. Epic #270 sub-issues: #272 (M2), #273 (M3),
#275 (M10), #276 (M11), #277 (M12).

Known pre-existing remainder (out of scope, unrelated to this cluster): the
`--features tracing` Part-2 tests `emits_span_per_tile` and
`tile_span_carries_coords` fail on `main` because the tile-level tracing span is
not yet wired (they emit zero `libviprs::tile` spans, with or without this
change). The #79 acceptance runs `phase3_tracing` without the tracing feature.