### PR TITLE
feat(engine): skip_blanks + generate_pyramid_region (libviprs-tests#87)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -200,6 +200,16 @@ pub struct EngineConfig {
     /// `skip_blanks`. Blankness uses the same exact-uniformity test as
     /// [`is_blank_tile`], and the skip decision takes precedence over the
     /// active [`BlankTileStrategy`].
+    ///
+    /// Honoured by the monolithic engine only. The streaming and map-reduce
+    /// engines currently ignore this flag and emit every tile; parity across
+    /// those engines is deferred.
+    ///
+    /// A level that contains any skipped blank is not eligible for the
+    /// whole-level resume skip optimisation: its blank coordinates are never
+    /// recorded as completed, so the level is never promoted to
+    /// `levels_completed`. On resume such a level is re-walked and its blanks
+    /// re-skipped deterministically, which is safe and idempotent.
     pub skip_blanks: bool,
     /// How to react when a sink write fails after retries.
     pub failure_policy: FailurePolicy,
@@ -310,6 +320,9 @@ impl EngineConfig {
     /// at all for a blank tile. Blankness is the same exact-uniformity test as
     /// [`is_blank_tile`], and skipping wins over the active
     /// [`BlankTileStrategy`]. See [`EngineConfig::skip_blanks`] for the field.
+    ///
+    /// Honoured by the monolithic engine only (the streaming and map-reduce
+    /// engines currently ignore it; parity is deferred).
     pub fn skip_blanks(mut self, skip: bool) -> Self {
         self.skip_blanks = skip;
         self
@@ -456,10 +469,16 @@ pub struct StageDurations {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct EngineResult {
-    /// Total number of tiles written to the sink (including placeholders).
+    /// Total number of tiles written to the sink (including placeholder
+    /// markers). This always equals the number of files the run handed to the
+    /// sink.
     pub tiles_produced: u64,
-    /// Number of tiles that were blank and replaced with placeholders
-    /// (only non-zero when `BlankTileStrategy::Placeholder` is used).
+    /// Number of blank (uniform-colour) tiles the engine treated specially.
+    /// A blank tile is counted here under either
+    /// [`BlankTileStrategy::Placeholder`] (the tile is still written, as a
+    /// 1-byte marker, so it is ALSO in `tiles_produced`) or
+    /// [`EngineConfig::skip_blanks`] (the tile is dropped and so is EXCLUDED
+    /// from `tiles_produced`).
     pub tiles_skipped: u64,
     /// Number of pyramid levels that were processed (always equals the plan's level count).
     pub levels_processed: u32,
@@ -517,9 +536,13 @@ pub(crate) fn generate_pyramid_observed(
 ///
 /// The supplied `plan` must describe the **region** dimensions (`width ×
 /// height`), not the whole source: it is applied to the crop as-is. Build it
-/// with `PyramidPlanner::new(width, height, ..)`. A plan whose dimensions do
-/// not match the crop surfaces as an [`EngineError::Raster`] from the tiling
-/// step rather than silently mis-tiling.
+/// with `PyramidPlanner::new(width, height, ..)`. Sizing the plan for anything
+/// other than the crop is a caller error: an oversized plan (level-0 larger
+/// than the crop) drives the tiling past the crop bounds, while an undersized
+/// plan would silently cover only part of the region. To fail fast rather than
+/// mis-tile, this function checks the plan's level-0 dimensions against
+/// `(width, height)` up front and returns [`EngineError::PlanSourceMismatch`]
+/// before cropping when they differ.
 ///
 /// This mirrors libvips `dzsave`'s region rendering. It is observer-free (it
 /// drives a [`NoopObserver`](crate::observe::NoopObserver) internally); use
@@ -528,8 +551,10 @@ pub(crate) fn generate_pyramid_observed(
 ///
 /// # Errors
 ///
-/// Returns [`EngineError::Raster`] if the region rectangle falls outside `src`,
-/// and any error the underlying pyramid run produces.
+/// Returns [`EngineError::PlanSourceMismatch`] if `plan`'s level-0 dimensions
+/// do not equal `(width, height)`, [`EngineError::Raster`] if the region
+/// rectangle falls outside `src`, and any error the underlying pyramid run
+/// produces.
 // The eight parameters are the region contract: the four pyramid inputs plus
 // the `left/top/width/height` crop rectangle. Bundling the rectangle into a
 // struct would obscure the call site and diverge from the documented API shape,
@@ -545,6 +570,18 @@ pub fn generate_pyramid_region(
     width: u32,
     height: u32,
 ) -> Result<EngineResult, EngineError> {
+    // Fail fast before cropping: the plan must be sized for the crop, not the
+    // whole source. An oversized plan would tile past the crop bounds and an
+    // undersized one would silently cover only part of the region, so a
+    // dimension mismatch is a typed error here rather than a mis-tiled run.
+    if plan.image_width != width || plan.image_height != height {
+        return Err(EngineError::PlanSourceMismatch {
+            plan_width: plan.image_width,
+            plan_height: plan.image_height,
+            source_width: width,
+            source_height: height,
+        });
+    }
     let cropped = src.extract(left, top, width, height)?;
     generate_pyramid_observed(&cropped, plan, sink, config, &crate::observe::NoopObserver)
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -189,6 +189,18 @@ pub struct EngineConfig {
     /// How to handle tiles where every pixel is the same color.
     /// Defaults to `Emit` (write full tile data).
     pub blank_tile_strategy: BlankTileStrategy,
+    /// When `true`, blank (uniform-color) tiles are dropped from the run
+    /// entirely: a blank tile is never handed to the sink, so the output
+    /// carries strictly fewer files. Defaults to `false`.
+    ///
+    /// This is deliberately stronger than
+    /// [`BlankTileStrategy::Placeholder`], which still writes a 1-byte marker
+    /// for every blank tile and so leaves the file count unchanged. Skipping
+    /// removes the tile altogether, mirroring libvips `dzsave`'s
+    /// `skip_blanks`. Blankness uses the same exact-uniformity test as
+    /// [`is_blank_tile`], and the skip decision takes precedence over the
+    /// active [`BlankTileStrategy`].
+    pub skip_blanks: bool,
     /// How to react when a sink write fails after retries.
     pub failure_policy: FailurePolicy,
     /// Persist the resume checkpoint every N tiles (0 = never).
@@ -238,6 +250,7 @@ impl Default for EngineConfig {
             buffer_size: 0,
             background_rgb: [255, 255, 255],
             blank_tile_strategy: BlankTileStrategy::Emit,
+            skip_blanks: false,
             failure_policy: FailurePolicy::default(),
             checkpoint_every: 0,
             dedupe_strategy: None,
@@ -283,6 +296,22 @@ impl EngineConfig {
     /// (and the related [`--blank-tolerance`](https://libviprs.org/cli/#flag-blank-tolerance) flag).
     pub fn with_blank_tile_strategy(mut self, strategy: BlankTileStrategy) -> Self {
         self.blank_tile_strategy = strategy;
+        self
+    }
+
+    /// When `skip` is `true`, blank (uniform-color) tiles are dropped from the
+    /// run entirely rather than written to the sink, so the output has strictly
+    /// fewer files.
+    ///
+    /// This differs from
+    /// [`with_blank_tile_strategy`](Self::with_blank_tile_strategy) with
+    /// [`BlankTileStrategy::Placeholder`], which still emits a 1-byte marker per
+    /// blank tile (leaving the file count unchanged): skipping produces no file
+    /// at all for a blank tile. Blankness is the same exact-uniformity test as
+    /// [`is_blank_tile`], and skipping wins over the active
+    /// [`BlankTileStrategy`]. See [`EngineConfig::skip_blanks`] for the field.
+    pub fn skip_blanks(mut self, skip: bool) -> Self {
+        self.skip_blanks = skip;
         self
     }
 
@@ -475,6 +504,49 @@ pub(crate) fn generate_pyramid_observed(
     observer: &dyn EngineObserver,
 ) -> Result<EngineResult, EngineError> {
     run_pyramid(source, plan, sink, config, observer)
+}
+
+/// Generates a tile pyramid for a rectangular sub-region of `src`.
+///
+/// Region generation is exactly crop-then-pyramid: the `[left, top, width,
+/// height]` rectangle is cropped out of `src` into an owned raster (via
+/// [`Raster::extract`]), and that crop is run through the normal pyramid
+/// pipeline. As a result the top-level tile covers only the requested region,
+/// and every emitted tile is byte-identical to the tile a full run over the
+/// same crop would produce.
+///
+/// The supplied `plan` must describe the **region** dimensions (`width ×
+/// height`), not the whole source: it is applied to the crop as-is. Build it
+/// with `PyramidPlanner::new(width, height, ..)`. A plan whose dimensions do
+/// not match the crop surfaces as an [`EngineError::Raster`] from the tiling
+/// step rather than silently mis-tiling.
+///
+/// This mirrors libvips `dzsave`'s region rendering. It is observer-free (it
+/// drives a [`NoopObserver`](crate::observe::NoopObserver) internally); use
+/// [`generate_pyramid_observed`] on a pre-cropped raster if progress events are
+/// needed.
+///
+/// # Errors
+///
+/// Returns [`EngineError::Raster`] if the region rectangle falls outside `src`,
+/// and any error the underlying pyramid run produces.
+// The eight parameters are the region contract: the four pyramid inputs plus
+// the `left/top/width/height` crop rectangle. Bundling the rectangle into a
+// struct would obscure the call site and diverge from the documented API shape,
+// so the argument count is intentional here.
+#[allow(clippy::too_many_arguments)]
+pub fn generate_pyramid_region(
+    src: &Raster,
+    plan: &PyramidPlan,
+    sink: &dyn TileSink,
+    config: &EngineConfig,
+    left: u32,
+    top: u32,
+    width: u32,
+    height: u32,
+) -> Result<EngineResult, EngineError> {
+    let cropped = src.extract(left, top, width, height)?;
+    generate_pyramid_observed(&cropped, plan, sink, config, &crate::observe::NoopObserver)
 }
 
 /// Internal driver behind [`generate_pyramid_observed`].
@@ -1513,6 +1585,15 @@ fn extract_and_emit_level(
                 let tile_raster = extract_tile(raster, plan, coord, config.background_rgb)?;
                 ctx.stage_extract
                     .fetch_add(extract_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+                // skip_blanks (issue libviprs-tests#87): a uniform tile is
+                // dropped before it ever reaches the sink, so the output holds
+                // strictly fewer files. This is engine-side on purpose (it must
+                // not live in the sink), and it takes precedence over the
+                // BlankTileStrategy marker path below.
+                if config.skip_blanks && is_blank_tile(&tile_raster) {
+                    skipped += 1;
+                    continue;
+                }
                 let blank = blank_for_output(&tile_raster, blank_strategy, config.dedupe_strategy);
                 if blank {
                     skipped += 1;
@@ -1796,6 +1877,18 @@ fn extract_and_emit_parallel(
             config.check_cancelled()?;
             let tile = result?;
             let coord = tile.coord;
+            // skip_blanks (issue libviprs-tests#87): mirror the single-threaded
+            // path — a uniform tile is dropped here, before the sink write, so
+            // the output holds strictly fewer files. The in_flight gauge was
+            // already decremented above, so the queue accounting stays balanced.
+            // The worker still extracted and enqueued this tile; only the sink
+            // write is elided (the test drives the monolithic single-threaded
+            // path, and keeping the skip at the write decision point matches it
+            // exactly and keeps `tiles_skipped` consistent across both paths).
+            if config.skip_blanks && is_blank_tile(&tile.raster) {
+                skipped += 1;
+                continue;
+            }
             if tile.blank {
                 skipped += 1;
             }
@@ -2320,6 +2413,126 @@ mod tests {
     fn solid_raster(w: u32, h: u32, val: u8) -> Raster {
         let data = vec![val; w as usize * h as usize * 3];
         Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    /// A mostly-white raster whose top-left `patch × patch` quadrant carries a
+    /// gradient, so full-resolution tiles split into uniform (blank) tiles over
+    /// the white margin and non-uniform tiles over the patch.
+    fn mostly_blank_raster(w: u32, h: u32, patch: u32) -> Raster {
+        let bpp = PixelFormat::Rgb8.bytes_per_pixel();
+        let mut data = vec![255u8; w as usize * h as usize * bpp];
+        for y in 0..patch.min(h) {
+            for x in 0..patch.min(w) {
+                let off = (y as usize * w as usize + x as usize) * bpp;
+                data[off] = (x % 256) as u8;
+                data[off + 1] = (y % 256) as u8;
+                data[off + 2] = ((x + y) % 256) as u8;
+            }
+        }
+        Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    /// `EngineConfig::skip_blanks(true)` must drop uniform tiles from the run
+    /// entirely, so a mostly-blank source yields strictly fewer emitted tiles /
+    /// sink files than the same run with skipping off. This is distinct from
+    /// `BlankTileStrategy::Placeholder`, which still writes one marker file per
+    /// blank tile (file count unchanged).
+    #[test]
+    fn skip_blanks_emits_strictly_fewer_tiles() {
+        let src = mostly_blank_raster(512, 512, 256);
+        let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+
+        // Full run: every tile coordinate is written.
+        let full_sink = MemorySink::new();
+        let full = generate_pyramid_observed(
+            &src,
+            &plan,
+            &full_sink,
+            &EngineConfig::default(),
+            &NoopObserver,
+        )
+        .unwrap();
+
+        // skip_blanks run: uniform tiles are never handed to the sink.
+        let skip_sink = MemorySink::new();
+        let skipped = generate_pyramid_observed(
+            &src,
+            &plan,
+            &skip_sink,
+            &EngineConfig::default().skip_blanks(true),
+            &NoopObserver,
+        )
+        .unwrap();
+
+        assert!(
+            skipped.tiles_produced < full.tiles_produced,
+            "skip_blanks(true) must emit fewer tiles: got {} vs full {}",
+            skipped.tiles_produced,
+            full.tiles_produced,
+        );
+        assert!(
+            skipped.tiles_skipped > 0,
+            "at least one blank tile must be reported as skipped"
+        );
+        assert_eq!(
+            skip_sink.tile_count() as u64,
+            skipped.tiles_produced,
+            "every produced tile must correspond to exactly one sink file under skip_blanks"
+        );
+        assert!(
+            (skip_sink.tile_count() as u64) < full_sink.tile_count() as u64,
+            "the sink must hold strictly fewer files with skip_blanks on"
+        );
+    }
+
+    /// `generate_pyramid_region` must be exactly crop-then-pyramid: the tiles it
+    /// produces for a sub-region are byte-identical to a pyramid built from the
+    /// same region cropped out of the source directly, so the top-level tile
+    /// covers only the requested region.
+    #[test]
+    fn generate_pyramid_region_matches_direct_crop() {
+        let src = gradient_raster(256, 256);
+        let (left, top, width, height) = (0u32, 0u32, 100u32, 100u32);
+        // The plan describes the REGION dimensions: the function crops the
+        // source to the region and runs this plan against the crop.
+        let plan = PyramidPlanner::new(width, height, 64, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+        let config = EngineConfig::default();
+
+        let region_sink = MemorySink::new();
+        let region =
+            generate_pyramid_region(&src, &plan, &region_sink, &config, left, top, width, height)
+                .unwrap();
+
+        // Reference: build the same pyramid from an explicitly-cropped raster.
+        let cropped = src.extract(left, top, width, height).unwrap();
+        let direct_sink = MemorySink::new();
+        let direct =
+            generate_pyramid_observed(&cropped, &plan, &direct_sink, &config, &NoopObserver)
+                .unwrap();
+
+        assert_eq!(
+            region.tiles_produced, direct.tiles_produced,
+            "region generation must produce the same tile budget as the crop"
+        );
+        assert_eq!(region.tiles_produced, plan.total_tile_count());
+
+        let region_tiles = region_sink.tiles();
+        let direct_tiles = direct_sink.tiles();
+        assert_eq!(region_tiles.len(), direct_tiles.len());
+        for (r, d) in region_tiles.iter().zip(direct_tiles.iter()) {
+            assert_eq!(r.coord, d.coord, "tile coordinates must line up");
+            assert_eq!(r.width, d.width, "tile width must match the crop");
+            assert_eq!(r.height, d.height, "tile height must match the crop");
+            assert_eq!(r.data, d.data, "tile pixels must be identical to the crop");
+        }
+
+        // The top-level tile must be no larger than the requested region.
+        let top_plan = plan.levels.last().unwrap();
+        assert!(top_plan.width <= width && top_plan.height <= height);
     }
 
     /// Issue #130: `EngineConfig::dedupe_strategy` must not be a silent no-op.

--- a/src/engine_builder.rs
+++ b/src/engine_builder.rs
@@ -212,6 +212,7 @@ pub struct EngineBuilder<'a, S: TileSink> {
     buffer_size: Option<usize>,
     background_rgb: Option<[u8; 3]>,
     blank_strategy: Option<BlankTileStrategy>,
+    skip_blanks: Option<bool>,
     failure_policy: Option<FailurePolicy>,
     dedupe: Option<DedupeStrategy>,
 
@@ -239,6 +240,7 @@ impl<'a, S: TileSink> std::fmt::Debug for EngineBuilder<'a, S> {
             .field("buffer_size", &self.buffer_size)
             .field("background_rgb", &self.background_rgb)
             .field("blank_strategy", &self.blank_strategy)
+            .field("skip_blanks", &self.skip_blanks)
             .field("failure_policy", &self.failure_policy)
             .field("dedupe", &self.dedupe)
             .field("resume", &self.resume)
@@ -263,6 +265,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             buffer_size: None,
             background_rgb: None,
             blank_strategy: None,
+            skip_blanks: None,
             failure_policy: None,
             dedupe: None,
             resume: None,
@@ -364,6 +367,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
         self.buffer_size = Some(config.buffer_size);
         self.background_rgb = Some(config.background_rgb);
         self.blank_strategy = Some(config.blank_tile_strategy);
+        self.skip_blanks = Some(config.skip_blanks);
         self.failure_policy = Some(config.failure_policy);
         // Uniform precedence: every value the config carries overwrites any
         // earlier setter unconditionally, including when the config field is
@@ -457,6 +461,18 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
     /// **See also:** [interactive example](https://libviprs.org/cli/#flag-skip-blank).
     pub fn with_blank_strategy(mut self, strategy: BlankTileStrategy) -> Self {
         self.blank_strategy = Some(strategy);
+        self
+    }
+
+    /// Drop blank (uniform-colour) tiles from the run entirely rather than
+    /// writing them, so the output carries strictly fewer files. This is the
+    /// builder mirror of [`EngineConfig::skip_blanks`]; skipping takes
+    /// precedence over the active [`BlankTileStrategy`].
+    ///
+    /// Honoured by the monolithic engine only (the streaming and map-reduce
+    /// engines currently ignore it; parity is deferred).
+    pub fn with_skip_blanks(mut self, skip: bool) -> Self {
+        self.skip_blanks = Some(skip);
         self
     }
 
@@ -555,6 +571,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             buffer_size,
             background_rgb,
             blank_strategy,
+            skip_blanks,
             failure_policy,
             dedupe,
             resume,
@@ -571,6 +588,7 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
             buffer_size,
             background_rgb,
             blank_strategy,
+            skip_blanks,
             failure_policy,
             dedupe,
         );
@@ -1060,11 +1078,13 @@ impl<'a, S: TileSink> EngineBuilder<'a, S> {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn build_engine_config(
     concurrency: Option<usize>,
     buffer_size: Option<usize>,
     background_rgb: Option<[u8; 3]>,
     blank_strategy: Option<BlankTileStrategy>,
+    skip_blanks: Option<bool>,
     failure_policy: Option<FailurePolicy>,
     dedupe: Option<DedupeStrategy>,
 ) -> EngineConfig {
@@ -1080,6 +1100,9 @@ fn build_engine_config(
     }
     if let Some(bts) = blank_strategy {
         cfg = cfg.with_blank_tile_strategy(bts);
+    }
+    if let Some(skip) = skip_blanks {
+        cfg = cfg.skip_blanks(skip);
     }
     if let Some(fp) = failure_policy {
         cfg = cfg.with_failure_policy(fp);
@@ -2165,6 +2188,7 @@ mod with_config_precedence_tests {
         let builder = EngineBuilder::new(&src, plan(), MemorySink::new())
             .with_concurrency(4)
             .with_dedupe(DedupeStrategy::Blanks)
+            .with_skip_blanks(true)
             .with_cancel(cancel)
             .with_config(cfg);
 
@@ -2177,6 +2201,12 @@ mod with_config_precedence_tests {
             builder.dedupe, None,
             "a config with no dedupe strategy must clear an earlier .with_dedupe, \
              matching how concurrency is overwritten"
+        );
+        assert_eq!(
+            builder.skip_blanks,
+            Some(false),
+            "a config with skip_blanks=false must overwrite an earlier \
+             .with_skip_blanks(true), matching how concurrency is overwritten"
         );
         assert!(
             builder.cancel.is_none(),
@@ -2198,6 +2228,128 @@ mod with_config_precedence_tests {
 
         assert_eq!(builder.concurrency, Some(7));
         assert_eq!(builder.dedupe, Some(DedupeStrategy::Blanks));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `skip_blanks` through the real EngineBuilder + FsSink acceptance path
+// (libviprs-tests issue #87)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod skip_blanks_builder_tests {
+    use super::*;
+    use crate::pixel::PixelFormat;
+    use crate::planner::{Layout, PyramidPlanner};
+    use crate::raster::Raster;
+    use crate::sink::{FsSink, TileFormat};
+    use std::path::Path;
+
+    /// A mostly-white raster whose top-left `patch × patch` quadrant carries a
+    /// gradient, so full-resolution tiles split into uniform (blank) tiles over
+    /// the white margin and non-uniform tiles over the patch.
+    fn mostly_blank_raster(w: u32, h: u32, patch: u32) -> Raster {
+        let bpp = PixelFormat::Rgb8.bytes_per_pixel();
+        let mut data = vec![255u8; w as usize * h as usize * bpp];
+        for y in 0..patch.min(h) {
+            for x in 0..patch.min(w) {
+                let off = (y as usize * w as usize + x as usize) * bpp;
+                data[off] = (x % 256) as u8;
+                data[off + 1] = (y % 256) as u8;
+                data[off + 2] = ((x + y) % 256) as u8;
+            }
+        }
+        Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+    }
+
+    /// Recursively count regular files with the `.raw` tile extension under
+    /// `root`. FsSink writes one such file per emitted tile, so this is the
+    /// on-disk tile-file count the acceptance path actually produces.
+    fn count_raw_tile_files(root: &Path) -> usize {
+        fn walk(cur: &Path, count: &mut usize) {
+            let Ok(entries) = std::fs::read_dir(cur) else {
+                return;
+            };
+            for entry in entries.filter_map(Result::ok) {
+                let p = entry.path();
+                if p.is_dir() {
+                    walk(&p, count);
+                } else if p.extension().and_then(|e| e.to_str()) == Some("raw") {
+                    *count += 1;
+                }
+            }
+        }
+        let mut count = 0;
+        walk(root, &mut count);
+        count
+    }
+
+    /// The real acceptance path: build a pyramid through
+    /// [`EngineBuilder`] + [`FsSink`] over a mostly-blank source, once with
+    /// `with_skip_blanks(true)` and once with it off. Skipping must hand
+    /// strictly FEWER tiles to the sink, leaving strictly fewer `.raw` files on
+    /// disk, and must report `tiles_skipped > 0`. This exercises the builder's
+    /// `with_skip_blanks` setter end to end (the field must survive the builder
+    /// into the monolithic engine, which was the regression), and it is
+    /// parameterised over concurrency so the parallel consumer's skip branch is
+    /// locked in alongside the single-threaded one.
+    #[test]
+    #[cfg_attr(miri, ignore)] // filesystem access blocked by Miri isolation
+    fn with_skip_blanks_writes_strictly_fewer_files_through_the_builder() {
+        for concurrency in [0usize, 2] {
+            let src = mostly_blank_raster(512, 512, 256);
+            let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::DeepZoom)
+                .unwrap()
+                .plan();
+
+            let run = |skip: bool, dir: &Path| -> EngineResult {
+                let sink =
+                    FsSink::new(dir.to_path_buf(), plan.clone()).with_format(TileFormat::Raw);
+                EngineBuilder::new(&src, plan.clone(), sink)
+                    .with_engine(EngineKind::Monolithic)
+                    .with_concurrency(concurrency)
+                    .with_skip_blanks(skip)
+                    .run()
+                    .expect("builder run must succeed")
+            };
+
+            let full_dir = tempfile::tempdir().unwrap();
+            let skip_dir = tempfile::tempdir().unwrap();
+
+            let full = run(false, full_dir.path());
+            let skipped = run(true, skip_dir.path());
+
+            let full_files = count_raw_tile_files(full_dir.path());
+            let skip_files = count_raw_tile_files(skip_dir.path());
+
+            // Setup sanity: the full run wrote one file per produced tile.
+            assert_eq!(
+                full_files as u64, full.tiles_produced,
+                "concurrency={concurrency}: full run must write one file per produced tile"
+            );
+            assert_eq!(
+                skip_files as u64, skipped.tiles_produced,
+                "concurrency={concurrency}: skip run must write one file per produced tile"
+            );
+
+            assert!(
+                skipped.tiles_skipped > 0,
+                "concurrency={concurrency}: at least one blank tile must be skipped, got {}",
+                skipped.tiles_skipped
+            );
+            assert!(
+                skip_files < full_files,
+                "concurrency={concurrency}: skip_blanks must leave strictly fewer .raw files on \
+                 disk: {skip_files} vs full {full_files}"
+            );
+            assert!(
+                skipped.tiles_produced < full.tiles_produced,
+                "concurrency={concurrency}: skip_blanks must hand strictly fewer tiles to the sink: \
+                 {} vs full {}",
+                skipped.tiles_produced,
+                full.tiles_produced
+            );
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,8 @@ pub use draw::{Circle, DrawError, DrawOp, Flood, Line, Mask, Paste, Rectangle, S
 // `Raster` and travel with the already-exported `Raster` type.
 pub use encode_tiff::{decode_tiff_page, tiff_page_count};
 pub use engine::{
-    BlankTileStrategy, EngineConfig, EngineError, EngineResult, StageDurations, is_blank_tile,
+    BlankTileStrategy, EngineConfig, EngineError, EngineResult, StageDurations,
+    generate_pyramid_region, is_blank_tile,
 };
 pub use engine_builder::{EngineBuilder, EngineKind, EngineSource, IntoEngineSource};
 pub use extract::{CompassDirection, Extend, ExtractError, SmartcropInteresting};

--- a/src/streaming_mapreduce.rs
+++ b/src/streaming_mapreduce.rs
@@ -100,6 +100,11 @@ impl MapReduceConfig {
             buffer_size: self.buffer_size,
             background_rgb: self.background_rgb,
             blank_tile_strategy: self.blank_tile_strategy,
+            // Build-only: the MapReduce engine does not (yet) honour
+            // skip_blanks; keeping it off preserves current behaviour.
+            // Engine-side skip_blanks parity for streaming/mapreduce is
+            // deferred (libviprs-tests#87 lane 2 covers the monolithic engine).
+            skip_blanks: false,
             failure_policy: self.failure_policy.clone(),
             checkpoint_every: 0,
             dedupe_strategy: None,


### PR DESCRIPTION
## What

Two engine-side capabilities for libviprs-tests#87 (lane 2), scoped to the monolithic engine.

### `EngineConfig::skip_blanks`

- New `pub skip_blanks: bool` field on `EngineConfig` (defaults to `false`), initialised in `Default`, with the inherent builder `skip_blanks(self, bool) -> Self` next to `with_blank_tile_strategy`.
- When on, a uniform (blank) tile is dropped before it reaches the sink, so the output holds **strictly fewer files**. This is deliberately stronger than `BlankTileStrategy::Placeholder`, which still writes a 1-byte marker per blank tile and leaves the file count unchanged.
- The skip is applied engine-side in both monolithic emit paths: the single-threaded loop in `extract_and_emit_level` and the parallel consumer in `extract_and_emit_parallel`. It is not in the sink (that would collide with another lane) and it takes precedence over the active `BlankTileStrategy`. Blankness reuses the existing exact-uniformity `is_blank_tile`.

### `generate_pyramid_region`

- New `pub fn generate_pyramid_region(src, plan, sink, config, left, top, width, height) -> Result<EngineResult, EngineError>` next to `generate_pyramid_observed`, re-exported at the crate root.
- Crop-then-pyramid: the rectangle is cropped out of the source via `Raster::extract` and the crop is run through the normal pipeline, so the top-level tile covers only the requested region. The supplied `plan` describes the region dimensions.

## Tests (red-then-green, in-crate)

- `skip_blanks_emits_strictly_fewer_tiles`: on a mostly-blank raster, `skip_blanks(true)` yields strictly fewer emitted tiles and sink files than the default run, with `tiles_skipped > 0`.
- `generate_pyramid_region_matches_direct_crop`: region output is byte-identical to a pyramid built from the same explicitly-cropped raster.

## Scope notes

- Engine-side skip_blanks **parity for the streaming / mapreduce engines is deferred**; the covering test drives the monolithic engine only. The single-line `skip_blanks: false` in `streaming_mapreduce.rs` is a build-only consequence of the new exhaustive struct field and preserves current behaviour (no skipping there).
- Local mirror green: fmt, clippy (default + pdfium, `-D warnings`), full test suite.