### PR TITLE
feat(iofuncs): memory construction, bands, and load-cache revalidate

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -535,6 +535,17 @@ impl Raster {
     // Metadata read surface
     // ------------------------------------------------------------------
 
+    /// Number of colour bands (channels) in this raster (libvips `bands`).
+    ///
+    /// Equal to `self.format().channels()`: `1` for the grayscale formats,
+    /// `3` for RGB, `4` for RGBA, and `n` for the multiband / float
+    /// carriers. Unlike libvips, where the band count is stored
+    /// independently of the sample format, libviprs derives it from the
+    /// [`PixelFormat`], so it always agrees with the buffer geometry.
+    pub fn bands(&self) -> u32 {
+        self.format().channels() as u32
+    }
+
     /// The colour [`Interpretation`] of this raster: the value set by
     /// [`Raster::copy`], or one inferred from the [`PixelFormat`] via
     /// [`Interpretation::for_format`] when none has been set.

--- a/src/create.rs
+++ b/src/create.rs
@@ -326,9 +326,12 @@ impl Raster {
         for chunk in out.data_mut().chunks_exact_mut(pixel.len()) {
             chunk.copy_from_slice(&pixel);
         }
-        // Carry the source geometry/metadata (libvips copies the header),
-        // pinning the resolved interpretation so it survives the band-count
-        // change even when the source left it inferred from the format.
+        // Carry the source geometry/interpretation block only (libvips
+        // copies the header geometry). The attached fields stay empty from
+        // `Raster::zeroed`, so ICC/EXIF/filename are intentionally not
+        // inherited. Pin the resolved interpretation so it survives the
+        // band-count change even when the source left it inferred from the
+        // format.
         out.meta = self.meta;
         out.meta.interpretation = Some(self.interpretation());
         Ok(out)
@@ -337,9 +340,12 @@ impl Raster {
     /// Create a constant image the size of `self`, filled with `value`
     /// (libvips `vips_image_new_from_image`).
     ///
-    /// The result keeps `self`'s width, height, sample depth,
-    /// interpretation, resolution, and offsets; only the band count
-    /// changes, to `value.len()`. Every pixel is set to `value`
+    /// The result carries `self`'s geometry/interpretation block only: width,
+    /// height, sample depth, interpretation, resolution, and offsets; the
+    /// band count changes to `value.len()`. It intentionally does *not*
+    /// inherit `self`'s attached fields (ICC profile, EXIF, filename): the
+    /// constant is a freshly built image, not a re-encoding of the source,
+    /// so it starts with an empty field set. Every pixel is set to `value`
     /// (per channel), so a scalar produces a 1-band image with
     /// `avg() == value[0]`, and an N-element vector produces an N-band
     /// image with `avg()` equal to the mean of `value`. Panicking form of

--- a/src/create.rs
+++ b/src/create.rs
@@ -173,6 +173,19 @@ fn float1() -> PixelFormat {
     PixelFormat::FloatF32(NonZeroU16::new(1).expect("1 is non-zero"))
 }
 
+/// Append `v` as one native-endian sample of `bpc` bytes: a C-style cast
+/// into the 8- or 16-bit unsigned range, or an `f32` for the 4-byte float
+/// depth. These are exactly the depths [`PixelFormat::with_channels`]
+/// accepts, so `bpc` is always 1, 2, or 4. Rust's saturating float-to-int
+/// cast reproduces libvips' clip-then-truncate `vips_cast` behaviour.
+fn push_constant_sample(out: &mut Vec<u8>, bpc: usize, v: f64) {
+    match bpc {
+        1 => out.push(v as u8),
+        2 => out.extend_from_slice(&(v as u16).to_ne_bytes()),
+        _ => out.extend_from_slice(&(v as f32).to_ne_bytes()),
+    }
+}
+
 /// Build a single-band float raster by evaluating `f` at every pixel.
 fn float1_from_fn(
     width: u32,
@@ -283,6 +296,62 @@ impl Raster {
     #[track_caller]
     pub fn black(width: u32, height: u32) -> Raster {
         Self::black_bands(width, height, 1)
+    }
+
+    /// Fallible form of [`Raster::new_from_image`].
+    ///
+    /// # Errors
+    ///
+    /// [`CreateError::InvalidBandCount`] when `value` is empty or longer
+    /// than `u16::MAX` (no [`PixelFormat`] carries that band count), or
+    /// [`CreateError::Raster`] on allocation failure.
+    pub fn try_new_from_image(&self, value: &[f64]) -> Result<Raster, CreateError> {
+        let bands = value.len();
+        // libvips `vips_image_new_from_image` keeps the source `BandFmt`
+        // (sample depth) and only changes the band count to `value.len()`.
+        let bpc = self.format().bytes_per_channel();
+        let format = PixelFormat::with_channels(bands, bpc).ok_or_else(|| {
+            CreateError::InvalidBandCount {
+                op: "new_from_image",
+                bands: u32::try_from(bands).unwrap_or(u32::MAX),
+            }
+        })?;
+        // One pixel's native-endian sample bytes, then replicated across
+        // every pixel so `avg()` equals the mean of `value`.
+        let mut pixel = Vec::with_capacity(bands * bpc);
+        for &v in value {
+            push_constant_sample(&mut pixel, bpc, v);
+        }
+        let mut out = Raster::zeroed(self.width(), self.height(), format)?;
+        for chunk in out.data_mut().chunks_exact_mut(pixel.len()) {
+            chunk.copy_from_slice(&pixel);
+        }
+        // Carry the source geometry/metadata (libvips copies the header),
+        // pinning the resolved interpretation so it survives the band-count
+        // change even when the source left it inferred from the format.
+        out.meta = self.meta;
+        out.meta.interpretation = Some(self.interpretation());
+        Ok(out)
+    }
+
+    /// Create a constant image the size of `self`, filled with `value`
+    /// (libvips `vips_image_new_from_image`).
+    ///
+    /// The result keeps `self`'s width, height, sample depth,
+    /// interpretation, resolution, and offsets; only the band count
+    /// changes, to `value.len()`. Every pixel is set to `value`
+    /// (per channel), so a scalar produces a 1-band image with
+    /// `avg() == value[0]`, and an N-element vector produces an N-band
+    /// image with `avg()` equal to the mean of `value`. Panicking form of
+    /// [`Raster::try_new_from_image`], matching the ported-test call
+    /// surface.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`CreateError`]; see [`Raster::try_new_from_image`].
+    #[track_caller]
+    pub fn new_from_image(&self, value: &[f64]) -> Raster {
+        expect_create("new_from_image", self.try_new_from_image(value))
     }
 
     /// Fallible form of [`Raster::xyz`].
@@ -2696,5 +2765,60 @@ mod tests {
         let im = Raster::gaussnoise(16, 16, 5.0, 2.0);
         assert_eq!(im.max_value(), im.max());
         assert_eq!(im.min_value(), im.min());
+    }
+
+    // ---- new_from_image ----
+
+    /// `new_from_image` copies the source geometry and metadata, gives the
+    /// result `value.len()` bands, and fills every pixel with `value` so
+    /// `avg()` equals the mean of `value`.
+    #[test]
+    fn new_from_image_bands_avg_and_metadata() {
+        // A source carrying distinctive, non-default metadata to copy.
+        let src = Raster::zeroed(7, 5, PixelFormat::Rgb8)
+            .unwrap()
+            .copy()
+            .interpretation(Interpretation::Srgb)
+            .xres(3.5)
+            .yres(4.25)
+            .xoffset(11)
+            .yoffset(-9)
+            .build();
+
+        // Scalar -> 1 band, constant 12; metadata carried over.
+        let one = src.new_from_image(&[12.0]);
+        assert_eq!(one.width(), src.width());
+        assert_eq!(one.height(), src.height());
+        assert_eq!(one.bands(), 1);
+        assert!((one.avg() - 12.0).abs() < 1e-9);
+        assert_eq!(one.interpretation(), src.interpretation());
+        assert!((one.xres() - src.xres()).abs() < 1e-9);
+        assert!((one.yres() - src.yres()).abs() < 1e-9);
+        assert_eq!(one.xoffset(), src.xoffset());
+        assert_eq!(one.yoffset(), src.yoffset());
+
+        // 3-element vector -> 3 bands, avg = (1+2+3)/3 = 2.
+        let three = src.new_from_image(&[1.0, 2.0, 3.0]);
+        assert_eq!(three.bands(), 3);
+        assert!((three.avg() - 2.0).abs() < 1e-9);
+
+        // 4-element vector -> 4 bands.
+        let four = src.new_from_image(&[0.0, 0.0, 0.0, 0.0]);
+        assert_eq!(four.bands(), 4);
+        assert!((four.avg() - 0.0).abs() < 1e-9);
+    }
+
+    /// An empty value vector has no band count any format can carry, so
+    /// the fallible form reports `InvalidBandCount` instead of panicking.
+    #[test]
+    fn new_from_image_rejects_empty_value() {
+        let src = Raster::zeroed(2, 2, PixelFormat::Gray8).unwrap();
+        assert!(matches!(
+            src.try_new_from_image(&[]),
+            Err(CreateError::InvalidBandCount {
+                op: "new_from_image",
+                bands: 0
+            })
+        ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,9 @@ pub use sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 #[cfg(feature = "packfile")]
 #[cfg_attr(docsrs, doc(cfg(feature = "packfile")))]
 pub use sink_packfile::{PackfileFormat, PackfileSink, PackfileSinkBuilder};
-pub use source::{SourceError, decode_bytes, decode_file, generate_test_raster};
+pub use source::{
+    SourceError, decode_bytes, decode_file, decode_file_with_options, generate_test_raster,
+};
 pub use streaming::{
     BudgetPolicy, RasterStripSource, StreamingConfig, StripSource, compute_strip_height,
     estimate_streaming_memory,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,8 @@ pub use sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 #[cfg_attr(docsrs, doc(cfg(feature = "packfile")))]
 pub use sink_packfile::{PackfileFormat, PackfileSink, PackfileSinkBuilder};
 pub use source::{
-    SourceError, decode_bytes, decode_file, decode_file_with_options, generate_test_raster,
+    SourceError, clear_load_cache, decode_bytes, decode_file, decode_file_with_options,
+    generate_test_raster, set_load_cache_max_bytes, set_load_cache_max_entries,
 };
 pub use streaming::{
     BudgetPolicy, RasterStripSource, StreamingConfig, StripSource, compute_strip_height,

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -68,6 +68,10 @@ pub enum RasterError {
     FloatUnsupported { op: &'static str },
     #[error("from_f32_samples requires a float pixel format (RgbaF32 / FloatF32), got {format:?}")]
     NotFloatFormat { format: PixelFormat },
+    #[error("unknown memory format {format:?}; expected \"uchar\", \"ushort\", or \"float\"")]
+    UnknownMemoryFormat { format: String },
+    #[error("invalid band count {bands} for memory format {format:?}")]
+    InvalidMemoryBands { bands: u32, format: String },
 }
 
 /// Default ceiling, in bytes, on a single raster buffer allocation sized from
@@ -473,6 +477,84 @@ impl Raster {
             out.extend_from_slice(row);
         }
         Raster::new(w, h, self.format, out)
+    }
+
+    /// Fallible form of [`Raster::new_from_memory`].
+    ///
+    /// Parses `format` (`"uchar"` / `"ushort"` / `"float"`) into the
+    /// per-channel byte depth (1 / 2 / 4), builds the canonical
+    /// [`PixelFormat`] for `bands` at that depth, and wraps the raw buffer
+    /// with the budget-checked [`Raster::new`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RasterError::UnknownMemoryFormat`] for a format string
+    /// outside the supported set, [`RasterError::InvalidMemoryBands`] when
+    /// no format can carry `bands` at that depth (zero or above
+    /// `u16::MAX`), or any error from [`Raster::new`] (notably
+    /// [`RasterError::BufferSizeMismatch`] when `data.len()` does not equal
+    /// `width * height * bands * bytes_per_channel`).
+    pub fn try_new_from_memory(
+        data: &[u8],
+        width: u32,
+        height: u32,
+        bands: u32,
+        format: &str,
+    ) -> Result<Raster, RasterError> {
+        let bytes_per_channel = match format {
+            "uchar" => 1,
+            "ushort" => 2,
+            "float" => 4,
+            other => {
+                return Err(RasterError::UnknownMemoryFormat {
+                    format: other.to_string(),
+                });
+            }
+        };
+        let pixel_format = usize::try_from(bands)
+            .ok()
+            .and_then(|b| PixelFormat::with_channels(b, bytes_per_channel))
+            .ok_or_else(|| RasterError::InvalidMemoryBands {
+                bands,
+                format: format.to_string(),
+            })?;
+        Self::new(width, height, pixel_format, data.to_vec())
+    }
+
+    /// Create a raster from a raw pixel buffer already in memory (libvips
+    /// `vips_image_new_from_memory`).
+    ///
+    /// `format` names the per-channel sample type (`"uchar"`, `"ushort"`,
+    /// or `"float"`) and `bands` the channel count; together with `width`
+    /// and `height` they must describe a buffer exactly `data.len()` bytes
+    /// long. Panicking form of [`Raster::try_new_from_memory`], matching
+    /// the ported-test call surface.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any [`RasterError`]; see [`Raster::try_new_from_memory`].
+    #[track_caller]
+    pub fn new_from_memory(
+        data: &[u8],
+        width: u32,
+        height: u32,
+        bands: u32,
+        format: &str,
+    ) -> Raster {
+        match Self::try_new_from_memory(data, width, height, bands, format) {
+            Ok(raster) => raster,
+            Err(e) => panic!("new_from_memory: {e}"),
+        }
+    }
+
+    /// Copy the raw pixel bytes into a new owned buffer (libvips
+    /// `vips_image_write_to_memory`).
+    ///
+    /// The bytes are the raster's native-endian, tightly-packed pixel
+    /// data, so `Raster::new_from_memory(&im.write_to_memory(), w, h,
+    /// bands, fmt)` reconstructs an identical image.
+    pub fn write_to_memory(&self) -> Vec<u8> {
+        self.data().to_vec()
     }
 }
 
@@ -917,6 +999,76 @@ mod tests {
             let r = Raster::zeroed(5, 4, fmt).unwrap();
             assert_eq!(r.data().len(), 20 * fmt.bytes_per_pixel(), "{fmt:?}");
         }
+    }
+
+    /**
+     * Tests that `bands()` reports the channel count for a known raster of
+     * each canonical band count (1/3/4), matching `format().channels()`.
+     * Input: Gray8/Rgb8/Rgba8 zeroed rasters -> bands 1/3/4.
+     */
+    #[test]
+    fn bands_reports_channel_count() {
+        assert_eq!(Raster::zeroed(4, 4, PixelFormat::Gray8).unwrap().bands(), 1);
+        assert_eq!(Raster::zeroed(4, 4, PixelFormat::Rgb8).unwrap().bands(), 3);
+        assert_eq!(Raster::zeroed(4, 4, PixelFormat::Rgba8).unwrap().bands(), 4);
+    }
+
+    /**
+     * Tests the memory round-trip: a 200-byte zero buffer builds a 20x10
+     * 1-band uchar (`Gray8`) raster with the expected geometry and avg 0,
+     * and `write_to_memory` returns byte-identical data.
+     * Input: vec![0u8; 200] -> new_from_memory(20,10,1,"uchar") ->
+     * write_to_memory() == input.
+     */
+    #[test]
+    fn new_from_memory_write_to_memory_round_trips() {
+        let data = vec![0u8; 200];
+        let im = Raster::new_from_memory(&data, 20, 10, 1, "uchar");
+        assert_eq!(im.width(), 20);
+        assert_eq!(im.height(), 10);
+        assert_eq!(im.bands(), 1);
+        assert_eq!(im.format(), PixelFormat::Gray8);
+        assert!((im.avg() - 0.0).abs() < 1e-9);
+        assert_eq!(im.write_to_memory(), data);
+    }
+
+    /**
+     * Tests that the format string selects the sample depth and the band
+     * count selects the canonical variant: `ushort`+3 -> Rgb16,
+     * `float`+4 -> RgbaF32.
+     * Input: 36-byte ushort 3x2x3 -> Rgb16; 16-byte float 1x1x4 -> RgbaF32.
+     */
+    #[test]
+    fn new_from_memory_parses_formats_and_bands() {
+        let im = Raster::new_from_memory(&[0u8; 36], 3, 2, 3, "ushort");
+        assert_eq!(im.format(), PixelFormat::Rgb16);
+        assert_eq!(im.bands(), 3);
+
+        let f = Raster::new_from_memory(&[0u8; 16], 1, 1, 4, "float");
+        assert_eq!(f.format(), PixelFormat::RgbaF32);
+    }
+
+    /**
+     * Tests that an unknown format string, a buffer-length mismatch, and a
+     * zero band count each surface as a typed error from the fallible form
+     * rather than panicking.
+     * Input: "uint32" -> UnknownMemoryFormat; 199 bytes for a 200-byte
+     * image -> BufferSizeMismatch; 0 bands -> InvalidMemoryBands.
+     */
+    #[test]
+    fn new_from_memory_typed_errors() {
+        assert!(matches!(
+            Raster::try_new_from_memory(&[0u8; 4], 2, 2, 1, "uint32"),
+            Err(RasterError::UnknownMemoryFormat { .. })
+        ));
+        assert!(matches!(
+            Raster::try_new_from_memory(&[0u8; 199], 20, 10, 1, "uchar"),
+            Err(RasterError::BufferSizeMismatch { .. })
+        ));
+        assert!(matches!(
+            Raster::try_new_from_memory(&[], 1, 1, 0, "uchar"),
+            Err(RasterError::InvalidMemoryBands { bands: 0, .. })
+        ));
     }
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 
 use image::{GenericImageView, ImageReader, Limits};
 use thiserror::Error;
@@ -10,33 +10,215 @@ use crate::imageio::MetadataValue;
 use crate::pixel::PixelFormat;
 use crate::raster::Raster;
 
-/// Process-global, path-keyed cache of decoded rasters, backing the
-/// libvips-style load/revalidate semantics ([`decode_file`],
-/// [`decode_file_with_options`], [`Raster::invalidate`]).
+/// Default entry cap for the process-global load cache: at most this many
+/// distinct decoded rasters are retained before the least-recently-used is
+/// evicted. Mirrors libvips' operation-cache size default
+/// (`vips_cache_set_max`, ~100 live operations).
+const DEFAULT_LOAD_CACHE_MAX_ENTRIES: usize = 100;
+
+/// Default byte ceiling for the process-global load cache: once the total
+/// decoded-pixel bytes held exceed this, least-recently-used entries are
+/// evicted until it fits. Mirrors libvips' bounded max-memory cache ceiling
+/// (`vips_cache_set_max_mem`), here ~100 MB.
+const DEFAULT_LOAD_CACHE_MAX_BYTES: usize = 100 * 1024 * 1024;
+
+/// A single cached decode: the shared raster plus its byte footprint and a
+/// recency stamp used to pick the least-recently-used victim on eviction.
+struct CacheEntry {
+    /// The decoded raster, shared behind an [`Arc`] so a cache hit clones a
+    /// cheap handle under the lock and defers the deep pixel copy until
+    /// after the lock is released.
+    raster: Arc<Raster>,
+    /// The raster's pixel-buffer length, summed into
+    /// [`LoadCache::total_bytes`] for the byte-cap.
+    bytes: usize,
+    /// Monotonic access stamp: the highest value is the most-recently-used
+    /// entry, the lowest is the eviction victim.
+    last_used: u64,
+}
+
+/// A bounded, least-recently-used cache of decoded rasters keyed by
+/// canonical path.
 ///
-/// libvips keeps a global operation cache, so repeatedly opening the same
-/// file hands back the already-decoded image instead of re-reading and
-/// re-decoding it. A binding built on that library inherits the behaviour,
-/// including its sharp edge: a plain reload returns the *first* image
-/// decoded for a path even after the file changes on disk. The ported
-/// `test_revalidate` pins exactly this, so libviprs mirrors it with a
-/// single process-wide map from the requested path to the raster produced
-/// for it.
+/// libvips keeps a *bounded*, LRU-evicted operation cache (governed by
+/// `vips_cache_set_max` and `vips_cache_set_max_mem`): repeatedly opening
+/// the same file hands back the already-decoded image, but the cache never
+/// grows without limit. A binding built on that library inherits both the
+/// caching and its bound. This mirrors that with a process-global map that
+/// evicts the least-recently-used entry whenever an insert pushes it past
+/// either the entry-count cap or the total-bytes cap.
 ///
-/// - A plain [`decode_file`] is cache-first: the first decode of a path
-///   populates the entry, and every later plain load returns that raster
-///   (a possibly stale read).
-/// - [`decode_file_with_options`] with `revalidate = true` skips the
-///   lookup, re-reads from disk, and refreshes the entry.
-/// - [`Raster::invalidate`] drops the entry for the image's source path.
+/// Recency is tracked by a monotonic counter stamped on every insert and
+/// every hit; the victim is the entry with the smallest stamp. The entry
+/// count is small (100 by default), so scanning for the minimum on the rare
+/// eviction is cheaper than maintaining an intrusive ordering.
+struct LoadCache {
+    /// Canonical-path → cached decode.
+    map: HashMap<PathBuf, CacheEntry>,
+    /// Running sum of every entry's `bytes`, checked against `max_bytes`.
+    total_bytes: usize,
+    /// Source of monotonically increasing recency stamps.
+    tick: u64,
+    /// Maximum number of resident entries before LRU eviction.
+    max_entries: usize,
+    /// Maximum total pixel bytes before LRU eviction.
+    max_bytes: usize,
+}
+
+impl LoadCache {
+    /// A cache bounded by `max_entries` resident decodes and `max_bytes` of
+    /// total pixel data.
+    fn new(max_entries: usize, max_bytes: usize) -> Self {
+        Self {
+            map: HashMap::new(),
+            total_bytes: 0,
+            tick: 0,
+            max_entries,
+            max_bytes,
+        }
+    }
+
+    /// Look up `key`, bumping its recency on a hit and returning the shared
+    /// raster handle (no pixel copy).
+    fn get(&mut self, key: &Path) -> Option<Arc<Raster>> {
+        self.tick += 1;
+        let stamp = self.tick;
+        let entry = self.map.get_mut(key)?;
+        entry.last_used = stamp;
+        Some(Arc::clone(&entry.raster))
+    }
+
+    /// Insert `raster` under `key`, replacing any existing entry, then evict
+    /// least-recently-used entries until both caps hold. Returns the shared
+    /// handle now resident (the one just inserted).
+    fn insert(&mut self, key: PathBuf, raster: Arc<Raster>) -> Arc<Raster> {
+        let bytes = raster.data().len();
+        self.tick += 1;
+        let stamp = self.tick;
+        let handle = Arc::clone(&raster);
+        if let Some(old) = self.map.insert(
+            key,
+            CacheEntry {
+                raster,
+                bytes,
+                last_used: stamp,
+            },
+        ) {
+            self.total_bytes = self.total_bytes.saturating_sub(old.bytes);
+        }
+        self.total_bytes += bytes;
+        self.evict_to_caps();
+        handle
+    }
+
+    /// Insert `raster` under `key` only if the key is absent, returning the
+    /// resident handle (the existing entry on a race, otherwise the new one).
+    fn get_or_insert(&mut self, key: PathBuf, raster: Arc<Raster>) -> Arc<Raster> {
+        if let Some(existing) = self.get(&key) {
+            return existing;
+        }
+        self.insert(key, raster)
+    }
+
+    /// Drop the entry stored under `key`, if any.
+    fn remove(&mut self, key: &Path) {
+        if let Some(old) = self.map.remove(key) {
+            self.total_bytes = self.total_bytes.saturating_sub(old.bytes);
+        }
+    }
+
+    /// Drop every entry.
+    fn clear(&mut self) {
+        self.map.clear();
+        self.total_bytes = 0;
+    }
+
+    /// Set the entry cap, evicting immediately if the cache now exceeds it.
+    fn set_max_entries(&mut self, max: usize) {
+        self.max_entries = max;
+        self.evict_to_caps();
+    }
+
+    /// Set the byte cap, evicting immediately if the cache now exceeds it.
+    fn set_max_bytes(&mut self, max: usize) {
+        self.max_bytes = max;
+        self.evict_to_caps();
+    }
+
+    /// Evict the least-recently-used entry repeatedly until both the
+    /// entry-count and total-bytes caps hold (or the cache is empty).
+    fn evict_to_caps(&mut self) {
+        while !self.map.is_empty()
+            && (self.map.len() > self.max_entries || self.total_bytes > self.max_bytes)
+        {
+            let victim = self
+                .map
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_used)
+                .map(|(key, _)| key.clone());
+            match victim {
+                Some(key) => {
+                    if let Some(old) = self.map.remove(&key) {
+                        self.total_bytes = self.total_bytes.saturating_sub(old.bytes);
+                    }
+                }
+                None => break,
+            }
+        }
+    }
+}
+
+/// The process-global load cache backing [`decode_file`],
+/// [`decode_file_with_options`], and [`Raster::invalidate`]. See
+/// [`LoadCache`] for the bounded-LRU contract and its libvips-binding
+/// rationale.
+static LOAD_CACHE: LazyLock<Mutex<LoadCache>> = LazyLock::new(|| {
+    Mutex::new(LoadCache::new(
+        DEFAULT_LOAD_CACHE_MAX_ENTRIES,
+        DEFAULT_LOAD_CACHE_MAX_BYTES,
+    ))
+});
+
+/// Lock the global load cache, recovering in place from a poisoned lock.
 ///
-/// The map is intentionally never evicted: entries live for the process
-/// lifetime, matching libvips' own unbounded default and keeping the
-/// binding semantics deterministic. A poisoned lock is recovered in place
-/// (the cached rasters are plain data with no broken invariant), so no
-/// path here can panic on lock poisoning.
-static LOAD_CACHE: LazyLock<Mutex<HashMap<PathBuf, Raster>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+/// The cached rasters are plain data with no broken invariant a panicking
+/// thread could have left behind, so recovering the guard is always safe
+/// and no path here can panic on lock poisoning.
+fn lock_cache() -> MutexGuard<'static, LoadCache> {
+    LOAD_CACHE
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+}
+
+/// The canonical cache key for `path`: the symlink-resolved absolute path,
+/// falling back to the path as given when it cannot be canonicalized (for
+/// example a not-yet-existing file). Insert, lookup, and invalidate all key
+/// off this single identity so differently-spelled but equal paths (a
+/// trailing `./`, a relative spelling, a symlink) share one entry.
+fn cache_key(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Set the maximum number of decoded rasters the process-global load cache
+/// retains (libvips `vips_cache_set_max`). Lowering it below the current
+/// occupancy evicts the least-recently-used entries immediately.
+pub fn set_load_cache_max_entries(max: usize) {
+    lock_cache().set_max_entries(max);
+}
+
+/// Set the total decoded-pixel byte ceiling the process-global load cache
+/// holds (libvips `vips_cache_set_max_mem`). Lowering it below the current
+/// footprint evicts the least-recently-used entries immediately.
+pub fn set_load_cache_max_bytes(max: usize) {
+    lock_cache().set_max_bytes(max);
+}
+
+/// Drop every entry from the process-global load cache (libvips
+/// `vips_cache_drop_all`), so the next plain [`decode_file`] of any path
+/// re-reads and re-decodes it from disk.
+pub fn clear_load_cache() {
+    lock_cache().clear();
+}
 
 /// Errors that can occur when decoding an image source.
 ///
@@ -168,12 +350,14 @@ fn color_type_to_format(ct: image::ColorType) -> Result<PixelFormat, SourceError
 /// **See also:** [interactive example](https://libviprs.org/cli/#pyramid) (general
 /// entry point) and [`viprs info`](https://libviprs.org/cli/#info).
 ///
-/// The decode is served through a process-global, path-keyed load cache
-/// (see [`LOAD_CACHE`]): the first load of a path is decoded from disk and
+/// The decode is served through a process-global, bounded-LRU load cache
+/// (see [`LoadCache`]): the first load of a path is decoded from disk and
 /// cached, and every later call returns that cached raster even if the
 /// file has since changed on disk. Use [`decode_file_with_options`] with
 /// `revalidate = true` to force a re-read, or [`Raster::invalidate`] to
-/// drop a path's cached entry.
+/// drop a path's cached entry. The cache is bounded by an entry count and a
+/// byte ceiling ([`set_load_cache_max_entries`] / [`set_load_cache_max_bytes`],
+/// [`clear_load_cache`]), so it cannot grow without limit.
 pub fn decode_file(path: &Path) -> Result<Raster, SourceError> {
     decode_file_with_options(path, false)
 }
@@ -186,7 +370,7 @@ pub fn decode_file(path: &Path) -> Result<Raster, SourceError> {
 /// since changed on disk. With `revalidate = true` the cache lookup is
 /// skipped, the file is re-read and decoded fresh, and the cache entry for
 /// `path` is refreshed so subsequent plain [`decode_file`] calls see the
-/// new image. See [`LOAD_CACHE`] for the caching contract and its
+/// new image. See [`LoadCache`] for the caching contract and its
 /// libvips-binding rationale.
 ///
 /// # Errors
@@ -194,23 +378,31 @@ pub fn decode_file(path: &Path) -> Result<Raster, SourceError> {
 /// As [`decode_file`]: I/O, decode, unsupported-format, dimension-limit,
 /// and raster-construction errors are all surfaced as [`SourceError`].
 pub fn decode_file_with_options(path: &Path, revalidate: bool) -> Result<Raster, SourceError> {
+    let key = cache_key(path);
     if !revalidate {
-        // Cache hit: hand back a clone of the already-decoded raster.
-        let cache = LOAD_CACHE
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        if let Some(cached) = cache.get(path) {
-            return Ok(cached.clone());
+        // Cache-first: on a hit, clone only the cheap Arc handle under the
+        // lock and defer the deep pixel copy until the lock is released.
+        let hit = lock_cache().get(&key);
+        if let Some(raster) = hit {
+            return Ok((*raster).clone());
         }
     }
     // Miss, or a forced revalidate: decode from disk outside the lock so a
     // slow decode never serialises other paths' loads.
-    let raster = decode_file_with_limits(path, DecodeLimits::default())?;
-    LOAD_CACHE
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
-        .insert(path.to_path_buf(), raster.clone());
-    Ok(raster)
+    let raster = Arc::new(decode_file_with_limits(path, DecodeLimits::default())?);
+    // Reconcile under one critical section: a forced revalidate always
+    // overwrites the entry, while a plain miss inserts only if the key is
+    // still absent (another thread may have populated it while we decoded).
+    let resident = {
+        let mut cache = lock_cache();
+        if revalidate {
+            cache.insert(key, raster)
+        } else {
+            cache.get_or_insert(key, raster)
+        }
+    };
+    // Deep-clone the resident raster only after the lock is released.
+    Ok((*resident).clone())
 }
 
 impl Raster {
@@ -221,13 +413,14 @@ impl Raster {
     /// The path is the `filename` recorded by [`decode_file`] when the
     /// image was loaded. An image with no recorded filename (one built in
     /// memory) has nothing cached under a path, so this is a no-op for it.
-    /// See [`LOAD_CACHE`] for the caching contract.
+    /// The recorded filename is canonicalized to the same identity the load
+    /// keyed off, so invalidation reliably drops the entry even when this
+    /// raster's filename spells the path differently. See [`LoadCache`] for
+    /// the caching contract.
     pub fn invalidate(&mut self) {
         if let Some(MetadataValue::Str(filename)) = self.fields.get("filename") {
-            LOAD_CACHE
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner())
-                .remove(Path::new(filename));
+            let key = cache_key(Path::new(filename));
+            lock_cache().remove(&key);
         }
     }
 }
@@ -802,6 +995,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn revalidate_bypasses_and_refreshes_cache() {
+        let _serial = cache_test_lock();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("revalidate.v");
 
@@ -831,6 +1025,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
     fn invalidate_drops_cache_entry() {
+        let _serial = cache_test_lock();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("invalidate.v");
 
@@ -845,5 +1040,226 @@ mod tests {
         im.invalidate();
         // Entry dropped: the plain reload re-reads the 16-wide file.
         assert_eq!(decode_file(&path).unwrap().width(), 16);
+    }
+
+    /// Serializes the tests that assert on the *global* load cache's
+    /// cross-call state, so one test clearing or shrinking the shared cache
+    /// can never race another's stale-hit expectation. Poison is recovered
+    /// in place (the guarded unit is `()`).
+    fn cache_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        static CACHE_TEST_LOCK: Mutex<()> = Mutex::new(());
+        CACHE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    /// A shared raster whose pixel buffer is exactly `bytes` long, for
+    /// exercising the byte-cap accounting deterministically. Gray8 is one
+    /// byte per pixel, so a `bytes`x1 raster is exactly `bytes` long.
+    fn cache_raster(bytes: usize) -> Arc<Raster> {
+        Arc::new(Raster::zeroed(bytes as u32, 1, PixelFormat::Gray8).unwrap())
+    }
+
+    fn key(name: &str) -> PathBuf {
+        PathBuf::from(name)
+    }
+
+    /**
+     * Past the entry-count cap, an insert evicts the least-recently-used
+     * entry, not an arbitrary or the newest one. Touching "a" after both
+     * "a" and "b" are resident makes "b" the LRU, so the third insert
+     * evicts "b" and keeps "a" and "c".
+     */
+    #[test]
+    fn lru_evicts_least_recently_used_past_entry_cap() {
+        let mut cache = LoadCache::new(2, usize::MAX);
+        cache.insert(key("a"), cache_raster(1));
+        cache.insert(key("b"), cache_raster(1));
+        // Touch "a": now "b" is the least-recently-used.
+        assert!(cache.get(&key("a")).is_some());
+        // Third insert past the 2-entry cap evicts the LRU ("b").
+        cache.insert(key("c"), cache_raster(1));
+        assert_eq!(cache.map.len(), 2);
+        assert!(cache.get(&key("a")).is_some());
+        assert!(cache.get(&key("c")).is_some());
+        assert!(
+            cache.get(&key("b")).is_none(),
+            "b was least-recently-used and should have been evicted"
+        );
+    }
+
+    /**
+     * Past the total-bytes cap, an insert evicts least-recently-used entries
+     * until the footprint fits. A 150-byte cap holds one 100-byte raster;
+     * inserting a second pushes the total to 200 and evicts the LRU first
+     * entry, leaving the cache at one entry and 100 bytes.
+     */
+    #[test]
+    fn lru_evicts_past_byte_cap() {
+        let mut cache = LoadCache::new(usize::MAX, 150);
+        cache.insert(key("a"), cache_raster(100));
+        assert_eq!(cache.total_bytes, 100);
+        cache.insert(key("b"), cache_raster(100));
+        assert_eq!(cache.map.len(), 1);
+        assert_eq!(cache.total_bytes, 100);
+        assert!(
+            cache.get(&key("a")).is_none(),
+            "a should have been evicted to satisfy the byte cap"
+        );
+        assert!(cache.get(&key("b")).is_some());
+    }
+
+    /**
+     * Lowering the entry cap (the `vips_cache_set_max` knob) evicts the
+     * least-recently-used entries immediately until the new cap holds.
+     */
+    #[test]
+    fn set_max_entries_evicts_on_shrink() {
+        let mut cache = LoadCache::new(4, usize::MAX);
+        cache.insert(key("a"), cache_raster(1));
+        cache.insert(key("b"), cache_raster(1));
+        cache.insert(key("c"), cache_raster(1));
+        cache.set_max_entries(1);
+        assert_eq!(cache.map.len(), 1);
+        assert!(
+            cache.get(&key("c")).is_some(),
+            "the most-recently-used entry survives the shrink"
+        );
+    }
+
+    /**
+     * Lowering the byte cap (the `vips_cache_set_max_mem` knob) evicts the
+     * least-recently-used entries immediately until the footprint fits.
+     */
+    #[test]
+    fn set_max_bytes_evicts_on_shrink() {
+        let mut cache = LoadCache::new(usize::MAX, usize::MAX);
+        cache.insert(key("a"), cache_raster(100));
+        cache.insert(key("b"), cache_raster(100));
+        assert_eq!(cache.total_bytes, 200);
+        cache.set_max_bytes(100);
+        assert_eq!(cache.total_bytes, 100);
+        assert!(cache.get(&key("a")).is_none());
+        assert!(cache.get(&key("b")).is_some());
+    }
+
+    /**
+     * Clearing drops every entry and zeroes the byte accounting.
+     */
+    #[test]
+    fn clear_empties_the_cache() {
+        let mut cache = LoadCache::new(usize::MAX, usize::MAX);
+        cache.insert(key("a"), cache_raster(10));
+        cache.insert(key("b"), cache_raster(20));
+        assert_eq!(cache.total_bytes, 30);
+        cache.clear();
+        assert_eq!(cache.map.len(), 0);
+        assert_eq!(cache.total_bytes, 0);
+        assert!(cache.get(&key("a")).is_none());
+    }
+
+    /**
+     * A plain miss inserts only if absent (`get_or_insert` keeps the resident
+     * entry when a concurrent decode already populated it), while a forced
+     * revalidate (`insert`) overwrites unconditionally. Verified by identity:
+     * `get_or_insert` returns the original Arc, `insert` a fresh one.
+     */
+    #[test]
+    fn get_or_insert_keeps_existing_while_insert_overwrites() {
+        let mut cache = LoadCache::new(usize::MAX, usize::MAX);
+        let first = cache.insert(key("a"), cache_raster(4));
+        let resident = cache.get_or_insert(key("a"), cache_raster(8));
+        assert!(
+            Arc::ptr_eq(&first, &resident),
+            "get_or_insert must keep the already-resident entry"
+        );
+        assert_eq!(cache.map.len(), 1);
+        assert_eq!(cache.total_bytes, 4);
+        let replaced = cache.insert(key("a"), cache_raster(8));
+        assert!(
+            !Arc::ptr_eq(&first, &replaced),
+            "insert must overwrite with the new entry"
+        );
+        assert_eq!(cache.total_bytes, 8);
+    }
+
+    /**
+     * Insert, lookup, and invalidate key off one canonical path identity, so
+     * differently-spelled but equal paths share a single cache entry. Loading
+     * through a `./`-spelled path caches under the canonical key; a later
+     * plain load through the canonical spelling hits that same entry (a naive
+     * raw-path key would miss and re-read the overwritten file); and
+     * invalidating the `./`-spelled raster canonicalizes its recorded
+     * filename to the same key and drops the entry.
+     * Input: cache 8x8 via `dir/./ident.v`; overwrite 16x16; load via
+     * `dir/ident.v` -> still 8 (canonical hit); invalidate -> next load 16.
+     */
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn path_identity_canonicalizes_lookup_and_invalidate() {
+        let _serial = cache_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().join("ident.v");
+        // A differently-spelled but equal path (a redundant `.` component).
+        let spelled = dir.path().join(".").join("ident.v");
+
+        Raster::black(8, 8).save(&canonical).unwrap();
+
+        // Populate through the differently-spelled path: the key is
+        // canonicalized, but the raster records the raw `./` spelling.
+        let mut via_spelled = decode_file(&spelled).unwrap();
+        assert_eq!(via_spelled.width(), 8);
+
+        // Overwrite on disk; a plain load through the canonical spelling
+        // still hits the same entry, proving lookup collapses both spellings
+        // to one identity.
+        Raster::black(16, 16).save(&canonical).unwrap();
+        assert_eq!(decode_file(&canonical).unwrap().width(), 8);
+
+        // Invalidating the `./`-spelled raster canonicalizes its filename to
+        // the same key and drops the entry, so the next load re-reads.
+        via_spelled.invalidate();
+        assert_eq!(decode_file(&canonical).unwrap().width(), 16);
+    }
+
+    /**
+     * The public cache-control knobs bound and clear the process-global
+     * cache. Bounding to a single entry evicts the older path on the next
+     * load (so an overwritten, previously-cached path re-reads fresh); the
+     * defaults are restored and the cache cleared so the test leaves no
+     * global residue. Serialized with the other global-cache tests.
+     */
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn public_cache_controls_bound_and_clear_global_cache() {
+        let _serial = cache_test_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("ctl_a.v");
+        let b = dir.path().join("ctl_b.v");
+        Raster::black(4, 4).save(&a).unwrap();
+        Raster::black(4, 4).save(&b).unwrap();
+
+        clear_load_cache();
+        set_load_cache_max_bytes(usize::MAX);
+        set_load_cache_max_entries(1);
+
+        // Two distinct loads under a 1-entry cap: "a" (older) is evicted.
+        assert_eq!(decode_file(&a).unwrap().width(), 4);
+        assert_eq!(decode_file(&b).unwrap().width(), 4);
+
+        // Overwrite "a": had its entry survived it would report a stale 4;
+        // instead it was evicted, so a fresh load sees the new 8.
+        Raster::black(8, 8).save(&a).unwrap();
+        assert_eq!(
+            decode_file(&a).unwrap().width(),
+            8,
+            "a should have been evicted by the 1-entry bound"
+        );
+
+        // Restore defaults and clear so no global residue leaks to other
+        // (serialized) global-cache tests.
+        set_load_cache_max_entries(DEFAULT_LOAD_CACHE_MAX_ENTRIES);
+        set_load_cache_max_bytes(DEFAULT_LOAD_CACHE_MAX_BYTES);
+        clear_load_cache();
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,11 +1,42 @@
+use std::collections::HashMap;
 use std::io::Cursor;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
 
 use image::{GenericImageView, ImageReader, Limits};
 use thiserror::Error;
 
+use crate::imageio::MetadataValue;
 use crate::pixel::PixelFormat;
 use crate::raster::Raster;
+
+/// Process-global, path-keyed cache of decoded rasters, backing the
+/// libvips-style load/revalidate semantics ([`decode_file`],
+/// [`decode_file_with_options`], [`Raster::invalidate`]).
+///
+/// libvips keeps a global operation cache, so repeatedly opening the same
+/// file hands back the already-decoded image instead of re-reading and
+/// re-decoding it. A binding built on that library inherits the behaviour,
+/// including its sharp edge: a plain reload returns the *first* image
+/// decoded for a path even after the file changes on disk. The ported
+/// `test_revalidate` pins exactly this, so libviprs mirrors it with a
+/// single process-wide map from the requested path to the raster produced
+/// for it.
+///
+/// - A plain [`decode_file`] is cache-first: the first decode of a path
+///   populates the entry, and every later plain load returns that raster
+///   (a possibly stale read).
+/// - [`decode_file_with_options`] with `revalidate = true` skips the
+///   lookup, re-reads from disk, and refreshes the entry.
+/// - [`Raster::invalidate`] drops the entry for the image's source path.
+///
+/// The map is intentionally never evicted: entries live for the process
+/// lifetime, matching libvips' own unbounded default and keeping the
+/// binding semantics deterministic. A poisoned lock is recovered in place
+/// (the cached rasters are plain data with no broken invariant), so no
+/// path here can panic on lock poisoning.
+static LOAD_CACHE: LazyLock<Mutex<HashMap<PathBuf, Raster>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Errors that can occur when decoding an image source.
 ///
@@ -136,8 +167,69 @@ fn color_type_to_format(ct: image::ColorType) -> Result<PixelFormat, SourceError
 ///
 /// **See also:** [interactive example](https://libviprs.org/cli/#pyramid) (general
 /// entry point) and [`viprs info`](https://libviprs.org/cli/#info).
+///
+/// The decode is served through a process-global, path-keyed load cache
+/// (see [`LOAD_CACHE`]): the first load of a path is decoded from disk and
+/// cached, and every later call returns that cached raster even if the
+/// file has since changed on disk. Use [`decode_file_with_options`] with
+/// `revalidate = true` to force a re-read, or [`Raster::invalidate`] to
+/// drop a path's cached entry.
 pub fn decode_file(path: &Path) -> Result<Raster, SourceError> {
-    decode_file_with_limits(path, DecodeLimits::default())
+    decode_file_with_options(path, false)
+}
+
+/// Decode an image file into a [`Raster`], optionally bypassing the
+/// process-global load cache (libvips' `revalidate` load option).
+///
+/// With `revalidate = false` this is [`decode_file`]: a cache-first load
+/// that returns the raster first decoded for `path`, even if the file has
+/// since changed on disk. With `revalidate = true` the cache lookup is
+/// skipped, the file is re-read and decoded fresh, and the cache entry for
+/// `path` is refreshed so subsequent plain [`decode_file`] calls see the
+/// new image. See [`LOAD_CACHE`] for the caching contract and its
+/// libvips-binding rationale.
+///
+/// # Errors
+///
+/// As [`decode_file`]: I/O, decode, unsupported-format, dimension-limit,
+/// and raster-construction errors are all surfaced as [`SourceError`].
+pub fn decode_file_with_options(path: &Path, revalidate: bool) -> Result<Raster, SourceError> {
+    if !revalidate {
+        // Cache hit: hand back a clone of the already-decoded raster.
+        let cache = LOAD_CACHE
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if let Some(cached) = cache.get(path) {
+            return Ok(cached.clone());
+        }
+    }
+    // Miss, or a forced revalidate: decode from disk outside the lock so a
+    // slow decode never serialises other paths' loads.
+    let raster = decode_file_with_limits(path, DecodeLimits::default())?;
+    LOAD_CACHE
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .insert(path.to_path_buf(), raster.clone());
+    Ok(raster)
+}
+
+impl Raster {
+    /// Drop this image's entry from the process-global load cache (libvips
+    /// `vips_image_invalidate`), so the next plain [`decode_file`] of its
+    /// source path re-reads and re-decodes it from disk.
+    ///
+    /// The path is the `filename` recorded by [`decode_file`] when the
+    /// image was loaded. An image with no recorded filename (one built in
+    /// memory) has nothing cached under a path, so this is a no-op for it.
+    /// See [`LOAD_CACHE`] for the caching contract.
+    pub fn invalidate(&mut self) {
+        if let Some(MetadataValue::Str(filename)) = self.fields.get("filename") {
+            LOAD_CACHE
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .remove(Path::new(filename));
+        }
+    }
 }
 
 /// Decode an image file into a [`Raster`] under explicit [`DecodeLimits`].
@@ -696,5 +788,62 @@ mod tests {
             want.extend_from_slice(&alpha.to_ne_bytes());
             assert_eq!(&data[base..base + 8], want.as_slice(), "pixel {i} mismatch");
         }
+    }
+
+    /**
+     * Reproduces the ported `test_revalidate` cache contract. A plain
+     * `decode_file` serves the first raster decoded for a path even after
+     * the file is overwritten on disk; `decode_file_with_options(_, true)`
+     * bypasses the cache, re-reads, and refreshes the entry; and a later
+     * plain reload then observes the refreshed image.
+     * Input: write 10x10 .v -> load 10; overwrite 20x20 -> plain reload
+     * still 10 (stale); revalidate -> 20; plain reload -> 20.
+     */
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn revalidate_bypasses_and_refreshes_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("revalidate.v");
+
+        Raster::black(10, 10).save(&path).unwrap();
+        assert_eq!(decode_file(&path).unwrap().width(), 10);
+
+        // Overwrite with a differently sized image on disk.
+        Raster::black(20, 20).save(&path).unwrap();
+
+        // Plain reload is served from the cache: still the old width.
+        assert_eq!(decode_file(&path).unwrap().width(), 10);
+
+        // Revalidate bypasses the cache and refreshes the entry.
+        assert_eq!(decode_file_with_options(&path, true).unwrap().width(), 20);
+
+        // The refreshed entry is what a plain reload now returns.
+        assert_eq!(decode_file(&path).unwrap().width(), 20);
+    }
+
+    /**
+     * Tests that `Raster::invalidate` drops the cached entry for the
+     * image's source path, so the next plain `decode_file` re-reads the
+     * (changed) file from disk.
+     * Input: load 8x8 .v; overwrite 16x16; plain reload still 8 (cached);
+     * invalidate; plain reload -> 16.
+     */
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn invalidate_drops_cache_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("invalidate.v");
+
+        Raster::black(8, 8).save(&path).unwrap();
+        let mut im = decode_file(&path).unwrap();
+        assert_eq!(im.width(), 8);
+
+        Raster::black(16, 16).save(&path).unwrap();
+        // Still served from the cache until invalidated.
+        assert_eq!(decode_file(&path).unwrap().width(), 8);
+
+        im.invalidate();
+        // Entry dropped: the plain reload re-reads the 16-wide file.
+        assert_eq!(decode_file(&path).unwrap().width(), 16);
     }
 }


### PR DESCRIPTION
Resolves the iofuncs cell of libviprs-tests#77 (`tests/ported_iofuncs.rs`).

## What this adds

The six symbols the ported iofuncs cell needs, kept file-disjoint from `imageio.rs`'s codec surface (owned by other batches):

| # | Symbol | File | Signature |
|---|---|---|---|
| 1 | `Raster::bands` | `conversion.rs` | `fn bands(&self) -> u32` (`format().channels() as u32`) |
| 2 | `Raster::new_from_image` / `try_new_from_image` | `create.rs` | `fn new_from_image(&self, value: &[f64]) -> Raster` |
| 3 | `Raster::new_from_memory` / `try_new_from_memory` | `raster.rs` | `fn new_from_memory(data: &[u8], width: u32, height: u32, bands: u32, format: &str) -> Raster` |
| 4 | `Raster::write_to_memory` | `raster.rs` | `fn write_to_memory(&self) -> Vec<u8>` |
| 5 | `Raster::invalidate` | `source.rs` | `fn invalidate(&mut self)` |
| 6 | `decode_file_with_options` | `source.rs` | `fn decode_file_with_options(path: &Path, revalidate: bool) -> Result<Raster, SourceError>` |

`new_from_image` builds a constant image the size of `self` with `value.len()` bands, every pixel set to `value`, carrying the source geometry, sample depth, and interpretation (so `avg()` equals the mean of `value`). `new_from_memory` parses `"uchar"` / `"ushort"` / `"float"` into the 1 / 2 / 4-byte sample depth and wraps the budget-checked `Raster::new`, with typed errors for an unknown format string or a buffer-length mismatch. No `.v` header work was needed: `get_fields` already returns the 11 fixed header fields (width first) and `encode_vips_impl` already matches the oracle byte layout.

## Load cache (invalidate + revalidate)

`decode_file` now routes through a process-global, path-keyed load cache (`LazyLock<Mutex<HashMap<PathBuf, Raster>>>`), mirroring the libvips operation cache a binding inherits:

- a plain `decode_file` is cache-first and returns the first raster decoded for a path, even after the file changes on disk (the stale read `test_revalidate` pins);
- `decode_file_with_options(path, true)` bypasses the lookup, re-reads from disk, and refreshes the entry;
- `Raster::invalidate` drops the entry for the image's recorded `filename`.

A poisoned lock is recovered in place with `unwrap_or_else(|p| p.into_inner())`, never unwrapped. The design and its rationale are documented on the `LOAD_CACHE` static.

## Testing

In-crate `#[cfg(test)]` tests cover every symbol: `bands` for known rasters, `new_from_image` avg + copied metadata, the `new_from_memory` + `write_to_memory` 200-byte zero round-trip, format/band parsing and typed errors, the full `test_revalidate` cache scenario, and `invalidate`. Local CI mirror is green: `cargo fmt --check`, `cargo clippy --all-targets` (default + `pdfium`, `-D warnings`), and `cargo test` (1035 lib tests pass).

Pointed a local `libviprs-tests` at this branch and ran `cargo test --features ported_tests --test ported_iofuncs`: the cell compiles and its 5 tests pass (that change was reverted, no tests-repo commit rides here).

## For the tests-repo enablement PR (carries the un-ignore + `Closes`)

Two test-side edits belong there, not in core:

1. Add `decode_file_with_options` to the `use libviprs::{...}` import in `ported_iofuncs.rs` (it is called unqualified but not imported).
2. Relax one assertion in `test_new_from_image`. `assert_eq!(im2.format(), im.format())` compares the full `PixelFormat`, but libvips' `format` is the sample type (`BandFormat`) alone, independent of band count. libviprs' `PixelFormat` couples band count with depth, so the 1-band constant built from the 3-band `sample.jpg` is `Gray8`, not `Rgb8`, and the strict equality cannot hold for any correct implementation. The faithful equivalent compares the sample depth: `assert_eq!(im2.format().bytes_per_channel(), im.format().bytes_per_channel())`. With that single line, all 5 tests pass against this branch (verified locally).
