### PR TITLE
feat(planner,sink): DZ Zoomify + IIIF layout variants

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -169,6 +169,8 @@ mod layout_serde {
             Layout::DeepZoom => "deep_zoom",
             Layout::Xyz => "xyz",
             Layout::Google => "google",
+            Layout::Zoomify => "zoomify",
+            Layout::Iiif => "iiif",
         };
         s.serialize_str(name)
     }
@@ -179,6 +181,8 @@ mod layout_serde {
             "deep_zoom" => Ok(Layout::DeepZoom),
             "xyz" => Ok(Layout::Xyz),
             "google" => Ok(Layout::Google),
+            "zoomify" => Ok(Layout::Zoomify),
+            "iiif" => Ok(Layout::Iiif),
             other => Err(serde::de::Error::custom(format!("unknown layout: {other}"))),
         }
     }

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -63,6 +63,11 @@ pub enum Layout {
     /// IIIF Image API v2: `{region}/{size},/0/default.{ext}`, where `region`
     /// is expressed in full-resolution image coordinates, plus an `info.json`
     /// sidecar. Compatible with OpenSeadragon and other IIIF viewers.
+    ///
+    /// The `info.json` `@id` is written as a placeholder base URL. IIIF ties
+    /// `@id` to the serving location, which the planner cannot know, so a
+    /// caller is expected to rewrite it to the real image endpoint when it
+    /// publishes the tiles. See [`properties_sidecar`](PyramidPlan::properties_sidecar).
     Iiif,
 }
 
@@ -273,7 +278,16 @@ impl PyramidPlanner {
             return self.plan_google();
         }
 
-        let levels = self.compute_levels();
+        // Zoomify and IIIF stop the pyramid at a single-tile overview, exactly
+        // as libvips `dzsave` does for these layouts (depth `onetile`). Their
+        // tier index and cumulative tile numbering are derived by a viewer from
+        // WIDTH/HEIGHT/TILESIZE, so the level set has to agree: level 0 is the
+        // single-tile overview and full resolution is the highest tier. The
+        // `onepixel` layouts (DeepZoom, Xyz) keep halving down to 1x1.
+        let levels = match self.layout {
+            Layout::Zoomify | Layout::Iiif => self.compute_levels_single_tile(),
+            _ => self.compute_levels(),
+        };
 
         let (canvas_width, canvas_height, offset_x, offset_y) = if self.centre {
             let top = levels.last().unwrap();
@@ -501,6 +515,43 @@ impl PyramidPlanner {
         levels
     }
 
+    /// Build the level set for layouts that stop at a single-tile overview
+    /// (Zoomify, IIIF), mirroring [`plan_google`](Self::plan_google) and
+    /// libvips `dzsave` with depth `onetile`.
+    ///
+    /// Halving proceeds from full resolution down and stops once the level
+    /// fits inside a single tile (`max(width, height) <= tile_size`), so after
+    /// reversing, level 0 is the single-tile overview and the highest-indexed
+    /// level is full resolution. Unlike Google this keeps the true (rectangular)
+    /// image dimensions and computes each level's grid from them rather than
+    /// forcing a square power-of-two canvas, so `cols`/`rows` at every tier
+    /// match a Zoomify/IIIF viewer's derivation from WIDTH/HEIGHT/TILESIZE.
+    fn compute_levels_single_tile(&self) -> Vec<LevelPlan> {
+        let mut dims = vec![(self.image_width, self.image_height)];
+        let (mut w, mut h) = (self.image_width, self.image_height);
+        while w > self.tile_size || h > self.tile_size {
+            w = ceil_div(w, 2);
+            h = ceil_div(h, 2);
+            dims.push((w, h));
+        }
+        // Reverse so level 0 = smallest (single-tile overview).
+        dims.reverse();
+
+        dims.iter()
+            .enumerate()
+            .map(|(level, &(w, h))| {
+                let (cols, rows) = self.tile_grid(w, h);
+                LevelPlan {
+                    level: level as u32,
+                    width: w,
+                    height: h,
+                    cols,
+                    rows,
+                }
+            })
+            .collect()
+    }
+
     /// Compute the number of tile columns and rows for an image of the given dimensions.
     fn tile_grid(&self, width: u32, height: u32) -> (u32, u32) {
         if width == 0 || height == 0 {
@@ -669,20 +720,25 @@ impl PyramidPlan {
                 // IIIF Image API v2 path: `{region}/{size},/{rotation}/default`.
                 // The region is expressed in full-resolution image coordinates,
                 // so a level's tile index scales up by `sub = 2^(top - level)`.
-                let top_level = self.levels.len() as u32 - 1;
-                let sub = 1u32 << (top_level - coord.level);
-                let ts = self.tile_size;
-                let left = coord.col * ts * sub;
-                let top = coord.row * ts * sub;
-                let region_w = (ts * sub).min(self.image_width - left);
-                let region_h = (ts * sub).min(self.image_height - top);
-                // Output size is the tile's pixel width at this level.
-                let size = ts.min(level.width - coord.col * ts);
-                let region = if left == 0
-                    && top == 0
-                    && region_w == self.image_width
-                    && region_h == self.image_height
-                {
+                // The unclamped region extent `tile_size * sub` can exceed u32
+                // for large images (a low tier over a tall canvas), so the
+                // region maths runs in u64 and clamps to the image bound before
+                // it ever narrows. `left`/`top` are real pixel coordinates of an
+                // in-bounds tile, hence provably `< image_width`/`image_height`.
+                let top_level = self.levels.len() as u64 - 1;
+                let sub = 1u64 << (top_level - coord.level as u64);
+                let ts = self.tile_size as u64;
+                let img_w = self.image_width as u64;
+                let img_h = self.image_height as u64;
+                let left = coord.col as u64 * ts * sub;
+                let top = coord.row as u64 * ts * sub;
+                let tw = ts * sub;
+                let region_w = tw.min(img_w - left);
+                let region_h = tw.min(img_h - top);
+                // Output size is the tile's pixel width at this level; it never
+                // exceeds tile_size, so it stays in u32.
+                let size = self.tile_size.min(level.width - coord.col * self.tile_size);
+                let region = if left == 0 && top == 0 && region_w == img_w && region_h == img_h {
                     "full".to_string()
                 } else {
                     format!("{left},{top},{region_w},{region_h}")
@@ -729,7 +785,9 @@ impl PyramidPlan {
     ///   and `TILESIZE`).
     /// * [`Layout::Iiif`]: `info.json` (the IIIF Image API v2 image
     ///   information document with `@context`, `width`, `height`, and the
-    ///   `tiles` descriptor).
+    ///   `tiles` descriptor). Its `@id` is a placeholder base URL: IIIF binds
+    ///   `@id` to the serving location, which is unknown at planning time, so
+    ///   the caller must rewrite it to the real image endpoint when serving.
     ///
     /// Returns `None` for layouts whose sidecar lives outside the tile
     /// directory or that have none. [`Layout::DeepZoom`] is one such case: its
@@ -1591,32 +1649,52 @@ mod tests {
 
     // -- DeepZoom layout variants: Zoomify + IIIF (libviprs-tests#87) --
 
-    /// Zoomify buckets tiles 256 to a `TileGroup{N}` directory, numbering them
-    /// cumulatively from the most zoomed-out level. These are concrete,
-    /// hand-computed group numbers for an 8192x8192 @ 128 pyramid (14 levels):
-    /// tiles preceding level 11 = 8+4+16+64 = 92, and preceding level 13 =
-    /// 92+256+1024 = 1372, so their groups are 347/256 = 1 and 1372/256 = 5.
+    /// Golden test against real libvips output. Captured with libvips 8.18.3:
+    ///
+    /// ```text
+    /// vips black big.v 8192 8192
+    /// vips dzsave big.v big_zoom --layout zoomify --tile-size 128 --overlap 0 --suffix .jpg
+    /// ```
+    ///
+    /// libvips stops the Zoomify pyramid at a single-tile overview, so the
+    /// 8192x8192 @ 128 pyramid has 7 tiers (0 = overview, 6 = full resolution),
+    /// not the 14 levels a halve-to-1x1 pyramid would emit, and it reports
+    /// `NUMTILES="5461" TILESIZE="128"`. Every `(tier, col, row) -> TileGroup`
+    /// entry below was read straight out of the produced directory tree; the
+    /// planner's `tile_path` must reproduce each byte for byte.
     #[test]
     fn zoomify_tile_path_matches_libvips_grouping() {
         let plan = PyramidPlanner::new(8192, 8192, 128, 0, Layout::Zoomify)
             .unwrap()
             .plan();
-        assert_eq!(plan.level_count(), 14);
-        // The overview tile is number 0, hence TileGroup0.
-        assert_eq!(
-            plan.tile_path(TileCoord::new(0, 0, 0), "jpg").unwrap(),
-            "TileGroup0/0-0-0.jpg"
-        );
-        // Level 11, tile (15,15): n = 92 + 15*16 + 15 = 347 -> group 1.
-        assert_eq!(
-            plan.tile_path(TileCoord::new(11, 15, 15), "jpg").unwrap(),
-            "TileGroup1/11-15-15.jpg"
-        );
-        // Full-res level 13, tile (0,0): 1372 tiles precede it -> group 5.
-        assert_eq!(
-            plan.tile_path(TileCoord::new(13, 0, 0), "jpg").unwrap(),
-            "TileGroup5/13-0-0.jpg"
-        );
+        // libvips: 7 tiers, full resolution is the highest tier.
+        assert_eq!(plan.level_count(), 7);
+        assert_eq!(plan.levels.last().unwrap().level, 6);
+        // libvips ImageProperties.xml: NUMTILES="5461" TILESIZE="128".
+        assert_eq!(plan.total_tile_count(), 5461);
+        let (_, xml) = plan.properties_sidecar("jpg").unwrap();
+        assert!(xml.contains("NUMTILES=\"5461\""), "got: {xml}");
+        assert!(xml.contains("TILESIZE=\"128\""), "got: {xml}");
+
+        // Each entry is a real path libvips wrote, including both sides of the
+        // TileGroup0->1 boundary (tier 4 -> tier 5) and the TileGroup5->...->21
+        // spread across the two largest tiers.
+        let golden = [
+            (0u32, 0u32, 0u32, "TileGroup0/0-0-0.jpg"),
+            (4, 15, 15, "TileGroup1/4-15-15.jpg"),
+            (5, 0, 0, "TileGroup1/5-0-0.jpg"),
+            (5, 31, 31, "TileGroup5/5-31-31.jpg"),
+            (6, 0, 0, "TileGroup5/6-0-0.jpg"),
+            (6, 63, 63, "TileGroup21/6-63-63.jpg"),
+        ];
+        for (level, col, row, expected) in golden {
+            assert_eq!(
+                plan.tile_path(TileCoord::new(level, col, row), "jpg")
+                    .unwrap(),
+                expected,
+                "Zoomify path mismatch for tier {level} ({col},{row})"
+            );
+        }
     }
 
     /// Every Zoomify tile path must agree with an independent recomputation of
@@ -1658,14 +1736,24 @@ mod tests {
         );
     }
 
-    /// IIIF v2 paths are `{region}/{size},/0/default.ext` with the region in
-    /// full-resolution coordinates. A single overview tile uses the `full`
-    /// region shorthand.
+    /// Golden test against real libvips output. Captured with libvips 8.18.3:
+    ///
+    /// ```text
+    /// vips black t512.v 512 512
+    /// vips dzsave t512.v t512_iiif --layout iiif --tile-size 256 --overlap 0 --suffix .jpg
+    /// ```
+    ///
+    /// libvips wrote exactly these five files (as `{region}/{size},/0/default.jpg`
+    /// directories): the four full-resolution tiles plus a single `full/256,`
+    /// overview. The overview level image is 256x256, so its output size is 256,
+    /// not 1 (a halve-to-1x1 pyramid would wrongly emit `full/1,`).
     #[test]
     fn iiif_tile_path_region_and_size() {
         let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::Iiif)
             .unwrap()
             .plan();
+        // libvips: 2 levels (overview + full res), scaleFactors [1, 2].
+        assert_eq!(plan.level_count(), 2);
         let top = plan.levels.last().unwrap().level;
         // Full-res top-left tile: 256x256 region at origin, output size 256.
         assert_eq!(
@@ -1677,10 +1765,47 @@ mod tests {
             plan.tile_path(TileCoord::new(top, 1, 1), "jpg").unwrap(),
             "256,256,256,256/256,/0/default.jpg"
         );
-        // Overview single tile covers the whole image -> "full".
+        // Overview single tile covers the whole image -> "full", size 256.
         assert_eq!(
             plan.tile_path(TileCoord::new(0, 0, 0), "jpg").unwrap(),
-            "full/1,/0/default.jpg"
+            "full/256,/0/default.jpg"
+        );
+    }
+
+    /// Golden test against real libvips output for a non-square image with
+    /// clipped edge tiles. Captured with libvips 8.18.3:
+    ///
+    /// ```text
+    /// vips black wide.v 5000 1200
+    /// vips dzsave wide.v wide_iiif --layout iiif --tile-size 256 --overlap 0 --suffix .jpg
+    /// ```
+    ///
+    /// libvips produced 146 tiles across 6 tiers (scaleFactors [1,2,4,8,16,32]).
+    /// The pinned entries below cover a right-edge tile, the bottom-right corner
+    /// (both region extents clipped), and the `full` overview whose output size
+    /// is the overview level's true width (157), all read straight from disk.
+    #[test]
+    fn iiif_tile_path_matches_libvips_edge_regions() {
+        let plan = PyramidPlanner::new(5000, 1200, 256, 0, Layout::Iiif)
+            .unwrap()
+            .plan();
+        assert_eq!(plan.level_count(), 6);
+        assert_eq!(plan.total_tile_count(), 146);
+        let top = plan.levels.last().unwrap().level;
+        // Full-res rightmost column (col 19): region width clips to 5000-4864=136.
+        assert_eq!(
+            plan.tile_path(TileCoord::new(top, 19, 0), "jpg").unwrap(),
+            "4864,0,136,256/136,/0/default.jpg"
+        );
+        // Full-res bottom-right corner: width 136, height 1200-1024=176.
+        assert_eq!(
+            plan.tile_path(TileCoord::new(top, 19, 4), "jpg").unwrap(),
+            "4864,1024,136,176/136,/0/default.jpg"
+        );
+        // Overview (tier 0) level image is 157x38 -> "full", size 157.
+        assert_eq!(
+            plan.tile_path(TileCoord::new(0, 0, 0), "jpg").unwrap(),
+            "full/157,/0/default.jpg"
         );
     }
 

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -35,6 +35,10 @@ pub enum PlannerError {
 ///   manifest. Compatible with OpenSeadragon, Leaflet, and similar viewers.
 /// * `Xyz` -- `{z}/{x}/{y}.{ext}`, the standard slippy-map / tile-server
 ///   convention used by web mapping libraries.
+/// * `Zoomify`: `TileGroup{N}/{level}-{col}-{row}.{ext}` with a companion
+///   `ImageProperties.xml` descriptor. Tiles are bucketed 256 per group.
+/// * `Iiif`: IIIF Image API v2 region paths with a companion `info.json`
+///   image information document.
 ///
 /// # Example usage
 ///
@@ -52,6 +56,14 @@ pub enum Layout {
     /// Google Maps -- power-of-2 tile grids, `{z}/{x}/{y}.{ext}`.
     /// z=0 is the most zoomed-out level (single tile). No manifest.
     Google,
+    /// Zoomify: `TileGroup{N}/{level}-{col}-{row}.{ext}`, 256 tiles per
+    /// group numbered cumulatively from the most zoomed-out level, plus an
+    /// `ImageProperties.xml` sidecar. `level` 0 is the smallest (overview).
+    Zoomify,
+    /// IIIF Image API v2: `{region}/{size},/0/default.{ext}`, where `region`
+    /// is expressed in full-resolution image coordinates, plus an `info.json`
+    /// sidecar. Compatible with OpenSeadragon and other IIIF viewers.
+    Iiif,
 }
 
 /// Configuration builder for pyramid tile generation.
@@ -634,6 +646,49 @@ impl PyramidPlan {
                 "{}/{}/{}.{}",
                 coord.level, coord.row, coord.col, extension
             )),
+            Layout::Zoomify => {
+                // Zoomify buckets tiles into `TileGroup{N}` directories of 256
+                // tiles each. Tiles are numbered sequentially starting from the
+                // most zoomed-out level (level 0): first every tile in the lower
+                // (smaller) levels, then row-major within this level. The group
+                // index is that running number divided by 256.
+                let mut n: u64 = 0;
+                for lp in &self.levels {
+                    if lp.level < coord.level {
+                        n += lp.cols as u64 * lp.rows as u64;
+                    }
+                }
+                n += coord.row as u64 * level.cols as u64 + coord.col as u64;
+                let group = n / 256;
+                Some(format!(
+                    "TileGroup{}/{}-{}-{}.{}",
+                    group, coord.level, coord.col, coord.row, extension
+                ))
+            }
+            Layout::Iiif => {
+                // IIIF Image API v2 path: `{region}/{size},/{rotation}/default`.
+                // The region is expressed in full-resolution image coordinates,
+                // so a level's tile index scales up by `sub = 2^(top - level)`.
+                let top_level = self.levels.len() as u32 - 1;
+                let sub = 1u32 << (top_level - coord.level);
+                let ts = self.tile_size;
+                let left = coord.col * ts * sub;
+                let top = coord.row * ts * sub;
+                let region_w = (ts * sub).min(self.image_width - left);
+                let region_h = (ts * sub).min(self.image_height - top);
+                // Output size is the tile's pixel width at this level.
+                let size = ts.min(level.width - coord.col * ts);
+                let region = if left == 0
+                    && top == 0
+                    && region_w == self.image_width
+                    && region_h == self.image_height
+                {
+                    "full".to_string()
+                } else {
+                    format!("{left},{top},{region_w},{region_h}")
+                };
+                Some(format!("{region}/{size},/0/default.{extension}"))
+            }
         }
     }
 
@@ -663,6 +718,72 @@ impl PyramidPlan {
             width = self.image_width,
             height = self.image_height,
         ))
+    }
+
+    /// Layout-specific properties/info sidecar that a viewer needs alongside
+    /// the tiles, returned as `(relative_path, content)` where `relative_path`
+    /// is relative to the tile output directory.
+    ///
+    /// * [`Layout::Zoomify`]: `ImageProperties.xml` (the Zoomify
+    ///   `IMAGE_PROPERTIES` descriptor carrying `WIDTH`, `HEIGHT`, `NUMTILES`,
+    ///   and `TILESIZE`).
+    /// * [`Layout::Iiif`]: `info.json` (the IIIF Image API v2 image
+    ///   information document with `@context`, `width`, `height`, and the
+    ///   `tiles` descriptor).
+    ///
+    /// Returns `None` for layouts whose sidecar lives outside the tile
+    /// directory or that have none. [`Layout::DeepZoom`] is one such case: its
+    /// `.dzi` manifest is a sibling of the output directory (its name derives
+    /// from the directory name, which only the sink knows), so it is emitted
+    /// from [`dzi_manifest`](Self::dzi_manifest) instead.
+    ///
+    /// Keeping every layout's sidecar format in one place means the sink only
+    /// has to plumb bytes to a path, never reason about a layout.
+    pub fn properties_sidecar(&self, ext: &str) -> Option<(String, String)> {
+        match self.layout {
+            Layout::Zoomify => {
+                let xml = format!(
+                    "<IMAGE_PROPERTIES WIDTH=\"{width}\" HEIGHT=\"{height}\" \
+                     NUMTILES=\"{numtiles}\" NUMIMAGES=\"1\" VERSION=\"1.8\" \
+                     TILESIZE=\"{tile_size}\" />\n",
+                    width = self.image_width,
+                    height = self.image_height,
+                    numtiles = self.total_tile_count(),
+                    tile_size = self.tile_size,
+                );
+                Some(("ImageProperties.xml".to_string(), xml))
+            }
+            Layout::Iiif => {
+                // scaleFactors are the available downsampling ratios: one power
+                // of two per pyramid level, `1` (full resolution) up to
+                // `2^(levels-1)` (the smallest overview).
+                let scale_factors = (0..self.levels.len())
+                    .map(|i| (1u64 << i).to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let json = format!(
+                    "{{\n\
+                     \x20 \"@context\": \"http://iiif.io/api/image/2/context.json\",\n\
+                     \x20 \"@id\": \"https://example.com/iiif\",\n\
+                     \x20 \"protocol\": \"http://iiif.io/api/image\",\n\
+                     \x20 \"width\": {width},\n\
+                     \x20 \"height\": {height},\n\
+                     \x20 \"tiles\": [\n\
+                     \x20   {{ \"width\": {tile_size}, \"scaleFactors\": [{scale_factors}] }}\n\
+                     \x20 ],\n\
+                     \x20 \"profile\": [\n\
+                     \x20   \"http://iiif.io/api/image/2/level0.json\",\n\
+                     \x20   {{ \"formats\": [\"{ext}\"], \"qualities\": [\"default\"] }}\n\
+                     \x20 ]\n\
+                     }}\n",
+                    width = self.image_width,
+                    height = self.image_height,
+                    tile_size = self.tile_size,
+                );
+                Some(("info.json".to_string(), json))
+            }
+            Layout::DeepZoom | Layout::Xyz | Layout::Google => None,
+        }
     }
 
     /// Canvas dimensions at the given level for Google layout.
@@ -1466,6 +1587,155 @@ mod tests {
         let (ox0, oy0) = plan.centre_offset_at_level(0);
         assert_eq!(ox0, 1);
         assert_eq!(oy0, 26);
+    }
+
+    // -- DeepZoom layout variants: Zoomify + IIIF (libviprs-tests#87) --
+
+    /// Zoomify buckets tiles 256 to a `TileGroup{N}` directory, numbering them
+    /// cumulatively from the most zoomed-out level. These are concrete,
+    /// hand-computed group numbers for an 8192x8192 @ 128 pyramid (14 levels):
+    /// tiles preceding level 11 = 8+4+16+64 = 92, and preceding level 13 =
+    /// 92+256+1024 = 1372, so their groups are 347/256 = 1 and 1372/256 = 5.
+    #[test]
+    fn zoomify_tile_path_matches_libvips_grouping() {
+        let plan = PyramidPlanner::new(8192, 8192, 128, 0, Layout::Zoomify)
+            .unwrap()
+            .plan();
+        assert_eq!(plan.level_count(), 14);
+        // The overview tile is number 0, hence TileGroup0.
+        assert_eq!(
+            plan.tile_path(TileCoord::new(0, 0, 0), "jpg").unwrap(),
+            "TileGroup0/0-0-0.jpg"
+        );
+        // Level 11, tile (15,15): n = 92 + 15*16 + 15 = 347 -> group 1.
+        assert_eq!(
+            plan.tile_path(TileCoord::new(11, 15, 15), "jpg").unwrap(),
+            "TileGroup1/11-15-15.jpg"
+        );
+        // Full-res level 13, tile (0,0): 1372 tiles precede it -> group 5.
+        assert_eq!(
+            plan.tile_path(TileCoord::new(13, 0, 0), "jpg").unwrap(),
+            "TileGroup5/13-0-0.jpg"
+        );
+    }
+
+    /// Every Zoomify tile path must agree with an independent recomputation of
+    /// the cumulative numbering, and the chosen pyramid must actually span more
+    /// than one 256-tile group.
+    #[test]
+    fn zoomify_grouping_is_internally_consistent() {
+        let plan = PyramidPlanner::new(4096, 4096, 128, 0, Layout::Zoomify)
+            .unwrap()
+            .plan();
+        let expected_group = |target: TileCoord| -> u64 {
+            let mut n = 0u64;
+            for lp in &plan.levels {
+                if lp.level < target.level {
+                    n += lp.cols as u64 * lp.rows as u64;
+                }
+            }
+            let cols = plan.levels[target.level as usize].cols as u64;
+            n += target.row as u64 * cols + target.col as u64;
+            n / 256
+        };
+        let mut max_group = 0;
+        for coord in plan.tile_coords() {
+            let path = plan.tile_path(coord, "jpg").unwrap();
+            let g = expected_group(coord);
+            max_group = max_group.max(g);
+            assert_eq!(
+                path,
+                format!(
+                    "TileGroup{g}/{}-{}-{}.jpg",
+                    coord.level, coord.col, coord.row
+                ),
+                "unexpected Zoomify path for {coord:?}"
+            );
+        }
+        assert!(
+            max_group >= 1,
+            "test pyramid must cross a 256-tile group boundary"
+        );
+    }
+
+    /// IIIF v2 paths are `{region}/{size},/0/default.ext` with the region in
+    /// full-resolution coordinates. A single overview tile uses the `full`
+    /// region shorthand.
+    #[test]
+    fn iiif_tile_path_region_and_size() {
+        let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::Iiif)
+            .unwrap()
+            .plan();
+        let top = plan.levels.last().unwrap().level;
+        // Full-res top-left tile: 256x256 region at origin, output size 256.
+        assert_eq!(
+            plan.tile_path(TileCoord::new(top, 0, 0), "jpg").unwrap(),
+            "0,0,256,256/256,/0/default.jpg"
+        );
+        // Full-res bottom-right tile: region offset by one tile.
+        assert_eq!(
+            plan.tile_path(TileCoord::new(top, 1, 1), "jpg").unwrap(),
+            "256,256,256,256/256,/0/default.jpg"
+        );
+        // Overview single tile covers the whole image -> "full".
+        assert_eq!(
+            plan.tile_path(TileCoord::new(0, 0, 0), "jpg").unwrap(),
+            "full/1,/0/default.jpg"
+        );
+    }
+
+    /// Zoomify emits an `ImageProperties.xml` sidecar carrying the full-image
+    /// dimensions, the total tile count, and the tile size.
+    #[test]
+    fn zoomify_properties_sidecar_dimensions() {
+        let plan = PyramidPlanner::new(300, 200, 128, 0, Layout::Zoomify)
+            .unwrap()
+            .plan();
+        let (rel, xml) = plan.properties_sidecar("jpg").unwrap();
+        assert_eq!(rel, "ImageProperties.xml");
+        assert!(xml.contains("WIDTH=\"300\""), "got: {xml}");
+        assert!(xml.contains("HEIGHT=\"200\""), "got: {xml}");
+        assert!(xml.contains("TILESIZE=\"128\""), "got: {xml}");
+        assert!(
+            xml.contains(&format!("NUMTILES=\"{}\"", plan.total_tile_count())),
+            "got: {xml}"
+        );
+    }
+
+    /// IIIF emits an `info.json` sidecar carrying the image dimensions, the
+    /// tile width, and the IIIF v2 context.
+    #[test]
+    fn iiif_info_json_sidecar_dimensions() {
+        let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::Iiif)
+            .unwrap()
+            .plan();
+        let (rel, json) = plan.properties_sidecar("png").unwrap();
+        assert_eq!(rel, "info.json");
+        assert!(json.contains("\"width\": 512"), "got: {json}");
+        assert!(json.contains("\"height\": 512"), "got: {json}");
+        assert!(
+            json.contains("\"width\": 256"),
+            "tile width missing: {json}"
+        );
+        assert!(
+            json.contains("http://iiif.io/api/image/2/context.json"),
+            "got: {json}"
+        );
+    }
+
+    /// Layouts whose sidecar is not written inside the tile directory return
+    /// `None` from `properties_sidecar` (DeepZoom keeps its sibling `.dzi`).
+    #[test]
+    fn non_indir_layouts_have_no_properties_sidecar() {
+        for layout in [Layout::DeepZoom, Layout::Xyz, Layout::Google] {
+            let plan = PyramidPlanner::new(300, 200, 128, 0, layout)
+                .unwrap()
+                .plan();
+            assert!(
+                plan.properties_sidecar("png").is_none(),
+                "{layout:?} should have no in-directory properties sidecar"
+            );
+        }
     }
 }
 

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -1290,6 +1290,8 @@ fn layout_tag(layout: Layout) -> u8 {
         Layout::DeepZoom => 1,
         Layout::Xyz => 2,
         Layout::Google => 3,
+        Layout::Zoomify => 4,
+        Layout::Iiif => 5,
     }
 }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1083,10 +1083,18 @@ impl TileSink for FsSink {
 
     fn finish(&self) -> Result<(), SinkError> {
         // DZI sidecar for DeepZoom layouts is still emitted exactly as
-        // before.
+        // before: a sibling of the output directory named `{base}.dzi`.
         if let Some(manifest) = self.plan.dzi_manifest(self.format.extension()) {
             let dzi_path = self.base_dir.with_extension("dzi");
             std::fs::write(&dzi_path, manifest)?;
+        }
+
+        // Layout sidecars that live inside the tile directory (Zoomify's
+        // `ImageProperties.xml`, IIIF's `info.json`). The planner owns the
+        // format and the relative name; the sink only resolves the location.
+        if let Some((rel_path, content)) = self.plan.properties_sidecar(self.format.extension()) {
+            std::fs::create_dir_all(&self.base_dir)?;
+            std::fs::write(self.base_dir.join(rel_path), content)?;
         }
 
         // If ChecksumMode::Verify is active, re-hash every tile on disk and
@@ -1940,6 +1948,87 @@ mod tests {
             recorded, 2,
             "recovered leaf must retain the pre-poison bookkeeping and accept new writes"
         );
+    }
+
+    // -- DeepZoom layout variants: Zoomify + IIIF sidecars (libviprs-tests#87) --
+
+    /// Drive an entire plan through `FsSink` (write every tile, then finish)
+    /// and return the base output directory for structural assertions.
+    fn run_plan_through_fs_sink(plan: PyramidPlan, base: PathBuf) {
+        let sink = FsSink::new(base, plan.clone());
+        for coord in plan.tile_coords() {
+            sink.write_tile(&make_tile(coord.level, coord.col, coord.row))
+                .unwrap();
+        }
+        sink.finish().unwrap();
+    }
+
+    /// A Zoomify pyramid produces a `TileGroup0/` directory and an
+    /// `ImageProperties.xml` sidecar carrying the source dimensions.
+    #[test]
+    fn zoomify_run_writes_tilegroup_and_image_properties() {
+        let plan = PyramidPlanner::new(300, 200, 128, 0, Layout::Zoomify)
+            .unwrap()
+            .plan();
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("zoomify_out");
+        run_plan_through_fs_sink(plan, base.clone());
+
+        assert!(
+            base.join("TileGroup0").is_dir(),
+            "Zoomify must produce a TileGroup0 directory"
+        );
+        let props = base.join("ImageProperties.xml");
+        assert!(props.exists(), "ImageProperties.xml sidecar must exist");
+        let xml = std::fs::read_to_string(&props).unwrap();
+        assert!(xml.contains("WIDTH=\"300\""), "got: {xml}");
+        assert!(xml.contains("HEIGHT=\"200\""), "got: {xml}");
+        // No .dzi sibling for Zoomify.
+        assert!(!dir.path().join("zoomify_out.dzi").exists());
+    }
+
+    /// An IIIF pyramid produces an `info.json` sidecar carrying the source
+    /// dimensions.
+    #[test]
+    fn iiif_run_writes_info_json() {
+        let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::Iiif)
+            .unwrap()
+            .plan();
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("iiif_out");
+        run_plan_through_fs_sink(plan, base.clone());
+
+        let info = base.join("info.json");
+        assert!(info.exists(), "info.json sidecar must exist");
+        let json = std::fs::read_to_string(&info).unwrap();
+        assert!(json.contains("\"width\": 512"), "got: {json}");
+        assert!(json.contains("\"height\": 512"), "got: {json}");
+        // The full-res tile lands under its region directory.
+        assert!(
+            base.join("0,0,256,256").is_dir(),
+            "IIIF region directory must exist"
+        );
+        assert!(!dir.path().join("iiif_out.dzi").exists());
+    }
+
+    /// DeepZoom behaviour is unchanged: a sibling `.dzi` manifest is emitted
+    /// and no in-directory properties sidecar appears.
+    #[test]
+    fn deepzoom_run_still_writes_sibling_dzi_only() {
+        let plan = PyramidPlanner::new(300, 200, 128, 0, Layout::DeepZoom)
+            .unwrap()
+            .plan();
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("deepzoom_out");
+        run_plan_through_fs_sink(plan, base.clone());
+
+        let dzi = dir.path().join("deepzoom_out.dzi");
+        assert!(dzi.exists(), "DeepZoom must keep its sibling .dzi manifest");
+        let manifest = std::fs::read_to_string(&dzi).unwrap();
+        assert!(manifest.contains("Width=\"300\""), "got: {manifest}");
+        assert!(manifest.contains("Height=\"200\""), "got: {manifest}");
+        assert!(!base.join("ImageProperties.xml").exists());
+        assert!(!base.join("info.json").exists());
     }
 
     // -- Transparent-decorator bookkeeping (issue #137) --

--- a/src/sink_object_store.rs
+++ b/src/sink_object_store.rs
@@ -353,6 +353,19 @@ impl ObjectStoreSink {
                 coord.row,
                 ext,
             ),
+            // Zoomify / IIIF tile paths are plan-dependent (cumulative tile
+            // numbering, region maths), so the planner is the single source of
+            // truth. Prefix its canonical relative tile path with the key
+            // prefix and image name, matching the XYZ / Google key shape.
+            crate::planner::Layout::Zoomify | crate::planner::Layout::Iiif => {
+                let rel = self.plan.tile_path(coord, ext)?;
+                let trimmed = self.cfg.key_prefix.trim_matches('/');
+                if trimmed.is_empty() {
+                    format!("{}/{rel}", self.cfg.image_name)
+                } else {
+                    format!("{trimmed}/{}/{rel}", self.cfg.image_name)
+                }
+            }
         };
         Some(key)
     }


### PR DESCRIPTION
DZ Zoomify+IIIF layouts for libviprs-tests#87.

Adds `Layout::Zoomify` and `Layout::Iiif` to the pyramid planner, mirroring the libvips `dzsave` conventions.

## What landed
- **planner**: `Layout::Zoomify` tile paths (`TileGroup{N}/{level}-{col}-{row}.{ext}`, 256 tiles per group numbered cumulatively from the most zoomed-out level) and `Layout::Iiif` IIIF Image API v2 region paths (`{region}/{size},/0/default.{ext}`, region in full-resolution coordinates).
- **planner**: new `properties_sidecar(ext) -> Option<(rel_path, content)>` returning the in-directory sidecar per layout: Zoomify `ImageProperties.xml`, IIIF `info.json`. DeepZoom keeps its sibling `.dzi` via `dzi_manifest`; all layout-format knowledge stays in the planner.
- **sink**: `FsSink::finish` writes the `properties_sidecar` alongside the tiles (DZI behaviour unchanged).
- **resume / manifest / sink_object_store**: extend the in-crate exhaustive `Layout` matches for the two new variants (required for the crate to compile; `Layout` is `#[non_exhaustive]` only for downstream crates).

## Correctness fix: single-tile cutoff (was blocking)
Zoomify and IIIF derive their tier index and cumulative `TileGroup` numbering from `WIDTH`/`HEIGHT`/`TILESIZE`, so a viewer expects the pyramid to stop at a single-tile overview (libvips `dzsave` depth `onetile`), not to keep halving down to 1x1. The initial revision reused the DeepZoom `compute_levels` (halve to 1x1), which added spurious sub-tile levels below the overview, offsetting every tier and group number so the output would not render in a real viewer.

Both layouts now build their level set with the single-tile cutoff (`compute_levels_single_tile`, mirroring `plan_google`): level 0 is the single-tile overview and full resolution is the highest tier. The IIIF region maths also moved to `u64` so the unclamped `tile_size * sub` region extent cannot overflow `u32` on large images.

## Golden-anchored against real libvips 8.18.3
Captured ground truth with the actual `vips dzsave` CLI and pinned it:

```
vips black big.v 8192 8192
vips dzsave big.v big_zoom --layout zoomify --tile-size 128 --overlap 0 --suffix .jpg
vips dzsave wide.v wide_iiif --layout iiif --tile-size 256 --overlap 0 --suffix .jpg
```

- Zoomify 8192x8192@128: 7 tiers (0 overview, 6 full-res), `NUMTILES="5461" TILESIZE="128"`; pinned `TileGroup`/tier/col/row entries include both sides of the group-0->1 and group-5->21 boundaries.
- IIIF 512x512@256 and 5000x1200@256 (non-square, clipped edge tiles): pinned region/size paths including `full/256,` and `full/157,` overviews and clipped `4864,1024,136,176/136,`; `info.json` `scaleFactors` match.
- During development the planner's `tile_path` was diffed exhaustively against the produced trees: all 6440 golden tile paths across the six fixtures reproduce byte for byte. The in-crate tests pin a representative subset (the temp golden files are not committed).

The previously mislabeled `zoomify_tile_path_matches_libvips_grouping` (hand-computed 14-level model) now genuinely compares to the captured libvips output.

## Tests
Local mirror green: `make fmt` + `make clippy` (default + pdfium, `-D warnings`) + `make test` (1142 lib tests) + `cargo build --features s3` + `make doc`.

## Deferred
S3 `ObjectStoreSink::finish` does not upload the Zoomify `ImageProperties.xml` or IIIF `info.json` sidecar yet (it is currently a no-op that also omits the DeepZoom `.dzi`); left consistent with the existing `.dzi` omission for a follow-up. The IIIF `info.json` `@id` is written as a placeholder base URL that a caller rewrites to the real image endpoint at serving time.
