### PR TITLE
feat(foreign): deferred-format stubs and thin foreign extensions (#77)

### DIFF
--- a/src/foreign_stubs.rs
+++ b/src/foreign_stubs.rs
@@ -1,0 +1,531 @@
+//! Deferred foreign-format surface: typed stubs for genuinely-external
+//! codecs, plus the in-memory DeepZoom zip writer.
+//!
+//! The ported foreign and connection cells reference a set of encoders and
+//! decoders for formats that have no mature pure-Rust implementation yet
+//! (HEIF/AVIF, JPEG 2000, JPEG XL, Ultra HDR, the ImageMagick delegate, SVG
+//! rasterisation, OpenSlide, and the libvips `fail_on` strictness knob). This
+//! module supplies those symbols so the cells compile and pin the typed error
+//! path:
+//!
+//! * The deferred **encoders** on [`Raster`] return
+//!   [`EncodeError::Unsupported`] naming the format, so a call site asserts on
+//!   the typed error rather than a panic.
+//! * The deferred **decoders** are free functions that return
+//!   [`DecodeError`] (an alias of [`crate::source::SourceError`]) naming the
+//!   capability that is not available in this build.
+//! * [`Raster::dzsave_buffer`] is real: it packs a DeepZoom manifest and the
+//!   image tile into a valid, self-contained zip in memory. The zip container
+//!   is written by hand (STORE method, CRC-32 via `flate2`) because the
+//!   `zip`-crate path lives behind the optional `packfile` feature.
+//!
+//! When a pure-Rust or delegate backend for one of these formats lands, the
+//! stub body is replaced with the real codec while the signature stays put.
+
+use std::path::Path;
+
+use crate::codec::{DecodeError, EncodeError};
+use crate::raster::Raster;
+
+/// Options for the ImageMagick/GraphicsMagick delegate loader
+/// ([`magickload_with`]), mirroring the libvips `magickload` load options the
+/// ported foreign cell exercises.
+///
+/// Every field is optional and defaults to `None`, so callers set only the
+/// options they need with struct-update syntax
+/// (`MagickLoadOptions { n: Some(-1), ..Default::default() }`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MagickLoadOptions {
+    /// Rendering density passed to the delegate (libvips `density`), for
+    /// vector inputs such as SVG. A higher density rasterises at a larger
+    /// pixel size. Expressed as the delegate's density string (for example
+    /// `"100"` or `"200"`).
+    pub density: Option<&'static str>,
+    /// First page/frame to load (libvips `page`), zero-based.
+    pub page: Option<i32>,
+    /// Number of pages/frames to load (libvips `n`); `-1` loads all of them.
+    pub n: Option<i32>,
+}
+
+/// Build a [`DecodeError`] that names a decode capability the pure-Rust build
+/// does not provide yet. The message carries `what` so the ported cells and
+/// the in-crate tests can assert on the format name.
+fn decode_unavailable(what: impl std::fmt::Display) -> DecodeError {
+    DecodeError::Io(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        format!("{what} is not available in this build"),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Deferred encoders (typed Unsupported)
+// ---------------------------------------------------------------------------
+
+impl Raster {
+    /// Encode as HEIF/AVIF with the given quality and compression codec
+    /// (libvips `heifsave`, `compression` = `"av1"`, `"hevc"`, ...).
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`]: HEIF/AVIF encoding needs an
+    /// external `libheif`/`libaom` path that the pure-Rust build does not
+    /// provide.
+    pub fn encode_heif(&self, quality: u8, compression: &str) -> Result<Vec<u8>, EncodeError> {
+        let _ = (quality, compression);
+        Err(EncodeError::unsupported("heif"))
+    }
+
+    /// Encode as lossless HEIF/AVIF (libvips `heifsave` with `lossless`).
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`]; see [`Raster::encode_heif`].
+    pub fn encode_heif_lossless(&self, compression: &str) -> Result<Vec<u8>, EncodeError> {
+        let _ = compression;
+        Err(EncodeError::unsupported("heif"))
+    }
+
+    /// Encode as HEIF/AVIF with explicit chroma sub-sampling control.
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`]; see [`Raster::encode_heif`].
+    pub fn encode_heif_chroma(
+        &self,
+        quality: u8,
+        compression: &str,
+        subsample: bool,
+    ) -> Result<Vec<u8>, EncodeError> {
+        let _ = (quality, compression, subsample);
+        Err(EncodeError::unsupported("heif"))
+    }
+
+    /// Encode as lossless HEIF/AVIF at a specific stored bit depth (libvips
+    /// `heifsave` with `lossless` and `bitdepth`).
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`]; see [`Raster::encode_heif`].
+    pub fn encode_heif_lossless_bitdepth(
+        &self,
+        compression: &str,
+        bitdepth: u32,
+    ) -> Result<Vec<u8>, EncodeError> {
+        let _ = (compression, bitdepth);
+        Err(EncodeError::unsupported("heif"))
+    }
+
+    /// Encode as HEIF/AVIF with an encoder tuning parameter (libvips
+    /// `heifsave` with `encoder`/`tune`, for example `"ssim"`).
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`]; see [`Raster::encode_heif`].
+    pub fn encode_heif_tune(
+        &self,
+        quality: u8,
+        compression: &str,
+        tune: &str,
+    ) -> Result<Vec<u8>, EncodeError> {
+        let _ = (quality, compression, tune);
+        Err(EncodeError::unsupported("heif"))
+    }
+
+    /// Encode as JPEG 2000 (libvips `jp2ksave`), lossy or lossless.
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`]: JPEG 2000 encoding needs an
+    /// external `libopenjp2` path.
+    pub fn encode_jp2k(&self, quality: u8, lossless: bool) -> Result<Vec<u8>, EncodeError> {
+        let _ = (quality, lossless);
+        Err(EncodeError::unsupported("jp2k"))
+    }
+
+    /// Encode as JPEG 2000 with explicit chroma sub-sampling control.
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`]; see [`Raster::encode_jp2k`].
+    pub fn encode_jp2k_chroma(
+        &self,
+        quality: u8,
+        lossless: bool,
+        subsample: bool,
+    ) -> Result<Vec<u8>, EncodeError> {
+        let _ = (quality, lossless, subsample);
+        Err(EncodeError::unsupported("jp2k"))
+    }
+
+    /// Encode as JPEG XL (libvips `jxlsave`), lossy or lossless.
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`]: JPEG XL encoding needs an
+    /// external `libjxl` path.
+    pub fn encode_jxl(&self, lossless: bool) -> Result<Vec<u8>, EncodeError> {
+        let _ = lossless;
+        Err(EncodeError::unsupported("jxl"))
+    }
+
+    /// Encode as Ultra HDR (gain-map JPEG; libvips `uhdrsave`).
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`]: Ultra HDR encoding needs an
+    /// external `libultrahdr` path.
+    pub fn encode_uhdr(&self, quality: u8) -> Result<Vec<u8>, EncodeError> {
+        let _ = quality;
+        Err(EncodeError::unsupported("uhdr"))
+    }
+
+    /// Encode as Ultra HDR with an explicit gain-map scale factor.
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`]; see [`Raster::encode_uhdr`].
+    pub fn encode_uhdr_gainmap_scale(
+        &self,
+        quality: u8,
+        scale_factor: u32,
+    ) -> Result<Vec<u8>, EncodeError> {
+        let _ = (quality, scale_factor);
+        Err(EncodeError::unsupported("uhdr"))
+    }
+
+    /// Encode via the ImageMagick/GraphicsMagick delegate to a buffer in the
+    /// given format (libvips `magicksave_buffer`, `format` = `".png"`,
+    /// `".gif"`, ...).
+    ///
+    /// # Errors
+    ///
+    /// Always [`EncodeError::Unsupported`], naming the requested `format`:
+    /// the magick delegate is an external dependency the pure-Rust build does
+    /// not link.
+    pub fn magicksave_buffer(&self, format: &str) -> Result<Vec<u8>, EncodeError> {
+        Err(EncodeError::unsupported(format))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deferred decoders (typed decode error)
+// ---------------------------------------------------------------------------
+
+/// Load an image through the ImageMagick/GraphicsMagick delegate (libvips
+/// `magickload`).
+///
+/// # Errors
+///
+/// Always a [`DecodeError`] naming the magick delegate: it is an external
+/// dependency the pure-Rust build does not link.
+pub fn magickload(path: &Path) -> Result<Raster, DecodeError> {
+    Err(decode_unavailable(format!(
+        "magick load of {}",
+        path.display()
+    )))
+}
+
+/// Load an image through the magick delegate with [`MagickLoadOptions`].
+///
+/// # Errors
+///
+/// Always a [`DecodeError`]; see [`magickload`].
+pub fn magickload_with(path: &Path, opts: MagickLoadOptions) -> Result<Raster, DecodeError> {
+    let _ = opts;
+    Err(decode_unavailable(format!(
+        "magick load of {}",
+        path.display()
+    )))
+}
+
+/// Rasterise an SVG document from bytes at an optional DPI (libvips
+/// `svgload_buffer`).
+///
+/// # Errors
+///
+/// Always a [`DecodeError`]: SVG rasterisation needs an external `librsvg`
+/// path.
+pub fn decode_svg(data: &[u8], dpi: Option<f64>) -> Result<Raster, DecodeError> {
+    let _ = (data, dpi);
+    Err(decode_unavailable("SVG rasterisation"))
+}
+
+/// Open a whole-slide image at the given pyramid level through OpenSlide
+/// (libvips `openslideload`).
+///
+/// # Errors
+///
+/// Always a [`DecodeError`]: OpenSlide is an external dependency the
+/// pure-Rust build does not link.
+pub fn decode_openslide(path: &Path, level: u32) -> Result<Raster, DecodeError> {
+    Err(decode_unavailable(format!(
+        "OpenSlide load of {} at level {level}",
+        path.display()
+    )))
+}
+
+/// Decode a file with a libvips `fail_on` strictness level (`"none"`,
+/// `"truncated"`, `"warning"`, `"error"`).
+///
+/// # Errors
+///
+/// Always a [`DecodeError`]: the `fail_on` strictness knob needs decoder
+/// warning/truncation reporting that the pure-Rust decode path does not
+/// surface yet.
+pub fn decode_file_fail_on(path: &Path, fail_on: &str) -> Result<Raster, DecodeError> {
+    Err(decode_unavailable(format!(
+        "fail_on={fail_on:?} strict decode of {}",
+        path.display()
+    )))
+}
+
+/// Decode a memory buffer with a libvips `fail_on` strictness level.
+///
+/// # Errors
+///
+/// Always a [`DecodeError`]; see [`decode_file_fail_on`].
+pub fn decode_bytes_fail_on(data: &[u8], fail_on: &str) -> Result<Raster, DecodeError> {
+    let _ = data;
+    Err(decode_unavailable(format!(
+        "fail_on={fail_on:?} strict decode"
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// DeepZoom to an in-memory zip (real)
+// ---------------------------------------------------------------------------
+
+impl Raster {
+    /// Save the raster as a DeepZoom image set packed into an in-memory zip
+    /// blob (libvips `dzsave_buffer`).
+    ///
+    /// The blob is a valid, self-contained zip carrying the DeepZoom `.dzi`
+    /// manifest for the raster's dimensions plus the image tile. It is
+    /// written with the STORE method (no compression) and a hand-computed
+    /// CRC-32, so it depends only on the always-present `flate2` crate rather
+    /// than the optional `packfile`/`zip` path.
+    pub fn dzsave_buffer(&self) -> Vec<u8> {
+        const STEM: &str = "image";
+        const TILE_SIZE: u32 = 256;
+
+        let dzi = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <Image xmlns=\"http://schemas.microsoft.com/deepzoom/2008\" \
+             Format=\"raw\" Overlap=\"0\" TileSize=\"{tile}\">\n  \
+             <Size Width=\"{w}\" Height=\"{h}\"/>\n</Image>\n",
+            tile = TILE_SIZE,
+            w = self.width(),
+            h = self.height(),
+        );
+
+        let entries = [
+            ZipEntry::new(format!("{STEM}.dzi"), dzi.into_bytes()),
+            ZipEntry::new(format!("{STEM}_files/0/0_0.raw"), self.data().to_vec()),
+        ];
+        write_store_zip(&entries)
+    }
+}
+
+/// One STORE-method zip entry, with its CRC-32 pre-computed.
+struct ZipEntry {
+    name: String,
+    data: Vec<u8>,
+    crc: u32,
+}
+
+impl ZipEntry {
+    fn new(name: String, data: Vec<u8>) -> Self {
+        let mut crc = flate2::Crc::new();
+        crc.update(&data);
+        let crc = crc.sum();
+        Self { name, data, crc }
+    }
+}
+
+/// Append a little-endian `u16`.
+fn push_u16(out: &mut Vec<u8>, value: u16) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+/// Append a little-endian `u32`.
+fn push_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+/// Write the given entries into a minimal but valid STORE-method zip archive.
+///
+/// The layout is the standard sequence of local file headers and stored data,
+/// followed by the central directory and the end-of-central-directory record,
+/// all little-endian (APPNOTE 6.3, no compression, no Zip64).
+fn write_store_zip(entries: &[ZipEntry]) -> Vec<u8> {
+    // 1980-01-01 as the fixed DOS timestamp, so the output is reproducible.
+    const DOS_TIME: u16 = 0;
+    const DOS_DATE: u16 = 0x0021;
+
+    let mut out = Vec::new();
+    let mut offsets = Vec::with_capacity(entries.len());
+
+    for entry in entries {
+        offsets.push(out.len() as u32);
+        let size = entry.data.len() as u32;
+        push_u32(&mut out, 0x0403_4b50); // local file header signature
+        push_u16(&mut out, 20); // version needed to extract
+        push_u16(&mut out, 0); // general purpose flags
+        push_u16(&mut out, 0); // compression method: store
+        push_u16(&mut out, DOS_TIME);
+        push_u16(&mut out, DOS_DATE);
+        push_u32(&mut out, entry.crc);
+        push_u32(&mut out, size); // compressed size
+        push_u32(&mut out, size); // uncompressed size
+        push_u16(&mut out, entry.name.len() as u16);
+        push_u16(&mut out, 0); // extra field length
+        out.extend_from_slice(entry.name.as_bytes());
+        out.extend_from_slice(&entry.data);
+    }
+
+    let central_offset = out.len() as u32;
+    let mut central = Vec::new();
+    for (entry, &offset) in entries.iter().zip(offsets.iter()) {
+        let size = entry.data.len() as u32;
+        push_u32(&mut central, 0x0201_4b50); // central directory header signature
+        push_u16(&mut central, 20); // version made by
+        push_u16(&mut central, 20); // version needed to extract
+        push_u16(&mut central, 0); // general purpose flags
+        push_u16(&mut central, 0); // compression method: store
+        push_u16(&mut central, DOS_TIME);
+        push_u16(&mut central, DOS_DATE);
+        push_u32(&mut central, entry.crc);
+        push_u32(&mut central, size); // compressed size
+        push_u32(&mut central, size); // uncompressed size
+        push_u16(&mut central, entry.name.len() as u16);
+        push_u16(&mut central, 0); // extra field length
+        push_u16(&mut central, 0); // file comment length
+        push_u16(&mut central, 0); // disk number start
+        push_u16(&mut central, 0); // internal file attributes
+        push_u32(&mut central, 0); // external file attributes
+        push_u32(&mut central, offset); // relative offset of local header
+        central.extend_from_slice(entry.name.as_bytes());
+    }
+
+    let central_size = central.len() as u32;
+    out.extend_from_slice(&central);
+
+    push_u32(&mut out, 0x0605_4b50); // end of central directory signature
+    push_u16(&mut out, 0); // number of this disk
+    push_u16(&mut out, 0); // disk with the central directory
+    push_u16(&mut out, entries.len() as u16); // entries on this disk
+    push_u16(&mut out, entries.len() as u16); // total entries
+    push_u32(&mut out, central_size);
+    push_u32(&mut out, central_offset);
+    push_u16(&mut out, 0); // zip comment length
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pixel::PixelFormat;
+
+    fn rgb_raster(w: u32, h: u32) -> Raster {
+        let data = vec![128u8; w as usize * h as usize * 3];
+        Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    #[test]
+    fn encode_heif_reports_unsupported_naming_the_format() {
+        let im = rgb_raster(4, 4);
+        let err = im.encode_heif(50, "av1").unwrap_err();
+        assert!(matches!(err, EncodeError::Unsupported { .. }));
+        assert_eq!(err.to_string(), "unsupported encode format: heif");
+    }
+
+    #[test]
+    fn deferred_encoders_all_report_their_format() {
+        let im = rgb_raster(4, 4);
+        for (err, format) in [
+            (im.encode_heif_lossless("av1").unwrap_err(), "heif"),
+            (im.encode_heif_chroma(50, "av1", true).unwrap_err(), "heif"),
+            (
+                im.encode_heif_lossless_bitdepth("hevc", 8).unwrap_err(),
+                "heif",
+            ),
+            (im.encode_heif_tune(50, "av1", "ssim").unwrap_err(), "heif"),
+            (im.encode_jp2k(50, false).unwrap_err(), "jp2k"),
+            (im.encode_jp2k_chroma(50, false, true).unwrap_err(), "jp2k"),
+            (im.encode_jxl(true).unwrap_err(), "jxl"),
+            (im.encode_uhdr(75).unwrap_err(), "uhdr"),
+            (im.encode_uhdr_gainmap_scale(75, 4).unwrap_err(), "uhdr"),
+        ] {
+            match err {
+                EncodeError::Unsupported { format: got } => assert_eq!(got, format),
+                other => panic!("expected Unsupported, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn magicksave_buffer_names_the_requested_format() {
+        let im = rgb_raster(4, 4);
+        let err = im.magicksave_buffer(".png").unwrap_err();
+        assert_eq!(err.to_string(), "unsupported encode format: .png");
+    }
+
+    #[test]
+    fn deferred_decoders_report_a_typed_error() {
+        let path = Path::new("/nonexistent/slide.svs");
+        assert!(magickload(path).is_err());
+        assert!(magickload_with(path, MagickLoadOptions::default()).is_err());
+        assert!(decode_openslide(path, 0).is_err());
+        assert!(decode_file_fail_on(path, "warning").is_err());
+
+        let svg = b"<svg/>";
+        let err = decode_svg(svg, None).unwrap_err();
+        assert!(err.to_string().contains("SVG"));
+
+        let err = decode_bytes_fail_on(b"1,2,3", "truncated").unwrap_err();
+        assert!(err.to_string().contains("truncated"));
+    }
+
+    #[test]
+    fn magick_load_options_supports_struct_update() {
+        // The ported cell builds these three shapes; keep them compiling.
+        let a = MagickLoadOptions {
+            density: Some("100"),
+            ..Default::default()
+        };
+        let b = MagickLoadOptions {
+            n: Some(-1),
+            ..Default::default()
+        };
+        let c = MagickLoadOptions {
+            page: Some(1),
+            n: Some(2),
+            ..Default::default()
+        };
+        assert_eq!(a.density, Some("100"));
+        assert_eq!(b.n, Some(-1));
+        assert_eq!(c.page, Some(1));
+        assert_eq!(c.n, Some(2));
+    }
+
+    #[test]
+    fn dzsave_buffer_is_a_valid_nontrivial_zip() {
+        let im = rgb_raster(64, 64);
+        let blob = im.dzsave_buffer();
+
+        // Local file header magic and the end-of-central-directory magic.
+        assert_eq!(&blob[..4], &[0x50, 0x4b, 0x03, 0x04]);
+        assert!(blob.len() > 1000, "blob was {} bytes", blob.len());
+        assert!(
+            blob.windows(4).any(|w| w == [0x50, 0x4b, 0x05, 0x06]),
+            "missing end-of-central-directory record"
+        );
+        // The DZI manifest names the raster's dimensions.
+        assert!(
+            blob.windows(b"Width=\"64\"".len())
+                .any(|w| w == b"Width=\"64\""),
+            "manifest should carry the raster width"
+        );
+    }
+}

--- a/src/imageio.rs
+++ b/src/imageio.rs
@@ -490,6 +490,21 @@ impl Raster {
         })
     }
 
+    /// Read a metadata field as an `i32` (libvips `vips_image_get_int`).
+    ///
+    /// Resolves `name` through [`Raster::get_field`] and returns the value
+    /// when it is an integer that fits in an `i32` (for example the built-in
+    /// `width`/`height`/`bands` header fields, or an attached field such as
+    /// `bits-per-sample`, `tile-width`, or `page-height` set by a loader).
+    /// Returns `None` for an absent field, a non-integer value, or an integer
+    /// outside the `i32` range.
+    pub fn get_int(&self, name: &str) -> Option<i32> {
+        match self.get_field(name)? {
+            MetadataValue::Int(value) => i32::try_from(value).ok(),
+            _ => None,
+        }
+    }
+
     /// Fallible form of [`Raster::set_field`].
     ///
     /// # Errors
@@ -1472,6 +1487,29 @@ mod tests {
         assert!(r.is_err());
         let r = std::panic::catch_unwind(|| MetadataValue::Int(-1).as_u32());
         assert!(r.is_err());
+    }
+
+    /**
+     * Tests `get_int` coerces integer fields (built-in `bands` and an
+     * attached loader field) to `i32`, and returns `None` for an absent
+     * field, a non-integer value, and an out-of-`i32`-range integer.
+     */
+    #[test]
+    fn get_int_reads_integer_fields() {
+        let mut im = rgb_2x2();
+        // Built-in header field resolves through get_field as an Int.
+        assert_eq!(im.get_int("bands"), Some(3));
+
+        // An attached loader-style field round-trips through get_int.
+        im.set_field("bits-per-sample", MetadataValue::Int(8));
+        assert_eq!(im.get_int("bits-per-sample"), Some(8));
+
+        // Absent, non-integer, and out-of-range cases all yield None.
+        assert_eq!(im.get_int("no-such-field"), None);
+        im.set_field("note", "hello".into());
+        assert_eq!(im.get_int("note"), None);
+        im.set_field("huge", MetadataValue::Int(i64::from(i32::MAX) + 1));
+        assert_eq!(im.get_int("huge"), None);
     }
 
     // -- save / .v ----------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub mod engine;
 pub mod engine_builder;
 pub mod extensions;
 pub mod extract;
+pub mod foreign_stubs;
 pub mod freqfilt;
 pub mod geo;
 pub mod histogram;
@@ -132,6 +133,15 @@ pub use engine::{
 };
 pub use engine_builder::{EngineBuilder, EngineKind, EngineSource, IntoEngineSource};
 pub use extract::{CompassDirection, Extend, ExtractError, SmartcropInteresting};
+// The deferred foreign-format free functions and options are re-exported at
+// the root because the ported foreign cell reaches them there
+// (`use libviprs::{magickload, decode_svg, ...}`), matching the imageio
+// convention above. The deferred encoders and `dzsave_buffer` are inherent
+// methods on `Raster`, so they need no re-export.
+pub use foreign_stubs::{
+    MagickLoadOptions, decode_bytes_fail_on, decode_file_fail_on, decode_openslide, decode_svg,
+    magickload, magickload_with,
+};
 pub use freqfilt::FreqfiltError;
 pub use geo::{GeoBounds, GeoCoord, GeoTransform, PixelCoord};
 pub use histogram::HistogramError;
@@ -155,7 +165,10 @@ pub use observe::{
 #[cfg(feature = "pdfium")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pdfium")))]
 pub use pdf::{BudgetRenderResult, render_page_pdfium, render_page_pdfium_budgeted};
-pub use pdf::{PageRotation, PdfError, PdfInfo, PdfPageInfo, extract_page_image, pdf_info};
+pub use pdf::{
+    PageRotation, PdfError, PdfInfo, PdfPageInfo, extract_page_image, extract_page_image_dpi,
+    extract_page_image_with_password, pdf_info, pdf_info_with_password,
+};
 pub use pixel::PixelFormat;
 pub use planner::{
     Layout, LevelPlan, PlannerError, PyramidPlan, PyramidPlanner, TileCoord, TileRect,
@@ -163,6 +176,7 @@ pub use planner::{
 pub use raster::{Raster, RasterError, RegionView};
 pub use resample::{
     AffineOptions, Interpolator, ReduceKernel, ResampleError, ResizeOptions, ThumbnailError,
+    thumbnail, thumbnail_crop,
 };
 pub use resume::{
     CompletedTileSet, JobCheckpoint, JobMetadata, ResumeError, ResumeMode, ResumePolicy,
@@ -178,8 +192,9 @@ pub use sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 #[cfg_attr(docsrs, doc(cfg(feature = "packfile")))]
 pub use sink_packfile::{PackfileFormat, PackfileSink, PackfileSinkBuilder};
 pub use source::{
-    SourceError, clear_load_cache, decode_bytes, decode_file, decode_file_with_options,
-    generate_test_raster, set_load_cache_max_bytes, set_load_cache_max_entries,
+    SourceError, clear_load_cache, decode_bytes, decode_file, decode_file_sequential,
+    decode_file_with_options, decode_file_with_shrink, generate_test_raster,
+    set_load_cache_max_bytes, set_load_cache_max_entries,
 };
 pub use streaming::{
     BudgetPolicy, RasterStripSource, StreamingConfig, StripSource, compute_strip_height,

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -301,6 +301,117 @@ pub fn pdf_info(path: &Path) -> Result<PdfInfo, PdfError> {
     Ok(PdfInfo { page_count, pages })
 }
 
+/// Build a shared decode error naming a PDF capability that is not available
+/// in this build.
+fn decode_unavailable(what: impl std::fmt::Display) -> crate::codec::DecodeError {
+    crate::source::SourceError::Io(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        format!("{what} is not available in this build"),
+    ))
+}
+
+/// Fold a [`PdfError`] into the shared decode error, so the DPI/password
+/// extract helpers can report through the `DecodeError` their contracts name.
+fn pdf_to_decode(err: PdfError) -> crate::codec::DecodeError {
+    crate::source::SourceError::Io(std::io::Error::other(err.to_string()))
+}
+
+/// Read [`PdfInfo`] from a password-protected PDF (libvips `pdfload` with
+/// `password`).
+///
+/// Unencrypted documents open regardless of `password`, so this returns the
+/// same result as [`pdf_info`] for them. Encrypted documents need a
+/// decryption path this pure-Rust build does not provide: when the plain read
+/// fails and a non-empty `password` was supplied, this reports a typed
+/// [`PdfError::UnsupportedFormat`] naming the password-protected case rather
+/// than a decrypted document.
+///
+/// # Errors
+///
+/// [`PdfError::UnsupportedFormat`] for an encrypted document, otherwise the
+/// same errors as [`pdf_info`].
+pub fn pdf_info_with_password(path: &Path, password: &str) -> Result<PdfInfo, PdfError> {
+    match pdf_info(path) {
+        Ok(info) => Ok(info),
+        Err(_) if !password.is_empty() => Err(PdfError::UnsupportedFormat(
+            "password-protected PDF decryption is not available in this build".to_string(),
+        )),
+        Err(err) => Err(err),
+    }
+}
+
+/// Extract a page's embedded image at a target render DPI (libvips `pdfload`
+/// with `dpi`), page numbers 1-based.
+///
+/// With the `pdfium` feature the page is rendered at `dpi` through pdfium, so
+/// the output dimensions scale with the DPI. Without `pdfium` there is no
+/// DPI-controlled rasteriser, so this reports a typed decode error: embedded
+/// extraction ([`extract_page_image`]) returns images at their stored size
+/// and cannot honour a DPI.
+///
+/// # Errors
+///
+/// A [`crate::codec::DecodeError`]: an unsupported-capability error without
+/// `pdfium`, an invalid-input error for a non-positive DPI or a zero page,
+/// otherwise the rasteriser's error folded into the decode error.
+pub fn extract_page_image_dpi(
+    path: &Path,
+    page: u32,
+    dpi: f64,
+) -> Result<Raster, crate::codec::DecodeError> {
+    #[cfg(feature = "pdfium")]
+    {
+        if page == 0 {
+            return Err(crate::source::SourceError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "page index must be >= 1",
+            )));
+        }
+        if !(dpi.is_finite() && dpi >= 1.0) {
+            return Err(crate::source::SourceError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("dpi must be finite and >= 1, got {dpi}"),
+            )));
+        }
+        let dpi_u32 = dpi.round() as u32;
+        render_page_pdfium(path, page as usize, dpi_u32).map_err(pdf_to_decode)
+    }
+    #[cfg(not(feature = "pdfium"))]
+    {
+        let _ = (path, page, dpi);
+        Err(decode_unavailable(
+            "PDF rendering at a specified DPI (requires the `pdfium` feature)",
+        ))
+    }
+}
+
+/// Extract a page image from a password-protected PDF (libvips `pdfload` with
+/// `password`), page numbers 1-based.
+///
+/// Unencrypted documents extract regardless of `password`. Encrypted
+/// documents need a decryption path this build does not provide: when the
+/// plain extraction fails and a non-empty `password` was supplied, this
+/// reports a typed decode error naming the password-protected case.
+///
+/// # Errors
+///
+/// A [`crate::codec::DecodeError`]: an unsupported-capability error for an
+/// encrypted document, otherwise the extraction error folded into the decode
+/// error.
+pub fn extract_page_image_with_password(
+    path: &Path,
+    page: u32,
+    password: &str,
+) -> Result<Raster, crate::codec::DecodeError> {
+    match extract_page_image(path, page as usize) {
+        Ok(raster) => Ok(raster),
+        Err(_) if !password.is_empty() => {
+            Err(decode_unavailable("password-protected PDF decryption"))
+        }
+        Err(err) => Err(pdf_to_decode(err)),
+    }
+}
+
 /// Resolve a 1-based `page` number to its object id in the `lopdf` page map.
 ///
 /// `lopdf` keys its page map by `u32`, but callers hand us a `usize` page
@@ -1489,6 +1600,29 @@ pub fn render_page_pdfium_budgeted(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pdf_info_with_password_reports_encrypted_as_unsupported() {
+        let bogus = Path::new("/nonexistent/secret.pdf");
+        // A non-empty password on an unreadable/encrypted document reports the
+        // typed unsupported-capability error.
+        match pdf_info_with_password(bogus, "secret") {
+            Err(PdfError::UnsupportedFormat(msg)) => {
+                assert!(msg.contains("password"), "message was {msg:?}");
+            }
+            other => panic!("expected UnsupportedFormat, got {other:?}"),
+        }
+        // An empty password surfaces the underlying open error unchanged.
+        assert!(pdf_info_with_password(bogus, "").is_err());
+    }
+
+    #[test]
+    fn password_and_dpi_extract_return_a_clean_typed_error() {
+        let bogus = Path::new("/nonexistent/secret.pdf");
+        // Both return the shared DecodeError without panicking.
+        assert!(extract_page_image_with_password(bogus, 1, "secret").is_err());
+        assert!(extract_page_image_dpi(bogus, 1, 72.0).is_err());
+    }
 
     /// Regression for #91: `page_object_id` must range-check the `usize -> u32`
     /// page-number narrowing. A page number at or above `2^32` truncates under

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -281,14 +281,20 @@ pub struct PdfPageInfo {
 /// **See also:** [interactive example](https://libviprs.org/cli/#info)
 pub fn pdf_info(path: &Path) -> Result<PdfInfo, PdfError> {
     let doc = lopdf::Document::load(path).map_err(|e| PdfError::Parse(e.to_string()))?;
+    Ok(pdf_info_from_doc(&doc))
+}
+
+/// Build a [`PdfInfo`] from an already-loaded document. Shared by [`pdf_info`]
+/// and [`pdf_info_with_password`] so the loaded document is walked once.
+fn pdf_info_from_doc(doc: &lopdf::Document) -> PdfInfo {
     let pages_map = doc.get_pages();
     let page_count = pages_map.len();
     let mut pages = Vec::with_capacity(page_count);
 
     // Pages are returned as BTreeMap<u32, ObjectId>, sorted by page number
     for (&page_num, &page_id) in &pages_map {
-        let (width_pts, height_pts) = get_page_dimensions(&doc, page_id);
-        let has_images = page_has_images(&doc, page_id);
+        let (width_pts, height_pts) = get_page_dimensions(doc, page_id);
+        let has_images = page_has_images(doc, page_id);
 
         pages.push(PdfPageInfo {
             page_number: page_num as usize,
@@ -298,7 +304,7 @@ pub fn pdf_info(path: &Path) -> Result<PdfInfo, PdfError> {
         });
     }
 
-    Ok(PdfInfo { page_count, pages })
+    PdfInfo { page_count, pages }
 }
 
 /// Build a shared decode error naming a PDF capability that is not available
@@ -320,24 +326,30 @@ fn pdf_to_decode(err: PdfError) -> crate::codec::DecodeError {
 /// `password`).
 ///
 /// Unencrypted documents open regardless of `password`, so this returns the
-/// same result as [`pdf_info`] for them. Encrypted documents need a
-/// decryption path this pure-Rust build does not provide: when the plain read
-/// fails and a non-empty `password` was supplied, this reports a typed
-/// [`PdfError::UnsupportedFormat`] naming the password-protected case rather
-/// than a decrypted document.
+/// same result as [`pdf_info`] for them. Encrypted documents need a decryption
+/// path this pure-Rust build does not provide: only when the opened document
+/// actually carries an encryption dictionary (`lopdf`'s
+/// [`is_encrypted`](lopdf::Document::is_encrypted)) and a non-empty `password`
+/// was supplied does this report a typed [`PdfError::UnsupportedFormat`] naming
+/// the password-protected case. A missing, unreadable, or malformed file
+/// surfaces its real IO/parse error unchanged rather than being mislabelled as
+/// password-protected.
 ///
 /// # Errors
 ///
-/// [`PdfError::UnsupportedFormat`] for an encrypted document, otherwise the
-/// same errors as [`pdf_info`].
+/// [`PdfError::UnsupportedFormat`] for an encrypted document opened with a
+/// non-empty password, otherwise the same errors as [`pdf_info`].
 pub fn pdf_info_with_password(path: &Path, password: &str) -> Result<PdfInfo, PdfError> {
-    match pdf_info(path) {
-        Ok(info) => Ok(info),
-        Err(_) if !password.is_empty() => Err(PdfError::UnsupportedFormat(
+    // Open first so a missing/unreadable/malformed file surfaces its real
+    // IO/parse error. `lopdf` loads an encrypted document's structure without
+    // decrypting its streams, so the encryption dictionary is observable here.
+    let doc = lopdf::Document::load(path).map_err(|e| PdfError::Parse(e.to_string()))?;
+    if !password.is_empty() && doc.is_encrypted() {
+        return Err(PdfError::UnsupportedFormat(
             "password-protected PDF decryption is not available in this build".to_string(),
-        )),
-        Err(err) => Err(err),
+        ));
     }
+    Ok(pdf_info_from_doc(&doc))
 }
 
 /// Extract a page's embedded image at a target render DPI (libvips `pdfload`
@@ -388,28 +400,34 @@ pub fn extract_page_image_dpi(
 /// Extract a page image from a password-protected PDF (libvips `pdfload` with
 /// `password`), page numbers 1-based.
 ///
-/// Unencrypted documents extract regardless of `password`. Encrypted
-/// documents need a decryption path this build does not provide: when the
-/// plain extraction fails and a non-empty `password` was supplied, this
-/// reports a typed decode error naming the password-protected case.
+/// Unencrypted documents extract regardless of `password`. Encrypted documents
+/// need a decryption path this build does not provide: only when the opened
+/// document actually carries an encryption dictionary (`lopdf`'s
+/// [`is_encrypted`](lopdf::Document::is_encrypted)) and a non-empty `password`
+/// was supplied does this report a typed unsupported-capability decode error
+/// naming the password-protected case. A missing, unreadable, or malformed file
+/// surfaces its real IO/parse error folded into the decode error rather than
+/// being mislabelled as password-protected.
 ///
 /// # Errors
 ///
 /// A [`crate::codec::DecodeError`]: an unsupported-capability error for an
-/// encrypted document, otherwise the extraction error folded into the decode
-/// error.
+/// encrypted document opened with a non-empty password, otherwise the
+/// extraction error folded into the decode error.
 pub fn extract_page_image_with_password(
     path: &Path,
     page: u32,
     password: &str,
 ) -> Result<Raster, crate::codec::DecodeError> {
-    match extract_page_image(path, page as usize) {
-        Ok(raster) => Ok(raster),
-        Err(_) if !password.is_empty() => {
-            Err(decode_unavailable("password-protected PDF decryption"))
-        }
-        Err(err) => Err(pdf_to_decode(err)),
+    // Open first so a missing/unreadable/malformed file surfaces its real
+    // error. Only a genuinely encrypted document folds to the
+    // password-protected capability error.
+    let doc =
+        lopdf::Document::load(path).map_err(|e| pdf_to_decode(PdfError::Parse(e.to_string())))?;
+    if !password.is_empty() && doc.is_encrypted() {
+        return Err(decode_unavailable("password-protected PDF decryption"));
     }
+    extract_page_image_from_doc(&doc, page as usize).map_err(pdf_to_decode)
 }
 
 /// Resolve a 1-based `page` number to its object id in the `lopdf` page map.
@@ -526,10 +544,17 @@ pub(crate) fn pdfium_page_index(
 /// uses this when the page has embedded images).
 pub fn extract_page_image(path: &Path, page: usize) -> Result<Raster, PdfError> {
     let doc = lopdf::Document::load(path).map_err(|e| PdfError::Parse(e.to_string()))?;
+    extract_page_image_from_doc(&doc, page)
+}
+
+/// Extract the largest embedded image from a page of an already-loaded
+/// document. Shared by [`extract_page_image`] and
+/// [`extract_page_image_with_password`] so the document is loaded once.
+fn extract_page_image_from_doc(doc: &lopdf::Document, page: usize) -> Result<Raster, PdfError> {
     let pages_map = doc.get_pages();
     let page_id = page_object_id(&pages_map, page)?;
 
-    extract_largest_image(&doc, page_id, page)
+    extract_largest_image(doc, page_id, page)
 }
 
 /// Maximum permitted PDF image dimension, in pixels per axis.
@@ -1601,27 +1626,99 @@ pub fn render_page_pdfium_budgeted(
 mod tests {
     use super::*;
 
+    /// Save a `lopdf` document to a fresh temp file and return the directory
+    /// (kept alive for the file's lifetime) alongside the path.
+    fn save_doc(mut doc: lopdf::Document) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("doc.pdf");
+        doc.save(&path).unwrap();
+        (dir, path)
+    }
+
+    /// A minimal, readable, unencrypted 1-page PDF on disk.
+    fn save_plain_pdf() -> (tempfile::TempDir, std::path::PathBuf) {
+        let (doc, _page_id) = build_rotated_doc([0.0, 0.0, 100.0, 100.0], None, None);
+        save_doc(doc)
+    }
+
+    /// A 1-page PDF carrying a standard-security `/Encrypt` dictionary, so the
+    /// reloaded document reports `is_encrypted()`. Per the PDF spec the
+    /// encryption dictionary itself is not encrypted, so no crypto is needed to
+    /// make the file parse and read back as encrypted.
+    fn save_encrypted_pdf() -> (tempfile::TempDir, std::path::PathBuf) {
+        use lopdf::{Object, dictionary};
+        let (mut doc, _page_id) = build_rotated_doc([0.0, 0.0, 100.0, 100.0], None, None);
+        let encrypt_id = doc.add_object(dictionary! {
+            "Filter" => "Standard",
+            "V" => 1i64,
+            "R" => 2i64,
+            "P" => -1i64,
+        });
+        doc.trailer.set("Encrypt", Object::Reference(encrypt_id));
+        save_doc(doc)
+    }
+
     #[test]
     fn pdf_info_with_password_reports_encrypted_as_unsupported() {
-        let bogus = Path::new("/nonexistent/secret.pdf");
-        // A non-empty password on an unreadable/encrypted document reports the
-        // typed unsupported-capability error.
-        match pdf_info_with_password(bogus, "secret") {
+        // A genuinely encrypted document (one carrying an /Encrypt dictionary)
+        // opened with a non-empty password reports the typed
+        // unsupported-capability error, since this build cannot decrypt it.
+        let (_dir, path) = save_encrypted_pdf();
+        match pdf_info_with_password(&path, "secret") {
             Err(PdfError::UnsupportedFormat(msg)) => {
                 assert!(msg.contains("password"), "message was {msg:?}");
             }
             other => panic!("expected UnsupportedFormat, got {other:?}"),
         }
-        // An empty password surfaces the underlying open error unchanged.
+    }
+
+    #[test]
+    fn pdf_info_with_password_passes_through_open_error() {
+        // A missing/unreadable file must surface its real open error, not the
+        // password-protected message, even when a password is supplied.
+        let bogus = Path::new("/nonexistent/secret.pdf");
+        match pdf_info_with_password(bogus, "secret") {
+            Err(PdfError::Parse(msg)) => {
+                assert!(!msg.contains("password"), "message was {msg:?}");
+            }
+            other => panic!("expected the underlying open error, got {other:?}"),
+        }
+        // An empty password behaves identically.
         assert!(pdf_info_with_password(bogus, "").is_err());
+    }
+
+    #[test]
+    fn pdf_info_with_password_ignores_password_on_unencrypted_doc() {
+        // A normal, readable document is not mislabelled as password-protected
+        // just because a password was supplied.
+        let (_dir, path) = save_plain_pdf();
+        let info = pdf_info_with_password(&path, "secret").expect("plain doc reads back");
+        assert_eq!(info.page_count, 1);
     }
 
     #[test]
     fn password_and_dpi_extract_return_a_clean_typed_error() {
         let bogus = Path::new("/nonexistent/secret.pdf");
-        // Both return the shared DecodeError without panicking.
-        assert!(extract_page_image_with_password(bogus, 1, "secret").is_err());
+        // A missing file surfaces its real error folded into the decode error,
+        // not the password-protected capability message.
+        let err = extract_page_image_with_password(bogus, 1, "secret").unwrap_err();
+        assert!(
+            !err.to_string().contains("password-protected"),
+            "missing file was mislabelled: {err}"
+        );
         assert!(extract_page_image_dpi(bogus, 1, 72.0).is_err());
+    }
+
+    #[test]
+    fn extract_page_image_with_password_reports_encrypted_as_unsupported() {
+        // An encrypted document opened with a password folds to the typed
+        // password-protected capability error.
+        let (_dir, path) = save_encrypted_pdf();
+        let err = extract_page_image_with_password(&path, 1, "secret").unwrap_err();
+        assert!(
+            err.to_string().contains("password-protected"),
+            "encrypted doc should report password-protected, got: {err}"
+        );
     }
 
     /// Regression for #91: `page_object_id` must range-check the `usize -> u32`

--- a/src/resample.rs
+++ b/src/resample.rs
@@ -2609,6 +2609,51 @@ impl Raster {
     }
 }
 
+/// Map a [`ThumbnailError`] onto the shared decode error, preserving the
+/// decode cause and folding the resample/colour/crop steps into an I/O error.
+fn thumbnail_to_decode(err: ThumbnailError) -> crate::codec::DecodeError {
+    match err {
+        ThumbnailError::Decode(source) => source,
+        other => crate::source::SourceError::Io(std::io::Error::other(other.to_string())),
+    }
+}
+
+/// Make a thumbnail from an image file, bounded by `width` (libvips
+/// `vips_thumbnail` bare-width form).
+///
+/// A convenience free function over [`Raster::try_thumbnail`] returning the
+/// shared [`crate::codec::DecodeError`], matching the ported foreign cell's
+/// `thumbnail(path, width)` surface. The image is loaded and shrunk to fit
+/// inside a `width` x `width` box, preserving aspect ratio.
+///
+/// # Errors
+///
+/// A [`crate::codec::DecodeError`] when the file cannot be read or decoded,
+/// or when the resample step fails.
+pub fn thumbnail(path: &Path, width: u32) -> Result<Raster, crate::codec::DecodeError> {
+    Raster::try_thumbnail(path, width, None, false).map_err(thumbnail_to_decode)
+}
+
+/// Make a thumbnail from an image file into a `width` x `height` box with a
+/// crop mode (libvips `vips_thumbnail` with `crop`).
+///
+/// `crop` selects the fit: `"none"` (or an empty string) fits inside the box
+/// preserving aspect ratio, and any other value (for example `"centre"`)
+/// fills the box and centre-crops to it.
+///
+/// # Errors
+///
+/// As [`thumbnail`], plus the crop step.
+pub fn thumbnail_crop(
+    path: &Path,
+    width: u32,
+    height: u32,
+    crop: &str,
+) -> Result<Raster, crate::codec::DecodeError> {
+    let do_crop = !matches!(crop, "" | "none");
+    Raster::try_thumbnail(path, width, Some(height), do_crop).map_err(thumbnail_to_decode)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3384,5 +3429,44 @@ mod tests {
                 "{interp} overshot the [30, 220] input range: got [{lo}, {hi}]"
             );
         }
+    }
+
+    #[test]
+    fn thumbnail_free_fn_fits_the_width_box() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("thumb_in.png");
+        Raster::new(100, 60, PixelFormat::Rgb8, vec![120u8; 100 * 60 * 3])
+            .unwrap()
+            .save(&path)
+            .unwrap();
+
+        // Bare-width fit into a 50x50 box: shrink = max(100/50, 60/50) = 2.
+        let thumb = super::thumbnail(&path, 50).unwrap();
+        assert_eq!(thumb.width(), 50);
+        assert!(
+            (i64::from(thumb.height()) - 30).abs() <= 1,
+            "height {} not near 30",
+            thumb.height()
+        );
+    }
+
+    #[test]
+    fn thumbnail_crop_free_fn_fills_and_crops_the_box() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("thumb_crop_in.png");
+        Raster::new(100, 60, PixelFormat::Rgb8, vec![90u8; 100 * 60 * 3])
+            .unwrap()
+            .save(&path)
+            .unwrap();
+
+        // crop="centre" fills a 40x40 box and centre-crops to it.
+        let thumb = super::thumbnail_crop(&path, 40, 40, "centre").unwrap();
+        assert_eq!(thumb.width(), 40);
+        assert_eq!(thumb.height(), 40);
+
+        // crop="none" fits inside the box, preserving aspect ratio.
+        let fit = super::thumbnail_crop(&path, 40, 40, "none").unwrap();
+        assert!(fit.width() <= 40 && fit.height() <= 40);
+        assert!(fit.width() == 40 || fit.height() == 40);
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -432,6 +432,47 @@ impl Raster {
 /// The limits are configured on the decoder before any pixel data is
 /// allocated, and the `width * height` ceiling is checked before the
 /// [`Raster`] is constructed.
+/// Decode an image file in sequential-access mode (libvips
+/// `access = sequential`).
+///
+/// Sequential access is a memory/IO hint: it lets a loader stream the image
+/// top to bottom instead of keeping it randomly addressable. libviprs
+/// decodes each supported format fully into a [`Raster`] regardless, so the
+/// hint does not change the result: this returns exactly what [`decode_file`]
+/// returns for the same file. The distinct entry point pins the ported
+/// `access = sequential` call surface and reserves the seam for a future
+/// streaming loader.
+///
+/// # Errors
+///
+/// As [`decode_file`].
+pub fn decode_file_sequential(path: &Path) -> Result<Raster, SourceError> {
+    decode_file(path)
+}
+
+/// Decode an image file with shrink-on-load by an integer factor (libvips
+/// JPEG `shrink` load option, typically 1, 2, 4, or 8).
+///
+/// The image is decoded and then reduced by `shrink` on each axis with the
+/// box shrink, giving output dimensions `round(dim / shrink)`. A `shrink` of
+/// 0 or 1 returns the image at full size. A dedicated shrink-on-load decode
+/// path (decoding directly at reduced resolution) can replace the body later
+/// without changing this signature.
+///
+/// # Errors
+///
+/// As [`decode_file`], plus a shrink/resample failure surfaced as
+/// [`SourceError::Io`].
+pub fn decode_file_with_shrink(path: &Path, shrink: u32) -> Result<Raster, SourceError> {
+    let base = decode_file(path)?;
+    if shrink <= 1 {
+        return Ok(base);
+    }
+    let factor = f64::from(shrink);
+    base.try_shrink(factor, factor)
+        .map_err(|e| SourceError::Io(std::io::Error::other(e.to_string())))
+}
+
 pub fn decode_file_with_limits(path: &Path, limits: DecodeLimits) -> Result<Raster, SourceError> {
     // Sniff the leading magic: native .v files and JPEGs take the
     // in-memory path (the .v decoder parses the libvips header itself,
@@ -1261,5 +1302,44 @@ mod tests {
         set_load_cache_max_entries(DEFAULT_LOAD_CACHE_MAX_ENTRIES);
         set_load_cache_max_bytes(DEFAULT_LOAD_CACHE_MAX_BYTES);
         clear_load_cache();
+    }
+
+    #[test]
+    fn decode_file_sequential_matches_decode_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seq.v");
+        generate_test_raster(48, 32).unwrap().save(&path).unwrap();
+
+        let normal = decode_file(&path).unwrap();
+        let sequential = decode_file_sequential(&path).unwrap();
+        assert_eq!(normal.width(), sequential.width());
+        assert_eq!(normal.height(), sequential.height());
+        assert_eq!(normal.format(), sequential.format());
+        assert_eq!(normal.data(), sequential.data());
+    }
+
+    #[test]
+    fn decode_file_with_shrink_reduces_dimensions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shrink.v");
+        generate_test_raster(100, 100).unwrap().save(&path).unwrap();
+
+        // shrink <= 1 is a no-op returning the full-size image.
+        assert_eq!(decode_file_with_shrink(&path, 1).unwrap().width(), 100);
+
+        for factor in [2u32, 4] {
+            let shrunk = decode_file_with_shrink(&path, factor).unwrap();
+            let expected = (100.0_f64 / f64::from(factor)).round() as i64;
+            assert!(
+                (i64::from(shrunk.width()) - expected).abs() <= 1,
+                "shrink={factor}: width {} not near {expected}",
+                shrunk.width()
+            );
+            assert!(
+                (i64::from(shrunk.height()) - expected).abs() <= 1,
+                "shrink={factor}: height {} not near {expected}",
+                shrunk.height()
+            );
+        }
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -425,13 +425,6 @@ impl Raster {
     }
 }
 
-/// Decode an image file into a [`Raster`] under explicit [`DecodeLimits`].
-///
-/// Identical to [`decode_file`] but lets the caller supply the
-/// dimension/allocation budget instead of using [`DecodeLimits::default`].
-/// The limits are configured on the decoder before any pixel data is
-/// allocated, and the `width * height` ceiling is checked before the
-/// [`Raster`] is constructed.
 /// Decode an image file in sequential-access mode (libvips
 /// `access = sequential`).
 ///
@@ -473,6 +466,18 @@ pub fn decode_file_with_shrink(path: &Path, shrink: u32) -> Result<Raster, Sourc
         .map_err(|e| SourceError::Io(std::io::Error::other(e.to_string())))
 }
 
+/// Decode an image file into a [`Raster`] under explicit [`DecodeLimits`].
+///
+/// Identical to [`decode_file`] but lets the caller supply the
+/// dimension/allocation budget instead of using [`DecodeLimits::default`].
+/// The limits are configured on the decoder before any pixel data is
+/// allocated, and the `width * height` ceiling is checked before the
+/// [`Raster`] is constructed.
+///
+/// # Errors
+///
+/// As [`decode_file`], plus [`SourceError::DimensionLimitExceeded`] when
+/// the decoded `width * height` exceeds the supplied budget.
 pub fn decode_file_with_limits(path: &Path, limits: DecodeLimits) -> Result<Raster, SourceError> {
     // Sniff the leading magic: native .v files and JPEGs take the
     // in-memory path (the .v decoder parses the libvips header itself,


### PR DESCRIPTION
## FOREIGN-SUPPORT lane for libviprs-tests#77 (Wave 2)

Supplies the remaining symbols the ported foreign and connection cells need beyond the encode/tiff/connection/text lanes: the deferred-format typed stubs plus a few thin real extensions. Builds on the B0 codec spine (`codec::{EncodeError, DecodeError}`).

Strict file ownership: touches only `src/foreign_stubs.rs` (new), `src/imageio.rs`, `src/pdf.rs`, `src/resample.rs`, `src/source.rs`, and `src/lib.rs` (re-exports). No changes to `encode.rs`, `encode_tiff.rs`, `connection.rs`, `textio.rs`, `arithmetic.rs`, `sink.rs`, or `Cargo.toml`.

### Real (thin wrappers over existing code)
- `Raster::get_int(&self, name) -> Option<i32>` (imageio) reads an integer field via `get_field`.
- `Raster::dzsave_buffer(&self) -> Vec<u8>` (foreign_stubs): packs a DeepZoom `.dzi` manifest and the image tile into a valid, self-contained in-memory zip. The zip container is written by hand (STORE method, CRC-32 via `flate2`) because the `zip`-crate path lives behind the optional `packfile` feature (a Cargo change is out of scope for this lane).
- `decode_file_sequential(path)` and `decode_file_with_shrink(path, shrink)` (source): wrap the existing decode; the shrink form reduces by the integer factor via the existing box shrink.
- `thumbnail(path, width)` and `thumbnail_crop(path, width, height, crop)` free fns (resample): wrap `Raster::try_thumbnail`.
- `extract_page_image_dpi`, `extract_page_image_with_password`, `pdf_info_with_password` (pdf): real for the tractable path (pdfium render at DPI under the `pdfium` feature; unencrypted read for the password forms), a clean typed error otherwise.
- `encode_vips` was already present in `imageio.rs` (returns `SaveError`) and no compiled cell body calls it, so it is left untouched.

### Typed Unsupported (genuinely-external formats)
- Encoders on `Raster` returning `EncodeError::Unsupported { format }`: `encode_heif(quality, compression)`, `encode_heif_lossless`, `encode_heif_chroma`, `encode_heif_lossless_bitdepth`, `encode_heif_tune`, `encode_jp2k`, `encode_jp2k_chroma`, `encode_jxl`, `encode_uhdr`, `encode_uhdr_gainmap_scale`, `magicksave_buffer(format)`.
- Decoders returning `DecodeError`: `magickload`, `magickload_with`, `decode_svg(data, dpi)`, `decode_openslide`, `decode_file_fail_on`, `decode_bytes_fail_on`, plus `MagickLoadOptions { density, page, n }`.

The single-argument `encode_heif` in the cell's Required-API doc is never called by a compiled body; every call site uses `encode_heif(quality, compression)`, so that is the signature provided.

### Tests
Adds 13 in-crate red-then-green unit tests covering the typed Unsupported error paths, `get_int` coercion, the sequential/shrink decode equivalence and dimensions, the thumbnail free-fn dimensions, the DeepZoom zip validity, and the clean typed-error paths of the pdf option functions.

### Local mirror
`make fmt`, `make clippy` (default + pdfium, `-D warnings`), `make test`, and the doc broken-intra-doc-link check all pass.

Leave unmerged for review.


---

## Resolve stage (consensus: approve_with_changes)

Addressed the two core recommendations and recorded the enablement breadcrumbs. No author/AI markers; behavior of the other lanes untouched.

### Rec 1: doc-comment ownership (`src/source.rs`)
The `decode_file_with_limits` rustdoc block had ended up above `decode_file_sequential` (the two new wrappers were inserted between that block and its fn), so `decode_file_sequential` rendered with the explicit-`DecodeLimits` docs and `decode_file_with_limits` had none. I moved the `decode_file_with_limits` doc block back immediately above its own fn and gave it an `# Errors` section. Now `decode_file_with_limits`, `decode_file_sequential`, and `decode_file_with_shrink` each own their intended rustdoc. Verified with `cargo doc` (broken-intra-doc-link check clean).

### Rec 2: password-error precision (`src/pdf.rs`)
`pdf_info_with_password` and `extract_page_image_with_password` no longer label every failure "password-protected" when a password is supplied. Each now opens the document first via `lopdf::Document::load`, so a missing, unreadable, or malformed file surfaces its real IO/parse error, and folds to the unsupported-capability ("password-protected") message only when the opened document actually carries an encryption dictionary (`lopdf::Document::is_encrypted`) and a non-empty password was supplied. I factored the shared bodies into `pdf_info_from_doc` / `extract_page_image_from_doc` so the document loads once.

Tests updated so they no longer cement the wrong behavior:
- `pdf_info_with_password_reports_encrypted_as_unsupported`: now builds a real `/Encrypt`-carrying fixture on disk (the encryption dictionary itself is plaintext per spec, so no crypto is needed to parse as encrypted) and asserts the `UnsupportedFormat`/password path.
- `pdf_info_with_password_passes_through_open_error` (new): a nonexistent path with a password surfaces the underlying open error, not "password-protected".
- `pdf_info_with_password_ignores_password_on_unencrypted_doc` (new): a readable unencrypted document is not mislabelled.
- `extract_page_image_with_password_reports_encrypted_as_unsupported` (new) and `password_and_dpi_extract_return_a_clean_typed_error` (updated to assert the missing-file error is not the password-protected message).

### Enablement breadcrumbs (recorded, NOT changed in this lane)
Deferred combined-compile fixes for when the ported cells are turned on:
1. `decode_svg` is 2-arg `(data, dpi)` here (matches the foreign cell), but `ported_connection.rs:377` calls `decode_svg(svg)` 1-arg. At enablement, update that call site to `decode_svg(svg, None)` before turning on `ported_tests`, or the combined compile breaks.
2. `extract_page_image_dpi` returns a typed error without the `pdfium` feature, but `ported_foreign.rs` `test_pdfload_dpi` unwraps expecting DPI-scaled dims. At enablement, `cfg`-gate `test_pdfload_dpi` on `feature="pdfium"` (or mark it `#[ignore]` without pdfium).

### Local mirror (rebased on `origin/main`)
`make fmt`, `make clippy` (default + pdfium, `-D warnings`), `make test`, and the doc broken-intra-doc-link check all pass.
