### PR TITLE
Add ZipSink over PackfileSink (Zip) for libviprs-tests#87

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ pub use sink::{
 pub use sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 #[cfg(feature = "packfile")]
 #[cfg_attr(docsrs, doc(cfg(feature = "packfile")))]
-pub use sink_packfile::{PackfileFormat, PackfileSink, PackfileSinkBuilder};
+pub use sink_packfile::{PackfileFormat, PackfileSink, PackfileSinkBuilder, ZipSink};
 pub use source::{
     SourceError, clear_load_cache, decode_bytes, decode_file, decode_file_sequential,
     decode_file_with_options, decode_file_with_shrink, generate_test_raster,

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -24,7 +24,7 @@ pub use crate::retry::{FailurePolicy, RetryPolicy, RetryingSink};
 pub use crate::sink_object_store::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 
 #[cfg(feature = "packfile")]
-pub use crate::sink_packfile::{PackfileFormat, PackfileSink};
+pub use crate::sink_packfile::{PackfileFormat, PackfileSink, ZipSink};
 
 /// Errors that can occur when writing tiles to a sink.
 ///

--- a/src/sink_packfile.rs
+++ b/src/sink_packfile.rs
@@ -471,21 +471,43 @@ impl ZipSink {
     /// and `format` for the per-tile encoding. The container format is always
     /// [`PackfileFormat::Zip`].
     ///
-    /// This mirrors the sibling filesystem sinks with an infallible `-> Self`
-    /// signature. Under the hood it delegates to
-    /// [`PackfileSink::new`]`(path, PackfileFormat::Zip, plan, format)`.
+    /// This is the fallible constructor and the recommended entry point when a
+    /// caller wants to handle archive-creation failure explicitly. It delegates
+    /// to [`PackfileSink::new`]`(path, PackfileFormat::Zip, plan, format)`,
+    /// which opens `path` for writing up front.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SinkError::Io`] if the output file at `path` cannot be created
+    /// (for example a parent directory that cannot be created, or a permissions
+    /// error).
+    pub fn try_new(
+        path: impl Into<PathBuf>,
+        plan: PyramidPlan,
+        format: TileFormat,
+    ) -> Result<Self, SinkError> {
+        let inner = PackfileSink::new(path, PackfileFormat::Zip, plan, format)?;
+        Ok(Self { inner })
+    }
+
+    /// Create a ZIP tile sink writing to `path`, using `plan` for tile paths
+    /// and `format` for the per-tile encoding. The container format is always
+    /// [`PackfileFormat::Zip`]. This is a convenience wrapper over
+    /// [`ZipSink::try_new`] for call sites that treat archive creation as
+    /// infallible.
     ///
     /// # Panics
     ///
-    /// Panics if the output file at `path` cannot be created (for example a
-    /// parent directory that cannot be created, or a permissions error).
-    /// Callers who need to handle that I/O failure explicitly can build a
-    /// [`PackfileSink`] with [`PackfileFormat::Zip`] directly, which returns a
-    /// `Result`.
-    pub fn new(path: PathBuf, plan: PyramidPlan, format: TileFormat) -> Self {
-        let inner = PackfileSink::new(path, PackfileFormat::Zip, plan, format)
-            .expect("ZipSink::new: failed to create the ZIP archive output file");
-        Self { inner }
+    /// Unlike the filesystem sinks (whose `new` constructors do no eager I/O
+    /// and defer every write to their `finish` path), `ZipSink::new` performs
+    /// eager I/O: it creates the archive file at `path` when the sink is
+    /// constructed. It therefore panics if that file cannot be created (for
+    /// example a parent directory that cannot be created, or a permissions
+    /// error). Callers who need to handle that failure should use
+    /// [`ZipSink::try_new`], which returns a [`Result`] instead.
+    pub fn new(path: impl Into<PathBuf>, plan: PyramidPlan, format: TileFormat) -> Self {
+        Self::try_new(path, plan, format)
+            .expect("ZipSink::new: failed to create the ZIP archive output file")
     }
 
     /// Returns the archive's output path.
@@ -737,7 +759,9 @@ mod tests {
 
         let sink = ZipSink::new(out.clone(), plan.clone(), TileFormat::Png);
 
-        // Drive every tile of the small pyramid through the sink.
+        // Drive every tile of the small pyramid through the sink, counting the
+        // total we feed in so we can pin the stored `_files/` entry count.
+        let mut driven_tiles = 0usize;
         for level in &plan.levels {
             for y in 0..level.rows {
                 for x in 0..level.cols {
@@ -747,9 +771,11 @@ mod tests {
                         blank: false,
                     };
                     sink.write_tile(&tile).unwrap();
+                    driven_tiles += 1;
                 }
             }
         }
+        assert!(driven_tiles > 0, "test must drive at least one tile");
         sink.finish().unwrap();
 
         // 1. The archive file exists and is non-empty.
@@ -776,6 +802,26 @@ mod tests {
         assert!(
             names.iter().any(|n| n == "manifest.json"),
             "zip must contain the root manifest.json, got: {names:?}"
+        );
+
+        // 4. Exactly one DeepZoom `_files/<level>/<x>_<y>.png` entry per driven
+        //    tile: no tile is dropped and none is duplicated on that path. (The
+        //    mirror `<stem>/…` entries live outside `_files/` and are excluded.)
+        let deep_zoom_tiles = names
+            .iter()
+            .filter(|n| n.contains("_files/") && n.ends_with(".png"))
+            .count();
+        assert_eq!(
+            deep_zoom_tiles, driven_tiles,
+            "DeepZoom `_files/*.png` entry count must equal the driven tile total, got: {names:?}"
+        );
+
+        // 5. `finish()` writes the DeepZoom `<stem>.dzi` manifest at the root.
+        //    The archive stem for `pyramid.zip` is `pyramid`, so pin the
+        //    contract by requiring the `pyramid.dzi` entry.
+        assert!(
+            names.iter().any(|n| n == "pyramid.dzi"),
+            "zip must contain the DeepZoom manifest `pyramid.dzi`, got: {names:?}"
         );
     }
 }

--- a/src/sink_packfile.rs
+++ b/src/sink_packfile.rs
@@ -448,6 +448,67 @@ impl TileSink for PackfileSink {
 }
 
 // ---------------------------------------------------------------------------
+// ZipSink
+// ---------------------------------------------------------------------------
+
+/// Tile sink that packs an entire pyramid into a single ZIP archive.
+///
+/// `ZipSink` is a thin newtype over [`PackfileSink`] with the container
+/// format fixed to [`PackfileFormat::Zip`]. It gives callers who only ever
+/// want ZIP output a dedicated type to name, instead of threading a
+/// [`PackfileFormat`] argument through their code. Every [`TileSink`] method
+/// delegates straight to the inner [`PackfileSink`] (through the
+/// [`TileSink::inner_sink`] decorator hook for the engine-bookkeeping
+/// methods, and directly for [`TileSink::write_tile`] /
+/// [`TileSink::finish`]); ZipSink adds no archive-writing logic of its own.
+#[derive(Debug)]
+pub struct ZipSink {
+    inner: PackfileSink,
+}
+
+impl ZipSink {
+    /// Create a ZIP tile sink writing to `path`, using `plan` for tile paths
+    /// and `format` for the per-tile encoding. The container format is always
+    /// [`PackfileFormat::Zip`].
+    ///
+    /// This mirrors the sibling filesystem sinks with an infallible `-> Self`
+    /// signature. Under the hood it delegates to
+    /// [`PackfileSink::new`]`(path, PackfileFormat::Zip, plan, format)`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the output file at `path` cannot be created (for example a
+    /// parent directory that cannot be created, or a permissions error).
+    /// Callers who need to handle that I/O failure explicitly can build a
+    /// [`PackfileSink`] with [`PackfileFormat::Zip`] directly, which returns a
+    /// `Result`.
+    pub fn new(path: PathBuf, plan: PyramidPlan, format: TileFormat) -> Self {
+        let inner = PackfileSink::new(path, PackfileFormat::Zip, plan, format)
+            .expect("ZipSink::new: failed to create the ZIP archive output file");
+        Self { inner }
+    }
+
+    /// Returns the archive's output path.
+    pub fn out_path(&self) -> &Path {
+        self.inner.out_path()
+    }
+}
+
+impl TileSink for ZipSink {
+    fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+        self.inner.write_tile(tile)
+    }
+
+    fn finish(&self) -> Result<(), SinkError> {
+        self.inner.finish()
+    }
+
+    fn inner_sink(&self) -> Option<&dyn TileSink> {
+        Some(&self.inner)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Archive append helpers
 // ---------------------------------------------------------------------------
 
@@ -660,5 +721,61 @@ mod tests {
 
         let meta = std::fs::metadata(&out).unwrap();
         assert!(meta.len() > 0, "tar archive must be non-empty");
+    }
+
+    /// TDD for the ZipSink lane (libviprs-tests#87): driving a `ZipSink`
+    /// across a small pyramid produces a `.zip` that exists, is non-empty,
+    /// and, when reopened with the `zip` crate, contains the expected tile
+    /// entries plus the root manifest.
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn zip_sink_writes_pyramid_archive() {
+        let plan = make_plan(64, 64, 32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("pyramid.zip");
+
+        let sink = ZipSink::new(out.clone(), plan.clone(), TileFormat::Png);
+
+        // Drive every tile of the small pyramid through the sink.
+        for level in &plan.levels {
+            for y in 0..level.rows {
+                for x in 0..level.cols {
+                    let tile = Tile {
+                        coord: TileCoord::new(level.level, x, y),
+                        raster: Raster::zeroed(32, 32, PixelFormat::Rgb8).unwrap(),
+                        blank: false,
+                    };
+                    sink.write_tile(&tile).unwrap();
+                }
+            }
+        }
+        sink.finish().unwrap();
+
+        // 1. The archive file exists and is non-empty.
+        let meta = std::fs::metadata(&out).unwrap();
+        assert!(meta.len() > 0, "zip archive must be non-empty");
+
+        // 2. Reopen with the zip crate and enumerate entry names.
+        let file = File::open(&out).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        assert!(!archive.is_empty(), "zip archive must contain entries");
+
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+
+        // 3. It carries DeepZoom tile entries under `<stem>_files/…` and the
+        //    root manifest.
+        assert!(
+            names
+                .iter()
+                .any(|n| n.contains("_files/") && n.ends_with(".png")),
+            "zip must contain DeepZoom tile entries, got: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n == "manifest.json"),
+            "zip must contain the root manifest.json, got: {names:?}"
+        );
     }
 }


### PR DESCRIPTION
## ZipSink for libviprs-tests#87

Adds `ZipSink`, a thin newtype over the existing `PackfileSink` with the container format fixed to `PackfileFormat::Zip`. It gives callers who only want ZIP pyramid output a dedicated type instead of threading a `PackfileFormat` argument through their code.

### What it does
- `ZipSink::new(path: PathBuf, plan: PyramidPlan, format: TileFormat) -> Self` matches the test's Required-API sketch. It delegates to `PackfileSink::new(path, PackfileFormat::Zip, plan, format)`, reusing the existing `zip::ZipWriter` + `append_zip` path with no new archive-writing logic.
- The signature is infallible (`-> Self`) to mirror the sibling filesystem sinks; the fallible `PackfileSink::new` is `.expect`-ed internally with a clear message, and the panic is documented in a `# Panics` section. Callers who need to handle I/O failure explicitly can build a `PackfileSink` with `PackfileFormat::Zip` directly, which returns a `Result`.
- `impl TileSink for ZipSink` forwards `write_tile` and `finish` to the inner sink and overrides `inner_sink()` so the engine-bookkeeping methods (issue #137 decorator hook) auto-forward too. This is the same delegation idiom `RetryingSink` uses.
- One additive `pub use` re-exports `ZipSink` from the crate root under the same `#[cfg(feature = "packfile")]`.

### Test (TDD, red then green)
`sink_packfile::tests::zip_sink_writes_pyramid_archive` drives a small pyramid through `ZipSink`, then reopens the `.zip` with the `zip` crate and asserts it exists, is non-empty, and holds the DeepZoom tile entries plus the root `manifest.json`.

### Packfile gating (enablement note)
`ZipSink` and its test live entirely behind `#[cfg(feature = "packfile")]`. For the ignored `test_dz_zip` in the tests crate to exercise this, that test must be `cfg(feature = "packfile")` gated, or the tests crate must enable the `packfile` feature. Without `packfile` enabled, `ZipSink` is not compiled and the symbol is absent.

### Scope
Only `src/sink_packfile.rs` and one additive re-export line in `src/lib.rs` are touched. Left unmerged for review.